### PR TITLE
Fix redirect issue

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://o3de.org"
+baseURL = "https://o3deorg.netlify.app"
 title = "Open 3D Engine"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 copyright = "O3DE Authors | Documentation Distributed under CC-BY 4.0"


### PR DESCRIPTION
Fix a temporary redirect issue where the o3de.org domain is redirecting to an LF signup page by using the netlify subdomain in config.toml. 


Signed-off-by: Celeste Horgan <celeste@cncf.io>