### PR TITLE
Address flexbox issue

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -220,17 +220,19 @@ $width: '59vw';
 // layouts/docs/single.html, layouts/docs/section.html 
 
 .docs-sidebar 
-  position: sticky
-  top: 4rem
-  z-index: 1000
-  height: calc(100vh - 4rem)
-  border-right: 1px solid $o3de-lightgray
-  flex: 0 1 320px
-  order: 0
-  box-sizing: border-box
-  display: block
-  flex-wrap: wrap
+  height: 30vh 
   overflow: auto
+  @include media-breakpoint-up(xl)
+    position: sticky
+    top: 4rem
+    z-index: 1000
+    height: calc(100vh - 4rem)
+    border-right: 1px solid $o3de-lightgray
+    flex: 0 1 320px
+    order: 0
+    box-sizing: border-box
+    flex-wrap: wrap
+    overflow: auto
 
 // layouts/section-nav.html 
 

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,21 +1,23 @@
 {{ define "main" }}
   <div class="container-fluid">
-      <section class="row flex-xl-nowrap">
-        <section class="col d-none d-md-block col-xl-5 docs-sidebar p-0">
+      <section class="row flex">
+        <section class="col-12 col-md-12 col-xl-2 docs-sidebar p-0 order-2 order-xl-1">
           {{ partial "section-nav.html" . }}
         </section>
-        <section class="col docs-content pt-3 px-5 pb-3">
-          <div class="row flex">
-            <div class="col  order-1 col-12 order-xl-1">
+        <section class="col-12 col-md-12 col-xl-10 docs-content pt-3 px-5 pb-3 order-1 order-xl-2">
+          <div class="row">
+            <div class="col-12 col-md-12 col-xl-12 order-1 order-xl-1">
             {{ partial "single-header.html" . }}
             </div>
-            <div class="col order-3 order-xl-2">
+            <div class="col-12 col-md-12 col-xl-10 order-3 order-xl-2">
               <h1 class="title">{{ .Page.Title | markdownify }}</h1>
               {{ partial "docs/content.html" . }}     
             </div>
-            <div class="col col-12 order-2 col-xl-2 pt-5 order-xl-3">
-              {{ partial "docs/docs-nav.html" . }}
-            </div>
+              {{ if eq ($.Param "toc") true }}
+                <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
+                  {{ partial "docs/docs-nav.html" . }}
+                </div>
+            {{ end }}
         </section>
       </section>
     </div>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -9,7 +9,7 @@
 <li>
    <a href="{{ .p1.RelPermalink }}">
     {{ .p1.LinkTitle | markdownify }}
-  </a> / &nbsp;
+  </a> / 
 </li>
 {{ end }}
 

--- a/layouts/partials/single-header.html
+++ b/layouts/partials/single-header.html
@@ -1,8 +1,8 @@
 <div class="row single-header">
-  <div class="col">
+  <div class="col-12 col-md-9">
     {{ partial "breadcrumb.html" . }}
   </div>
-  <div class="col col-12 col-xl-2">
+  <div class="col-12 col-md-3">
   {{ partial "github-edit.html" . }}
   </div>
 </div>


### PR DESCRIPTION
Fixes an issue noticed by @chanmosq where some pages did not show the menus. In actuality, this was a weird flexbox edge case, so this PR 

- Fixes the issue
- Refines views on mobile/smaller screens in general.

To review, open the preview link, navigate to a page in the docs, and resize horizontally. (note: the left-hand nav, on small/mobile views, is intended to pop to the bottom to preserve "above the fold" screen space on mobile resolutions).

Signed-off-by: Celeste Horgan <celeste@cncf.io>