### PR TITLE
Clean-up for contributor guide. There are no significant changes to t…

### DIFF
--- a/content/docs/contributing/to-docs/_index.md
+++ b/content/docs/contributing/to-docs/_index.md
@@ -26,7 +26,7 @@ Wondering where to start? The conveniently titled [get started](./get-started) t
 
 * [Get started](./get-started): A high-level overview of the O3DE docs contribution process.
 
-* [Review PRs](./review-prs): Help ensure new documentation is as great as it can be by reviewing pull requests.
+* [Work with Issues](./work-with-issues): How to create and work with issues in the Open 3D Engine (O3DE) documentation project.
 
 * [Setup a local O3DE docs repo](./o3de-docs-repo-setup): A step-by-step guide to setting up and maintaining your O3DE docs repo.
 
@@ -39,5 +39,7 @@ Wondering where to start? The conveniently titled [get started](./get-started) t
 * [Style Guide](./style-guide): The fine details you need to know to create consistently formatted and styled docs for O3DE.
 
 * [Terminology](./terminology): O3DE has many specialized terms, and a handful of terms you shouldn't use.
+
+* [Work with Hugo](./hugo): Learn to work with Hugo, the static site generator for O3DE documentation.
 
 * [O3DE Documentation and Community SIG](./documentation-and-community-sig): The charter of the O3DE Documentation and Community Special Interest Group (D&C SIG) and information on how you can participate.

--- a/content/docs/contributing/to-docs/get-started.md
+++ b/content/docs/contributing/to-docs/get-started.md
@@ -1,6 +1,6 @@
 ---
 linktitle: Get Started
-title: Get started as an O3DE documentation contributor
+title: Get Started as an O3DE Documentation Contributor
 description: What you need to know before contributing to the Open 3D Engine (O3DE) documentation project.  
 toc: true
 weight: 200

--- a/content/docs/contributing/to-docs/git-workflow.md
+++ b/content/docs/contributing/to-docs/git-workflow.md
@@ -2,7 +2,7 @@
 linkTitle: Git Runbook
 title: "O3DE Docs Contributions: Runbook"
 description: A checklist of actions to take to start working with the Open 3D Engine (O3DE) documentation repository.
-weight: 500
+weight: 350
 toc: true
 ---
 

--- a/content/docs/contributing/to-docs/hugo.md
+++ b/content/docs/contributing/to-docs/hugo.md
@@ -1,6 +1,9 @@
 ---
-title: "O3DE Docs Contribution: Hugo"
+linkTitle: Hugo
+title: O3DE Docs Contribution with Hugo
+description: Learn to work with Hugo, the static site generator for O3DE documentation
 toc: true
+weight: 600
 ---
 
 # Hugo 

--- a/content/docs/contributing/to-docs/o3de-docs-structure.md
+++ b/content/docs/contributing/to-docs/o3de-docs-structure.md
@@ -2,8 +2,7 @@
 linkTitle: O3DE Docs Structure
 title: The Open 3D Engine (O3DE) Docs Structure 
 description: A guide to the Open 3D Engine (O3DE) documentation repository structure.
-
-weight: 600
+weight: 400
 ---
 
 {{< preview-new >}}

--- a/content/docs/contributing/to-docs/site-tenets.md
+++ b/content/docs/contributing/to-docs/site-tenets.md
@@ -1,8 +1,0 @@
----
-title: "O3DE Docs Contribution: Docs Site Structure"
-toc: true
----
-
-{{< preview-new >}}
-
-## Open 3D Engine Documentation: Docs Site Structure

--- a/content/docs/contributing/to-docs/style-guide.md
+++ b/content/docs/contributing/to-docs/style-guide.md
@@ -2,7 +2,7 @@
 linkTitle: Style Guide
 title: O3DE Documentation Contribution Style Guide
 description: Style guide for contributors to the Open 3D Engine (O3DE) documentation project.
-weight: 700
+weight: 500
 toc: true
 ---
 
@@ -657,7 +657,9 @@ Artful images are used for artistic or marketing purposes, such as images that d
 
 * Use solid color fills, not gradient fills.
 
-* Avoid colors affected by colorblindness. Be selective about tones of red, green, blue, and yellow.
+* Avoid colors affected by colorblindness. We recommend using white text and Rhodamine Red C (RGB: 225,0,152 HEX: E10098) for image annotations. See the following annotated image example:
+
+![Example of an image annotation](/images/welcome-guide/ui-editor-labeled.png)
 
 ### Diagrams
 

--- a/content/docs/contributing/to-docs/submit-a-pr.md
+++ b/content/docs/contributing/to-docs/submit-a-pr.md
@@ -1,9 +1,9 @@
 ---
 linkTitle: Submit a PR
-title: Submit a PR to Open 3D Engine (O3DE) Docs 
+title: Submit a PR to O3DE Docs 
 description: A guide to submitting a PR to the Open 3D Engine (O3DE) documentation repository.
 
-weight: 400
+weight: 450
 toc: true
 ---
 

--- a/content/docs/contributing/to-docs/terminology.md
+++ b/content/docs/contributing/to-docs/terminology.md
@@ -3,7 +3,7 @@ linkTitle: Terminology
 title: O3DE Documentation Terminology and Usage
 description: Rules for using Open 3D Engine (O3DE) specific technical terminology.
 toc: true
-weight: 600
+weight: 550
 ---
 
 {{< preview-new >}}

--- a/content/docs/contributing/to-docs/work-with-issues.md
+++ b/content/docs/contributing/to-docs/work-with-issues.md
@@ -1,7 +1,6 @@
 ---
-linkTitle: Working with issues
-title: Working with O3DE documentation issues
-
+linkTitle: Work with Issues
+title: Work with O3DE Documentation Issues
 description: Guide to create and work with issues in the Open 3D Engine (O3DE) documentation project.  
 toc: true
 weight: 250


### PR DESCRIPTION
…he content on these pages so no need to re-review the pages, just the changes. site-tenets.md removed because it is not being used. Update the weights on all pages. Added all pages to the _index.md ToC. Title cased titles and linkTitles. Added a recommendation on annotation colors and example image to style guide. Note the annotation example image is being replaced with a new version in an upcoming PR.

Signed-off-by: Mike Cronin <mikecro@amazon.com>