### PR TITLE
Add Documentation traits section to style-guide.md

### DIFF
--- a/content/docs/contributing/to-docs/style-guide.md
+++ b/content/docs/contributing/to-docs/style-guide.md
@@ -33,6 +33,15 @@ The English-language documentation uses U.S. English spelling and grammar.
 
 [//]: # (If you're localizing this page, you can omit the point about U.S. English.)
 
+## Documentation traits
+
+Facilitate code review by checking your work against the following traits of good O3DE documentation.
+
+- ✅ **Use active voice** - Do descriptive sentences have a clear _subject_ _verb_ action?
+- ✅ **Answer the 'why'?** - Does the documentation answer "why does this exist"?
+- ✅ **Be consistent** - Did you audit each change to ensure it conforms with this **O3DE Documentation Contribution Style Guide**?
+- ✅ **Help the user** - Is the documentation task-oriented, and assistive for users looking to accomplish a goal?
+
 ## General writer guidance
 
 The O3DE documentation project serves a global audience. To support English as a Second Language (ESL) readers, and to ease localization efforts, adhere to the following guidelines.


### PR DESCRIPTION
This is a follow-up to our discussion around style-guide voice, tone, and docs PR checklists.

We've previously discussed prescriptive documentation - let's use the phrase "Task-Oriented Docs". This matches the approach that has been used on Lumberyard docs, and I believe it could be used to inform voice & tone guidelines for our docs as a whole.

Very open to edits/feedback/discussion around what traits are important and verbiage for the additions.