### PR TITLE
add footer to all pages

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -27,4 +27,5 @@
         </section>
     </div>
 </main>
+{{ partial "footer.html" . }}
 {{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,4 +5,5 @@
 {{ define "main" }}
 {{ partial "blog/hero.html" . }}
 {{ partial "blog/post-list.html" . }}
+{{ partial "footer.html" . }}
 {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -5,4 +5,5 @@
 {{ define "main" }}
 {{ partial "blog/hero.html" . }}
 {{ partial "blog/content.html" . }}
+{{ partial "footer.html" . }}
 {{ end }}

--- a/layouts/docs/docs_landing.html
+++ b/layouts/docs/docs_landing.html
@@ -27,4 +27,5 @@
     {{ end }}
     </div>
   </div>
+  {{ partial "footer.html" . }}
 {{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -11,7 +11,9 @@
             </div>
             <div class="col-12 col-md-12 col-xl-10 order-3 order-xl-2">
               <h1 class="title">{{ .Page.Title | markdownify }}</h1>
-              {{ partial "docs/content.html" . }}     
+              {{ partial "docs/content.html" . }}  
+              <hr class="mt-5" />   
+              {{ partial "footer-content.html" . }}
             </div>
               {{ if eq ($.Param "toc") true }}
                 <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">

--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -1,0 +1,8 @@
+{{ $year := now.Year }}
+{{ with site.Copyright }}
+<p>&copy; {{ $year }} {{ . }}</p>
+<p>&copy; {{ $year }} The Linux Foundation. All rights reserved. 
+The Linux Foundation has registered trademarks and uses trademarks. 
+For a list of trademarks of The Linux Foundation, 
+please see our <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Trademark Policy</a> page.</p>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,18 +1,9 @@
 {{ $social := site.Params.social }}
-{{ $year := now.Year }}
-
-{{ with site.Copyright }}
-
 <footer class="footer text-white">
   <div class="container mt-5 pt-5 pb-5">
     <div class="row">
       <div class="col col-12 col-xl-8">
-        <p>
-          &copy; {{ $year }} {{ . }}
-        </p>
-        <p>&copy; {{ $year }} The Linux Foundation. All rights reserved. 
-          The Linux Foundation has registered trademarks and uses trademarks. 
-          For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank">Trademark Policy</a> page.</p>
+        {{ partial "footer-content.html" . }}
       </div>
       <div class="col col-12 col-xl-4">
         <div class="float-right">
@@ -22,4 +13,3 @@
     </div>
   </div>
 </footer>
-{{ end }}


### PR DESCRIPTION
This PR adds the copyright footer consistently on all pages. It also factors out the actual text of the copyright notice to a new partial, `footer-content.html`, to facilitate a more minimal display on individual docs pages (rather than the whole "fat" footer).

Signed-off-by: Celeste Horgan <celeste@cncf.io>