### PR TITLE
Remove top-level chevrons and align github button better

### DIFF
--- a/layouts/partials/section-nav-recurse.html
+++ b/layouts/partials/section-nav-recurse.html
@@ -2,7 +2,7 @@
 
 {{ range .CurrentSection.Pages }}
 <ul class="section-nav-subsection collapse">
-  <li>{{ if .IsSection }}<i id="docs-chevron" class="fas fa-chevron-right">&nbsp;</i> {{ end }}<a class="section-nav-link" href="{{ .Permalink }}"> 
+  <li>{{ if .IsSection }}<i id="docs-chevron" class="fas fa-chevron-right mr-1">&nbsp;</i> {{ end }}<a class="section-nav-link" href="{{ .Permalink }}"> 
     {{ .Page.LinkTitle | markdownify }}
     </a>
     {{ if .IsSection }}

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -37,7 +37,7 @@
                 {{ range .CurrentSection.Pages }}
                 <ul class="section-nav-subsection">
                   <li>
-                    {{ if .IsSection }}<i id="docs-chevron" class="fas fa-chevron-right"></i> {{ end }}<a class="section-nav-link" href="{{ .Permalink }}"> 
+                    {{ if .IsSection }}{{ end }}<a class="section-nav-link" href="{{ .Permalink }}"> 
                     {{ .Page.LinkTitle | markdownify }}
                     </a>
                       {{ if .IsSection }}

--- a/layouts/partials/single-header.html
+++ b/layouts/partials/single-header.html
@@ -1,8 +1,8 @@
 <div class="row single-header">
-  <div class="col-12 col-md-9">
+  <div class="col-12 col-md-10">
     {{ partial "breadcrumb.html" . }}
   </div>
-  <div class="col-12 col-md-3">
+  <div class="col-12 col-md-2">
   {{ partial "github-edit.html" . }}
   </div>
 </div>


### PR DESCRIPTION
Note @erickson-doug –  I removed chevrons for the top-level links but left them on lower-level (Depth 3 and below) because these are necessary to indicate that a page has subsections.