### PR TITLE
Very minor fix for visual issue in homepage

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -249,7 +249,7 @@ $width: '59vw';
     &::before
       content: ''
       background-color: rgba(0,0,0,.2)
-      position: absolute;
+      position: absolute
       left: 0
       top: 0
       right: 0


### PR DESCRIPTION
Fix transparent black overlay on the homepage hero leaving gap on the sides in tablet resolutions.

Before:
![image](https://user-images.githubusercontent.com/82231674/124513764-61c10180-dd90-11eb-8019-5382651b4c79.png)

After:
![image](https://user-images.githubusercontent.com/82231674/124513822-81582a00-dd90-11eb-88de-9d905db5d033.png)


Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>