### PR TITLE
Commented out a link to a page that is in 'draft' state 

### DIFF
--- a/content/docs/user-guide/interactivity/_index.md
+++ b/content/docs/user-guide/interactivity/_index.md
@@ -8,7 +8,7 @@ weight: 800
 | Topic | Description |
 | - | - | 
 | [Entities](entities) | Learn about how to interact with entities in the Editor. |
-| [Navigation and pathfinding](navigation-and-pathfinding) |  |
+| Navigation and pathfinding | - |
 | [Physics](physics) | Simulate physics interactions in O3DE using NVIDIA PhysX for collisions and rigid bodies, NVIDIA Blast to simulate destruction, and NVIDIA Cloth to simulate cloth. |
 | [Prefabs](prefabs) | Learn about O3DE's prefab system. |
 | [Audio](audio) | Control audio and sound effects in your game. |

--- a/content/docs/welcome-guide/get-started/create-intro.md
+++ b/content/docs/welcome-guide/get-started/create-intro.md
@@ -133,7 +133,8 @@ We suggest that you begin your learning path by browsing the following set of O3
 *  [Gem Library](/docs/user-guide/gems/)
 *  [Script Canvas](/docs/user-guide/scripting/script-canvas/)
 *  [Lua Editor](/docs/user-guide/scripting/lua/)
-*  [AI Navigation](/docs/user-guide/interactivity/navigation-and-pathfinding/)
+<!-- *  [AI Navigation](/docs/user-guide/interactivity/navigation-and-pathfinding/) -->
+<!-- 7/9/2021 - The AI Navigation page is in progress -->
 *  [Audio Controls Editor](/docs/user-guide/interactivity/audio/)
 *  [Animation Editor](/docs/user-guide/visualization/animation/animation-editor/)
 *  [Cloud Canvas](/docs/user-guide/cloud/)


### PR DESCRIPTION
Problem: 
Multiple pages have a link to `/docs/user-guide/interactivity/navigation-and-pathfinding/`, which  is in 'draft' state and currently leads to **page not found** on the website. 

Solution: 
This PR comments it out. When the nav and pathfinding page is created, the link should be published again (see this issue https://github.com/o3de/o3de.org/issues/721).
