### PR TITLE
Issue #741: Added missing Lua Editor page. Fixed some broken links that expected Lua Editor page.

### DIFF
--- a/content/docs/user-guide/scripting/lua/_index.md
+++ b/content/docs/user-guide/scripting/lua/_index.md
@@ -14,7 +14,7 @@ title: Writing Lua Scripts
 + [Properties Table](/docs/user-guide/interactivity/scripting/lua/properties.md)
 + [Network Binding Properties](/docs/userguide/scripting/lua/script-networking-binding.md)
 + [Using EBuses in Lua](/docs/user-guide/interactivity/scripting/lua/ebus.md)
-+ [Lua Editor](/docs/user-guide/interactivity/scripting/lua/debugging.md)
++ [Lua Editor](/docs/user-guide/scripting/lua/lua-editor.md)
 + [Debugging Lua Scripts](/docs/user-guide/interactivity/scripting/lua/debugging-scripts.md)
 + [The Lua Environment (Advanced)](/docs/user-guide/interactivity/scripting/lua/environment.md)
 + [Component Entity Lua API Reference](/docs/userguide/scripting/lua/api.md)
@@ -33,7 +33,7 @@ For learning the Lua language itself, the [lua.org](http://www.lua.org) website 
 ## Learning Lua in O3DE 
 
 After you read through this tutorial on writing Lua scripts for the component entity system, learn more about using Lua in O3DE by consulting the following resources.
-+ For information on O3DE's built-in Lua editor, see [Lua Editor](/docs/user-guide/interactivity/scripting/lua/debugging.md).
++ For information on O3DE's built-in Lua editor, see [Lua Editor](/docs/user-guide/scripting/lua/lua-editor.md).
 + For sample Lua [scripts](/docs/user-guide/appendix/glossary#scripts), see the O3DE `\dev\SamplesProject\Scripts` directory and its subdirectories.
 + For information about Lua API operations in O3DE, see the [Component Entity Lua API Reference](/docs/userguide/scripting/lua/api.md).
 + For information about the O3DE EBus, see [Working with the Event Bus (EBus) system](/docs/user-guide/engine/ebus).

--- a/content/docs/user-guide/scripting/lua/lua-editor.md
+++ b/content/docs/user-guide/scripting/lua/lua-editor.md
@@ -1,0 +1,8 @@
+---
+title: Lua Editor
+description: ' Learn about the Lua Editor in Open 3D Engine. '
+---
+
+{{< preview-new >}}
+
+The Open 3D Engine Lua Editor (Lua IDE) offers an intuitive integrated development environment (IDE) that makes it easy to author, debug, and edit Lua scripts when you create or extend your game. Lua Editor is a standalone application, but can be opened directly from the Open 3D Engine Editor using the Edit Mode Toolbar.


### PR DESCRIPTION
Added missing Lua Editor page (currently minimal/stub/placeholder/incomplete, requires more work). 

Fixed broken links on the Lua page (under Scripting) that directed towards the Lua Editor page, which was previously missing.