### PR TITLE
SPEC-7686 | Improve the anchor nav on the right hand side and typography css

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -32,7 +32,7 @@ $(() => {
 // nav bar search
 
 $(() => {
-  $("#search").click(function(event){
+  $("#search").submit(function(event){
     event.preventDefault();
     $(".search-input-view").show();
 
@@ -60,6 +60,8 @@ $(() => {
     
       // Perform the search
       const results = idx.search(data)
+      // Update the search title
+      $('#search-title').append('"' + data + '"')
       // Update the list with results
       displayResults(results, window.store)
     }
@@ -85,6 +87,7 @@ function displayResults (results, store) {
   const resultsContainer = document.getElementById('search-results')
   const mainContainer = document.getElementById('primary')
   const searchResults = document.getElementById('results')
+  
   if (results.length) {
     let resultList = ''
     // Iterate and build result list elements

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -332,6 +332,9 @@ code
   #nav-search
     margin-left: 5px
 
+#search-title
+  margin: 64px 0 32px
+
 
 // layouts/partials/navbar.html secondary
 
@@ -363,6 +366,9 @@ code
   right: 0
   top: 62px
   width: 214px
+  
+  @include media-breakpoint-down(lg)
+    display: none !important
 
   ul
     padding: 0 0.75rem
@@ -376,8 +382,14 @@ code
         text-transform: uppercase
         padding: 0.5rem
 
-      .active div
-        display: none
+      .active
+        color: $o3de-blue-highlight
+
+        div
+          display: none
+      
+      a:hover
+        color: $o3de-lightgray
 
 .mobile-docs-toggler
   .navbar-toggler-icon
@@ -1043,7 +1055,7 @@ body.docs-mobile-menu-open .docs-sidebar
     left: 0
     right: 0
     bottom: 0
-    background: rgba(0, 0, 0, .3)
+    background: rgba(0, 0, 0, .5)
     content: ''
     z-index: 99
     display: none
@@ -1052,6 +1064,15 @@ body.docs-mobile-menu-open .docs-sidebar
 
     &.show
       opacity: 1
+
+.edit-button-container
+  text-align: right
+  @include media-breakpoint-down(sm)
+    text-align: left
+  
+  a.btn
+    @include media-breakpoint-down(lg)
+      transform: scale(.9)
 
 
 // layouts/section-nav.html 
@@ -1168,6 +1189,39 @@ nav.docs-nav
 
 .docs-sidebar
   @include scrollbars(5px, $o3de-blue-highlight, $o3de-lightgray)
+
+  
+// layouts/section-nav.html 
+
+.docs-right-toc
+  p
+    color: #000
+    border-left: 2px solid $o3de-lightgray
+    padding-left: 12px
+    margin: 0
+    font-size: 14px
+    font-weight: 600
+  
+  ul
+    padding: 6px 0 0
+    list-style: none
+    
+    li
+      margin: 0
+      font-size: 14px
+      line-height: 20px
+      padding: 6px 0 6px 12px
+
+      a
+        color: #444
+        font-weight: 500
+        
+      a:hover
+        color: $o3de-blue-highlight
+  
+.docs-right-toc > nav > ul
+  border-left: 2px solid $o3de-lightgray
+
 
 // layouts/partials/footer-content.html
 

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -16,11 +16,9 @@
             <hr class="mt-5" />   
             {{ partial "footer-content.html" . }}
           </div>
-            {{ if eq ($.Param "toc") true }}
-              <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
-                {{ partial "docs/docs-nav.html" . }}
-              </div>
-          {{ end }}
+          <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
+            {{ partial "docs/docs-nav.html" . }}
+          </div>
         </div>
       </section>
     </section>

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -16,9 +16,11 @@
             <hr class="mt-5" />   
             {{ partial "footer-content.html" . }}
           </div>
-          <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
-            {{ partial "docs/docs-nav.html" . }}
-          </div>
+          {{ if and (ge (len .TableOfContents) 100) (ne .Params.toc "false") }}
+            <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
+              {{ partial "docs/docs-nav.html" . }}
+            </div>
+          {{ end }}
         </div>
       </section>
     </section>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -16,11 +16,9 @@
             <hr class="mt-5" />   
             {{ partial "footer-content.html" . }}
           </div>
-            {{ if eq ($.Param "toc") true }}
-              <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
-                {{ partial "docs/docs-nav.html" . }}
-              </div>
-          {{ end }}
+          <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
+            {{ partial "docs/docs-nav.html" . }}
+          </div>
         </div>
       </section>
     </section>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -16,9 +16,11 @@
             <hr class="mt-5" />   
             {{ partial "footer-content.html" . }}
           </div>
-          <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
-            {{ partial "docs/docs-nav.html" . }}
-          </div>
+          {{ if and (ge (len .TableOfContents) 100) (ne .Params.toc "false") }}
+            <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
+              {{ partial "docs/docs-nav.html" . }}
+            </div>
+          {{ end }}
         </div>
       </section>
     </section>

--- a/layouts/partials/docs/docs-nav.html
+++ b/layouts/partials/docs/docs-nav.html
@@ -2,6 +2,6 @@
 {{ $toc := .TableOfContents }}
 
 <div class="docs-right-toc">
-  <p>IN THIS ARTICLE:</p>
+  <p>IN THIS ARTICLE</p>
   {{ $toc }}
 </div>

--- a/layouts/partials/docs/docs-nav.html
+++ b/layouts/partials/docs/docs-nav.html
@@ -1,7 +1,7 @@
 {{ $hastoc := .Params.toc }}
 {{ $toc := .TableOfContents }}
 
-{{ if ($hastoc) }}
-<p> On this page:</p>
+<div class="docs-right-toc">
+  <p>IN THIS ARTICLE:</p>
   {{ $toc }}
-{{ end }}
+</div>

--- a/layouts/partials/single-header.html
+++ b/layouts/partials/single-header.html
@@ -1,8 +1,8 @@
 <div class="row single-header">
-  <div class="col-12 col-md-10">
+  <div class="col-12 col-md-8">
     {{ partial "breadcrumb.html" . }}
   </div>
-  <div class="col-12 col-md-2">
+  <div class="col-12 col-md-4 edit-button-container">
   {{ partial "github-edit.html" . }}
   </div>
 </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82231674/126390788-ed2bef63-661b-4182-8915-2c0fc8ea7399.png)

- Fixed Table of Contents styling on the right side of docs pages
- Fixed search not appearing correctly from docs search form
- Fixed minor visual details in docs mobile menus (active/hover states on secondary menu, overlay opacity)
- Fixed secondary menu not disappearing on resize
- Fixed "Edit on GitHub" button sizing on mobile resolutions