### PR TITLE
OS buttons in download page created

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -80,6 +80,29 @@ $(function() {
   })
 });
 
+// download page os buttons
+
+$(function() {
+  const contentAvailable = "Fork the O3DE source and build the engine and tools directly from any branch. For more details, read the documentation.";
+  const contentUnavailable = "Coming soon.";
+  $(".download-os-button").click(function(event){
+    event.preventDefault()
+    
+    $(".download-os").removeClass("active");
+    $(this).parent().addClass("active");
+
+    if($(this).text().includes("Windows")){
+      $(".download-os-content").text(contentAvailable);
+      $("#download-page-buttons a").removeClass("disabled");
+      $("#download-page-buttons a").attr('href', 'https://github.com/o3de/o3de');
+    } else {
+      $(".download-os-content").text(contentUnavailable);
+      $("#download-page-buttons a").addClass("disabled");
+      $("#download-page-buttons a").removeAttr('href');
+    }
+  })
+});
+
 
 // Search 
 

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -483,6 +483,9 @@ $width: '59vw';
   background-position: 50% 50%
   max-height: 20rem
 
+  h1, h4, h5
+    margin: 1.8rem 0 .5rem
+
   @include media-breakpoint-down(md)
     h1
       font-size: 1.8rem
@@ -537,6 +540,29 @@ $width: '59vw';
   background-color: $o3de-blue
   &:hover 
     background-color: darken(#1E71EB, 10%)
+
+.download-os-button
+  color: #000000
+  background-color: #EEEEEE
+  border-radius: 0 
+  padding: 0.5rem 0
+  &:hover
+    color: #000000
+    background-color: #E8E8E8
+
+.download-os.active a.download-os-button
+  color: #000000
+  background-color: #FFFFFF
+  &:hover
+    color: #000000
+    background-color: #F8F8F8
+
+.download-os.active div
+  background-color: #1E70EB
+  padding-bottom: 3px
+
+#download-page-buttons a.disabled
+  background-color: #007bff78
 
 // layouts/partials/home/features.html 
 

--- a/layouts/download/section.html
+++ b/layouts/download/section.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 {{ partial "download/hero.html" . }}
 {{ with .Content }}
-<section class="container pt-lg-5">
+<section class="container pt-5">
   <div class="row">
     <div class="col-12 col-lg-5 pr-lg-5">
       {{ partial "download/download.html" . }}

--- a/layouts/partials/download/download.html
+++ b/layouts/partials/download/download.html
@@ -2,8 +2,8 @@
 <div class="download_release">Release 2107.1</div>
 
 <p class="mr-lg-5">Read the <a href="https://o3de.org/docs/release-notes/archive/2107-1-release-notes/">Release Notes</a> to learn more about O3DE [Developer Preview] Release 2107.01.</p>
-<p class="mr-lg-5">Fork the O3DE source and build the engine and tools directly from any branch. For more details, read the documentation.</p>
+<p class="mr-lg-5 download-os-content">Fork the O3DE source and build the engine and tools directly from any branch. For more details, read the documentation.</p>
 
 <p id="download-page-buttons" class="mr-5">
-  <a href="https://github.com/o3de/o3de" class="btn-xl-block btn-lg btn-primary text-white text-center" target="_blank">Fork O3DE from GitHub</a>
+  <a href="https://github.com/o3de/o3de" class="btn-xl-block btn-lg btn-primary text-center" target="_blank">Fork O3DE from GitHub</a>
 </p>

--- a/layouts/partials/download/hero.html
+++ b/layouts/partials/download/hero.html
@@ -15,5 +15,19 @@
         </h5>
       </div>
     </div>
+    <div class="row justify-content-between">
+      <div class="col col-4 download-os active">
+        <a href="https://github.com/o3de/o3de" class="btn-block btn-lg text-center download-page-windows download-os-button" target="_blank">Windows</a>
+        <div></div>
+      </div>
+      <div class="col col-4 download-os">
+        <a href="https://github.com/o3de/o3de" class="btn-block btn-lg text-center download-page-macos download-os-button" target="_blank">macOS</a>
+        <div></div>
+      </div>
+      <div class="col col-4 download-os">
+        <a href="https://github.com/o3de/o3de" class="btn-block btn-lg text-center download-page-linux download-os-button" target="_blank">Linux</a>
+        <div></div>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
NOTE - This change isn't meant to be submitted until an installer is made available on the O3DE.org website.

Restored OS buttons in Download page from this PR:
https://github.com/o3de/o3de.org/pull/747

Added minor fixes (changed default button to "Windows", fixed availability information)

![image](https://user-images.githubusercontent.com/82231674/126409874-213953e3-4a2c-4375-bb60-2dc98710f61c.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>