### PR TITLE
Minor fixes to the Docs navigation

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -129,6 +129,7 @@ $(function() {
         {
           $(this).addClass("currentAncestor").addClass("open");
         });
+        $(this).parent('li').addClass("currentAncestorCategory");
       })
     }
   })

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1092,6 +1092,10 @@ body.docs-mobile-menu-open .docs-sidebar
 
 // layouts/section-nav.html 
 
+nav.docs-nav > ul > li:not(.currentAncestorCategory)
+    @include media-breakpoint-up(xl)
+      display: none
+
 nav.docs-nav
   ul 
     list-style: none

--- a/content/docs/atom-guide/_index.md
+++ b/content/docs/atom-guide/_index.md
@@ -6,7 +6,7 @@ description: Learn about the Atom Renderer, a modular, multi-threaded, physicall
 weight: 400
 menu_uuid: atom
 guide_img: "/images/atom-guide/guide_img.png"
-primary: true
+primary: false
 ---
 
 Welcome to the Atom Documentation! Atom Renderer is the graphics engine powering Open 3D Engine (O3DE). Check out the video below for a quick overview of some of Atom's features. Then, read on learn more about creating beautiful, high performance graphics with Atom!

--- a/content/docs/release-notes/_index.md
+++ b/content/docs/release-notes/_index.md
@@ -7,7 +7,7 @@ weight: 100
 toc: true
 menu_uuid: releasenotes
 guide_img: "/images/release-notes/guide_img.png"
-primary: false
+primary: true
 ---
 
 ## Current Versions of Open 3D Engine

--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -8,7 +8,7 @@
             {{ .LinkTitle }}</a>
             {{ if .Pages }}
                 <ul>
-                    {{ if .IsSection }}
+                    {{ if and ( .IsSection ) (ge (len .Content) 1) }}
                     <li>
                         <a href="{{ .RelPermalink }}"
                         class="docs-link">


### PR DESCRIPTION
- Left nav menu only shows current category on desktop resolutions. Mobile menu still shows all categories;
- Moved Release Notes out of the secondary menu, and Atom Renderer in its place;
- Added an extra check to only show redundant pages in navigation if they have content

![docs-menu-cleanup](https://user-images.githubusercontent.com/82231674/126545189-3679d7e6-15c0-4768-a4db-9aad76ce63ce.gif)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>