### PR TITLE
Author Python Runtime CLI Reference 

### DIFF
--- a/content/docs/user-guide/project-config/_index.md
+++ b/content/docs/user-guide/project-config/_index.md
@@ -1,7 +1,7 @@
 ---
 linktitle: Project Configuration
 title: Project Configuration
-description: Learn how to configure your projects in Open 3D Engine (O3DE)
+description: Learn how to configure your projects in Open 3D Engine (O3DE).
 weight: 100
 ---
 

--- a/content/docs/user-guide/project-config/_index.md
+++ b/content/docs/user-guide/project-config/_index.md
@@ -9,4 +9,5 @@ weight: 100
 | - | - | 
 | [Adding and Removing Gems](add-remove-gems/) | Learn how to add and remove Gems in your project. | 
 | [Registering Gems](register-gems/) | Learn how to register Gems that are provided outside of the O3DE source. | 
+| [CLI Reference](cli-reference.md) | A command line interface reference for the `o3de` Python script. 
 | [Troubleshooting](troubleshooting/) | A troubleshooting guide for project configuration. |

--- a/content/docs/user-guide/project-config/_index.md
+++ b/content/docs/user-guide/project-config/_index.md
@@ -3,8 +3,6 @@ title: Project Configuration
 weight: 100
 ---
 
-{{< preview-new >}}
-
 | Topic | Description |
 | - | - | 
 | [Adding and Removing Gems](add-remove-gems/) | Learn how to add and remove Gems in your project. | 

--- a/content/docs/user-guide/project-config/_index.md
+++ b/content/docs/user-guide/project-config/_index.md
@@ -1,5 +1,7 @@
 ---
+linktitle: Project Configuration
 title: Project Configuration
+description: Learn how to configure your projects in Open 3D Engine (O3DE)
 weight: 100
 ---
 

--- a/content/docs/user-guide/project-config/_index.md
+++ b/content/docs/user-guide/project-config/_index.md
@@ -5,7 +5,7 @@ weight: 100
 
 | Topic | Description |
 | - | - | 
-| [Adding and Removing Gems](add-remove-gems/) | Learn how to add and remove Gems in your project. | 
-| [Registering Gems](register-gems/) | Learn how to register Gems that are provided outside of the O3DE source. | 
-| [CLI Reference](cli-reference.md) | A command line interface reference for the `o3de` Python script. 
-| [Troubleshooting](troubleshooting/) | A troubleshooting guide for project configuration. |
+| [Adding and Removing Gems](add-remove-gems/) | Learn how to add and remove Gems in your project. |
+| [Registering Gems](register-gems/) | Learn how to register external Gems from sources outside of O3DE. |
+| [O3DE CLI Reference](cli-reference/) | A command line interface (CLI) reference for the `o3de` Python script.
+| [Troubleshooting](troubleshooting/) | Troubleshoot common issues that you might encounter during project configuration. |

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -1,27 +1,28 @@
 ---
-linktitle: CLI Reference
-title: Project Configuration CLI Reference
+linktitle: O3DE CLI Reference
+title: O3DE Project Configuration CLI Reference
+description: The command line interface (CLI) reference for the Open 3D Engine (O3DE) Python script.
 weight: 200
 toc: true
 ---
 
-The `o3de` Python script provides a solution to accomplish project configuration tasks using the command line interface (CLI). It aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so users can access them from a single point. The script is located in the engine folder at `/scripts/o3de.py`. 
+The `o3de` Python script lets you configure your project using the command line interface (CLI). The script aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so you can access them from a single point. Find the script in the engine folder at `/scripts/o3de.py`. 
 
-The `o3de` Python script is responsible for multiple tasks:
+You can use the `o3de` Python script for the following tasks:
 
 - Creating projects
 - Creating Gems
 - Creating templates
-- [Enabling and disabling Gems for your project](add-remove-gems/)
+- [Enabling and disabling Gems for your project](add-remove-gems/#using-the-command-line-interface-cli)
 - [Registering the engine](/docs/welcome-guide/setup/setup-from-github#register-the-engine)
 - Registering projects and Gems
-
+  
 
 <!-------------------------------------------------------------->
 
 ## Prerequisites
 
-To use the `o3de` Python script, you must have Python runtime set up. Python runtime was downloaded when you set up the engine. For more information, refer to instructions on how to get Python runtime in the [Register the engine](/docs/welcome-guide/setup/setup-from-github/#register-the-engine) section of the Setup From GitHub page.
+To use the `o3de` Python script, you must set up the Python runtime, which you download when you set up the engine. For instructions on downloading the runtime, refer to the [Register the engine](/docs/welcome-guide/setup/setup-from-github/#register-the-engine) section of the Setting up O3DE from GitHub page.
 
 
 <!-------------------------------------------------------------->
@@ -31,21 +32,23 @@ To use the `o3de` Python script, you must have Python runtime set up. Python run
 {{< tabs name="Python runtime setup" >}}
 {{% tab name="Windows" %}}
 
-For Windows, open a command prompt. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
+To run the O3DE Python runtime and a command, at a command prompt, do either of the following:
 
 - Run the `o3de.bat` batch file directly.
     ```cmd
     <engine>\scripts\o3de.bat <command>
     ```
 
-- Launch python and run the `o3de.py` script.
+- Launch Python and run the `o3de.py` script.
     ```cmd
     <engine>\python\python.cmd <engine>\scripts\o3de.py <command>
     ```
 
-**Example**
+{{< note >}}
+Replace `<engine>` with the path to your engine.
+{{< /note >}}
 
-For example, to register the engine, you can enter the following command. 
+For example, to register the engine, enter the following command:
 
 ```cmd
 <engine>\scripts\o3de.bat register --this-engine
@@ -54,21 +57,23 @@ For example, to register the engine, you can enter the following command.
 {{% /tab %}}
 {{% tab name="Linux" %}}
 
-For Linux, open a terminal. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
+To run the O3DE Python runtime and a command, in a terminal window, do either of the following:
 
 - Run the `o3de.sh` shell script file directly.
     ```bash
     <engine>/scripts/o3de.sh <command>
     ```
 
-- Launch python and run the `o3de.py` script.
+- Launch Python and run the `o3de.py` script.
     ```bash
     <engine>/python/python.sh <engine>/scripts/o3de.py <command>
     ```
 
-**Example**
+{{< note >}}
+Replace `<engine>` with the path to your engine.
+{{< /note >}}
 
-For example, to register the engine, you can enter the following command. 
+For example, to register the engine, enter the following command:
 
 ```bash
 <engine>/scripts/o3de.sh register --this-engine
@@ -99,14 +104,14 @@ The `o3de` Python script contains the following commands, with further details i
 | [`edit-engine-properties`](#edit-engine-properties) | Edits the engine's properties. |
 | [`edit-project-properties`](#edit-project-properties) | Edits the project's properties. |
 | [`edit-gem-properties`](#edit-gem-properties) | Edits the Gem's properties. |
-| [`sha256`](#sha256) | Creates a hash value for an O3DE object using the SHA-256 secure hash algorithm. |
+| [`sha256`](#sha256) | Creates a hash value for an O3DE object using SHA-256 (Secure Hash Algorithm 256). |
 
 
 <!-------------------------------------------------------------->
 
 ## `get-global-project`
 
-Gets the global project that is registered to the engine. By default, this is read from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`. You can also specify a file path using `-i`.
+Gets the global project that is registered to the engine. By default, reads the global project from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`. You can also specify a file path using `-i`.
 
 ### Format
 
@@ -142,9 +147,9 @@ o3de.bat get-global-project -i <USER_PATH>\.o3de\Registry\my-custom.setreg
 
 ## `set-global-project`
 
-Sets the specified project as the engine's global project. By default this is set in `C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
+Sets the specified project as the engine's global project. By default sets this in `C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
 
-If you set a global project, then O3DE tools (such as the Asset Processor and Editor) will use the global project. You can override the global project by specifying a project with the `project-path` parameter when you launch the O3DE tools from the command line.
+If you set a global project, then O3DE tools (such as **Asset Processor** and **O3DE Editor**) use the global project when they are launched from an installed engine. To override the global project, specify a project with the `project-path` parameter when you launch the O3DE tools from the command line.
 
 ### Format 
 
@@ -175,7 +180,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o <USER_PATH>\.o3de\Registry\my-cu
 
 - **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-  The path to the project. The path must contain the project manifest file, `project.json`, unless the `--force` parameter is also used.
+  The path to the project. The path must contain the project manifest file (`project.json`) unless you also use the `--force` parameter.
 
 - **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
@@ -183,11 +188,11 @@ o3de.bat set-global-project -pp PROJECT_PATH -o <USER_PATH>\.o3de\Registry\my-cu
 
 - **`-o OUTPUT_PATH, --output-path OUTPUT_PATH`**
 
-  The path and filename where the `project_path` key is written. The file should be located in `<USER_PATH>/.o3de/Registry/` and have the file extension `.setreg`. If this parameter is not used, the key is written to `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+  The path and filename where the `project_path` key is written. The file should be located in `<USER_PATH>/.o3de/Registry/` and have the file extension `.setreg`. If you don't use this parameter, the key is written to `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
 
 - **`-f, --force`**
 
-  Forces the project path to be set in the supplied setreg file. 
+  Forcibly sets the project path in the supplied .setreg file.
 
 
 <!-------------------------------------------------------------->
@@ -210,11 +215,13 @@ create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
 
 ### Usage
 
-Creates a template from the source folder and saves the template into the specified path.
+Creates a template from the source folder and saves the template in the specified path.
 
 ```cmd
 o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 ```
+
+{{< todo issue="https://github.com/o3de/o3de.org/issues/806">}} Add more usage examples. {{< /todo >}}
 
 ### Optional parameters
   
@@ -224,11 +231,11 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-sp SOURCE_PATH, --source-path SOURCE_PATH`**
 
-  The path to the source folder that you want to create into a template.
+  The path to the source folder that you want to use as a template.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-  The path to an existing template you want to create a new template from. The path can be absolute or relative to the default templates path.
+  The path to an existing template that you want to create a new template from. The path can be absolute or relative to the default template's path.
 
 - **`-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`**
 
@@ -248,7 +255,7 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-sn SOURCE_NAME, --source-name SOURCE_NAME`**
 
-  Substitutes any file and path entries that match the source name - ${Name} and ${SanitizedCppName} - in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
+  Substitutes any file and path entries that match the source name -- ${Name} and ${SanitizedCppName} -- in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
 
 - **`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -10,7 +10,7 @@ The `o3de` Python script lets you configure your project using the command line 
 
 You can use the `o3de` Python script for the following tasks:
 
-- Creating projects
+- [Creating projects](/docs/welcome-guide/create/creating-projects-using-cli/)
 - Creating Gems
 - Creating templates
 - [Enabling and disabling Gems for your project](add-remove-gems/#using-the-command-line-interface-cli)
@@ -86,6 +86,7 @@ For example, to register the engine, enter the following command:
 <!-------------------------------------------------------------->
 
 ## Commands
+
 The `o3de` Python script contains the following commands, with further details in the following sections. 
 
 | Command | Description | 
@@ -128,6 +129,7 @@ o3de.bat get-global-project
 ```
 
 Reads the global project from a specified file.
+
 ```cmd
 o3de.bat get-global-project -i <USER_DIRECTORY>\.o3de\Registry\my-custom.setreg
 ```
@@ -192,7 +194,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o <USER_DIRECTORY>\.o3de\Registry\
 
 - **`-f, --force`**
 
-  Forcibly sets the project path in the supplied .setreg file.
+  Forcibly sets the project path in the supplied `.setreg` file.
 
 
 <!-------------------------------------------------------------->
@@ -275,7 +277,7 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: \<TemplateName\> -> ${Name}, \<templatename\> -> ${NameLower}, \<TEMPLATENAME\> -> ${NameUpper}.
+  Add A to B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: `${Name}` to \<TemplateName\>, `${NameLower}` to \<templatename\>, `${NameUpper}` to \<TEMPLATENAME\>.
 
 - **`-f, --force`**
          
@@ -342,15 +344,15 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 - **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-The path to the restricted directory that `o3de` adds restricted platform sources to, if any.
+  The path to the restricted directory that `o3de` adds restricted platform sources to, if any.
 
 - **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
   
-The name of the restricted directory that `o3de` adds restricted platform sources to, if any. If supplied, you don't need to use the `--template-restricted-path` parameter.
+  The name of the restricted directory that `o3de` adds restricted platform sources to, if any. If supplied, you don't need to use the `--template-restricted-path` parameter.
 
 - **`-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-  A path to append to `DESTINATION_RESTRICTED_PATH/<platform>`, which contains the restricted destination. For example: `--destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder` => `C:/instance/<platform>/some/folder/<destination_name>`
+  A path to append to `DESTINATION_RESTRICTED_PATH/<platform>`, which contains the restricted destination. For example: `--destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder` => `C:/instance/<platform>/some/folder/<destination_name>`.
 
 - **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -366,7 +368,7 @@ The name of the restricted directory that `o3de` adds restricted platform source
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: \<DestinationName\> -> ${Name}, \<destinationname\> -> ${NameLower}, \<DESTINATIONNAME\> -> ${NameUpper}.
+  Add A to B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: `${Name}` to \<DestinationName\>, `${NameLower}` to \<destinationname\>, `${NameUpper}` to \<DESTINATIONNAME\>.
 
 - **`-f, --force`**
 
@@ -465,7 +467,7 @@ o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PAT
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard project replacements from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `MyUsername` with `${User}`, and `1723905` with `${id}`. Note: \<ProjectName\> is the last component of the template_path. The following replacement pairs already exist: \<ProjectName\> -> ${Name}, \<projectname\> -> ${NameLower}, \<PROJECTNAME\> -> ${NameUpper}.
+  Add A to B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard project replacements from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `MyUsername` with `${User}`, and `1723905` with `${id}`. Note: \<ProjectName\> is the last component of the template_path. The following replacement pairs already exist: `${Name}` to \<ProjectName\>, `${NameLower}` to \<projectname\>, `${NameUpper}` to \<PROJECTNAME\>.
 
 - **`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`**
 
@@ -570,7 +572,7 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard Gem replacements from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces `${DATE}` with `1/1/2020`, and  `${id}` with `1723905`. Note:  \<GemName> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMNAME\> -> ${NameUpper}.
+  Add A to B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard Gem replacements from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces `${DATE}` with `1/1/2020`, and  `${id}` with `1723905`. Note:  \<GemName> is the last component of the GEM_PATH. The following replacement pairs already exist: `${Name}` to \<GemName\>, `${NameLower}` to \<gemname\>, `${NameUpper}` to \<GEMNAME\>.
 
 - **`-kr, --keep-restricted-in-gem`**
 
@@ -854,6 +856,7 @@ o3de.bat register --update
 - **`-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`**
 
   All of the engines that you want to register or deregister in the specified folder.
+
 - **`-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`**
 
   All of the projects that you want to register or deregister in the specified folder.
@@ -896,7 +899,7 @@ o3de.bat register --update
 
 - **`-dtpf DEFAULT_THIRD_PARTY_FOLDER, --default-third-party-folder DEFAULT_THIRD_PARTY_FOLDER`**
 
-  The path to the default 3rd party folder that you want to register or deregister.
+  The path to the default third-party folder that you want to register or deregister.
 
 - **`-u, --update`**
 
@@ -1103,6 +1106,7 @@ o3de.bat register-show --all-external-subdirectories
 <br>
 
 **Showing registered repositories**
+
 Outputs the list of repositories that are registered in the `o3de_manifest.json` file.
 
 ```cmd
@@ -1146,15 +1150,15 @@ o3de.bat register-show --repos
 
 - **`-ep, --engine-projects`**
 
-  Outputs a list of the projects that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the projects that are registered in the current engine's `engine.json` file. 
 
 - **`-eg, --engine-gems`**
 
-  Outputs a list of the gems that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the Gems that are registered in the current engine's `engine.json` file. 
 
 - **`-et, --engine-templates`**
 
-  Outputs a list of the Gems that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the templates that are registered in the current engine's `engine.json` file. 
 
 - **`-ers, --engine-restricted`**
 
@@ -1182,7 +1186,7 @@ o3de.bat register-show --repos
 
 - **`-ap, --all-projects`**
 
-  Outputs all of the projects that are registered in the `o3de_manifest.json` file and the current engine's `engine.json`. Ignores repos.
+  Outputs all of the projects that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. 
 
 - **`-ag, --all-gems`**
 
@@ -1190,7 +1194,7 @@ o3de.bat register-show --repos
 
 - **`-at, --all-templates`**
 
-  Outputs all of the templates that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos.
+  Outputs all of the templates that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. 
 
 - **`-ares, --all-restricted`**
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -17,10 +17,14 @@ The `o3de` Python script is responsible for multiple tasks:
 - Registering projects and Gems
 
 
+<!-------------------------------------------------------------->
+
 ## Prerequisites
 
 To use the `o3de` Python script, you must have Python runtime set up. Python runtime was downloaded when you set up the engine. For more information, refer to instructions on how to get Python runtime in the [Register the engine](/docs/welcome-guide/setup/setup-from-github/#register-the-engine) section of the Setup From GitHub page.
 
+
+<!-------------------------------------------------------------->
 
 ## Quick start
 
@@ -74,6 +78,8 @@ For example, to register the engine, you can enter the following command.
 {{< /tabs >}}
 
 
+<!-------------------------------------------------------------->
+
 ## Commands
 The `o3de` Python script contains the following commands, with further details in the following sections. 
 
@@ -85,19 +91,22 @@ The `o3de` Python script contains the following commands, with further details i
 | [`create-from-template`](#create-from-template) | Creates an instance from a generic template.  |
 | [`create-project`](#create-project) | Creates a new project. |
 | [`create-gem`](#create-gem) | Creates a new Gem. |
-| [`register`](#register) | Register an O3DE object. |
+| [`register`](#register) | Registers an O3DE object. |
 | [`register-show`](#register-show) | Shows the registered O3DE objects. |
-| [`get-registered`](#get-registered) | Shows the registered O3DE object's path that is mapped to the specified name. |
-| [`enable-gem`](#enable-gem) | Enables the Gem in your project, so you can use the assets or code the Gem provides. |
+| [`get-registered`](#get-registered) | Shows the path to the registered O3DE object with the specified name. |
+| [`enable-gem`](#enable-gem) | Enables the Gem in your project. |
 | [`disable-gem`](#disable-gem) | Disables the Gem in your project. |
+| [`edit-engine-properties`](#edit-engine-properties) | Edits the engine's properties. |
+| [`edit-project-properties`](#edit-project-properties) | Edits the project's properties. |
+| [`edit-gem-properties`](#edit-gem-properties) | Edits the Gem's properties. |
 | [`sha256`](#sha256) | Creates a hash value for an O3DE object using the SHA-256 secure hash algorithm. |
-<!-- | [`edit-project-properties`](#edit-project-properties) |  | -->
 
 
+<!-------------------------------------------------------------->
 
 ## `get-global-project`
 
-Gets the global project that is registered to the engine in the specified `.setreg` file at `<user>/.o3de/Registry/`.
+Gets the global project that is registered to the engine. By default, this is read from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`. You can also specify a file path using `-i`.
 
 ### Format
 
@@ -113,7 +122,7 @@ Reads the global project from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
 o3de.bat get-global-project
 ```
 
-Reads the global project from a specified path.
+Reads the global project from a specified file.
 ```cmd
 o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setreg
 ```
@@ -128,6 +137,8 @@ o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setr
 
   A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `C:/Users/USER_PATH/.o3de/Registry/bootstrap.setreg` instead.
 
+
+<!-------------------------------------------------------------->
 
 ## `set-global-project`
 
@@ -176,6 +187,8 @@ o3de.bat set-global-project -pp PROJECT_PATH -o C:\Users\<USERNAME>\.o3de\Regist
 
   Forces the project path to be set in the supplied setreg file. 
 
+
+<!-------------------------------------------------------------->
 
 ## `create-template`
 
@@ -260,9 +273,11 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
   Forces the new template directory to override the existing one, if one exists. 
 
 
+<!-------------------------------------------------------------->
+
 ## `create-from-template`
 
-Creates a template with a `template.json` file. 
+Creates an instance of a generic template based on the specified template.
 
 ### Format
 
@@ -279,12 +294,6 @@ create-from-template [-h] -dp DESTINATION_PATH
 ```
 
 ### Usage
-
-Creates a generic template and saves it in the specified path. 
-
-```cmd
-o3de.bat create-from-template --destination-path DESTINATION_PATH
-```
 
 Creates a template based on the specified template and saves it in the specified path. 
 
@@ -354,6 +363,8 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
   Copies over instantiated template directory even if it exist.
 
+
+<!-------------------------------------------------------------->
 
 ## `create-project`
 
@@ -467,6 +478,8 @@ class component. The default is a random UUID. For example, {b60c92eb-3139-454b-
   Forces the new project directory to override the existing one, if one exists. 
 
 
+<!-------------------------------------------------------------->
+
 ## `create-gem`
 
 Create a new Gem at the specified path.
@@ -579,6 +592,8 @@ class component. The default is a random UUID. For example,
   Forces the new Gem directory to override the existing one, if one exists.
 
 
+<!-------------------------------------------------------------->
+
 ## `register`
 
 Register O3DE objects to the `o3de_manifest.json` file.
@@ -596,7 +611,7 @@ register [-h]
 ### Usage
 <br>
 
-#### Registering engines
+**Registering engines**
 
 Registers this engine to the `o3de_manifest.json` file.  This command maps the engine's name to its path in JSON. 
 
@@ -618,7 +633,7 @@ o3de.bat register --all-engines-path ALL_ENGINES_PATH
 
 <br>
 
-#### Registering projects
+**Registering projects**
 
 Registers the specified project to the engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
 
@@ -640,7 +655,7 @@ o3de.bat register --all-projects-path ALL_PROJECTS_PATH
 
 <br>
 
-#### Registering Gems
+**Registering Gems**
 
 Registers the Gem to the `o3de_manifest.json` file. Before registering the Gem, this command verifies that the Gem has a valid `gem.json` file. Then, it adds the Gem's path to the `external_subdirectories` list in the `o3de_manifest.json` file.
 
@@ -668,7 +683,7 @@ o3de.bat register --all-gems-path ALL_GEMS_PATH
 
 <br>
 
-#### Registering external subdirectories
+**Registering external subdirectories**
 
 Registers the specified subdirectory path to the `external_subdirectories` list in the `o3de_manifest.json` file.
 
@@ -690,7 +705,7 @@ o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY --external-subdi
 
 <br>
 
-#### Registering templates
+**Registering templates**
 
 Registers the specified template to the `templates` list in the `o3de_manifest.json` file.
 
@@ -712,7 +727,7 @@ o3de.bat register --all-templates-path ALL_TEMPLATES_PATH
 
 <br>
 
-#### Registering restricted paths
+**Registering restricted paths**
 
 Registers the specified restricted directory to the `restricted` list in the `o3de_manifest.json` file. 
 
@@ -728,7 +743,7 @@ o3de.bat register --all-restricted-path ALL_RESTRICTED_PATH
 
 <br>
 
-#### Registering repositories
+**Registering repositories**
 
 Registers the specified repository URI (uniform resource identifier) to the `repos` list in the `o3de_manifest.json` file.
 
@@ -744,7 +759,7 @@ o3de.bat register --all-repo-uri ALL_REPO_URI
 
 <br>
 
-#### Registering default folders
+**Registering default folders**
 
 Registers the specified folder as the default engines directory in the `o3de_manifest.json` file.
 
@@ -784,7 +799,7 @@ o3de.bat register --default-third-party folder THIRD_PARTY_FOLDER_PATH
 
 <br>
 
-#### Updating the `o3de_manifest.json` file
+**Updating the `o3de_manifest.json` file**
 
 Updates the `o3de_manifest.json` file. This command validates all of the registered objects, and then removes invalid objects.
 
@@ -908,8 +923,11 @@ The following parameters are used with the `--external-subdirectory` option.
   If supplied, registers the external subdirectory with the `project.json` file at the specified project path. 
 
 
+<!-------------------------------------------------------------->
+
 ## `register-show`
-Shows the registered O3DE objects in the `o3de_manifest.json` file. 
+
+Shows the O3DE objects that are registered in the `o3de_manifest.json` file. 
 
 ### Format
 
@@ -928,133 +946,160 @@ Outputs the `o3de_manifest.json` file.
 o3de.bat register-show
 ```
 
-Outputs the current engine that is registered in the `o3de_manifest.json` file.
+<br>
+
+**Showing registered engines**
+
+Outputs the current engine that is registered in the `o3de_manifest.json` file. If you use `-v`, this command also outputs the contents of the current engine's `engine.json` file.
 
 ```cmd
-o3de.bat register-show --this-engine
+o3de.bat register-show --this-engine -v
 ```
 
-Iterates over each engine that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of engines that are registered in the `o3de_manifest.json` file. If you use `-v`, then this command outputs each engine's `engine.json` file. 
 
 ```cmd
-o3de.bat register-show --engines
+o3de.bat register-show --engines -v
 ```
 
-Iterates over each project that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+<br>
+
+**Showing registered projects**
+
+Outputs the list of projects that are registered in the `o3de_manifest.json` file. If you use `-v`, then this command outputs each project's `project.json` file.
 
 ```cmd
-o3de.bat register-show --projects
+o3de.bat register-show --projects -v
 ```
 
-Iterates over each engine that is registered in the current engine's `engine.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of projects that are registered in the current engine's `engine.json` file. If you use `-v`, then this command outputs each project's `project.json` file.
 
 ```cmd
-o3de.bat register-show --engine-projects
+o3de.bat register-show --engine-projects -v
 ```
 
-Iterates over each project that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the `project.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of projects that are registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. If you use `-v`, then this command outputs each project's `project.json` file.
 
 ```cmd
-o3de.bat register-show --all-projects
+o3de.bat register-show --all-projects -v
 ```
 
-Iterators over each Gem that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+<br>
+
+**Showing registered Gems**
+
+Outputs the list of Gems that are registered in the `o3de_manifest.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
 
 ```cmd
-o3de.bat register-show --gems
+o3de.bat register-show --gems -v
 ```
 
-Iterates over each Gem that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of Gems that are registered in the current engine's `engine.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
 
 ```cmd
-o3de.bat register-show --engine-gems
+o3de.bat register-show --engine-gems -v
 ```
 
-Iterates over each gem in the project.json at the specified path. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of Gems that are registered in the specified project's `project.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
 
 ```cmd
-o3de.bat register-show --project-gems --project-path PROJECT_PATH
+o3de.bat register-show --project-gems --project-path PROJECT_PATH -v
 ```
 
-Iterates over each gem that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the Gem's path to stdout if verbose > 0 (`-v`).
+Outputs the list of Gems that are registered in both the `o3de_manifest.json` file and current engine's `engine.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
 
 ```cmd
-o3de.bat register-show --all-gems
+o3de.bat register-show --all-gems -v
 ```
 
-Outputs the templates that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `template.json` file to stdout if verbose > 0 (`-v`).
+<br>
+
+**Showing registered templates**
+
+Outputs the list of templates that are registered in the `o3de_manifest.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
 
 ```cmd
-o3de.bat register-show --templates
+o3de.bat register-show --templates -v
 ```
 
-Iterates over each template that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `template.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of templates that are registered in the current engine's `engine.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
 
 ```cmd
-o3de.bat register-show --engine-templates
+o3de.bat register-show --engine-templates -v
 ```
 
-Iterates over each template in the `project.json` file that is located at the specified project path. Then, for each iteration, outputs the `template.json` to stdout if verbose > 0 (`-v`).
+Outputs the list of templates that are registered in the specified project's `project.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
 
 ```cmd
-o3de.bat register-show --project-templates --project-path C:/Projects/TestProject
+o3de.bat register-show --project-templates --project-path PROJECT_PATH -v
 ```
 
-Iterates over each template that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json`. Then, for each iteration, outputs the `template.json` file path to stdout if verbose > 0 (`-v`).
+Outputs the list of templates that are registered in both the `o3de_manifest.json` file and current engine's `engine.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
 
 ```cmd
-o3de.bat register-show --all-templates
+o3de.bat register-show --all-templates -v
 ```
 
-Outputs the restricted directories that are registered in the `o3de_manifest.json` file. For each restricted directory, this command outputs the `restricted.json` file to stdout if verbose > 0 (`-v`).
+<br>
+
+**Showing registered restricted directories**
+
+Outputs the list of restricted directories that are registered in the `o3de_manifest.json` file. If you use `-v`, then this command outputs each restricted directory's `restricted.json` file.
 
 ```cmd
-o3de.bat register-show --restricted
+o3de.bat register-show --restricted -v
 ```
 
-Iterates over each restricted directory that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `restricted.json` file to stdout if verbose > 0 (`-v`).
+Outputs the list of restricted directories that are registered in the current engine's `engine.json` file. If you use `-v`, then this command outputs each restricted directory's `restricted.json` file.
 
 ```cmd
-o3de.bat register-show --engine-restricted
+o3de.bat register-show --engine-restricted -v
 ```
 
-Iterates over each restricted directory in the `project.json` file that is located at the specified project path. Then, for each iteration outputs the restricted directory's path to stdout if verbose > 0 (`-v`).
+Outputs the list of restricted directories that are registered in the specified project's `project.json` file. If you use `-v`, then this command outputs each restricted directory's `restricted.json` file.
 
 ```cmd
-o3de.bat register-show --project-templates --project-path C:/Projects/TestProject
+o3de.bat register-show --project-restricted --project-path PROJECT_PATH -v
 ```
 
-Iterates over each restricted directory that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the restricted directory's path to stdout if verbose > 0 (`-v`).
+Outputs the list of restricted directories that are registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. If you use `-v`, then this command outputs each restricted directory's `restricted.json` file.
 
 ```cmd
-o3de.bat register-show --all-restricted
+o3de.bat register-show --all-restricted -v
 ```
 
-Outputs the `external_subdirectories` array in the `o3de_manifest.json` file.
+<br>
+
+**Showing registered external subdirectories**
+
+Outputs the list of external subdirectories that are registered in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register-show --external-subdirectories
 ```
 
-Outputs the `external_subdirectories` array in the current engine's `engine.json` file. 
+Outputs the list of external subdirectories that are registered in the current engine's `engine.json` file.
 
 ```cmd
 o3de.bat register-show --engine-external-subdirectories
 ```
 
-Outputs the `external_subdirectories` array in the `project.json` that is located at the specified project path.
+Outputs the list of external subdirectories that are registered in the specified project's `project.json` file.
 
 ```cmd
 o3de.bat register-show --project-external-subdirectories --project-path PROJECT_PATH
 ```
 
-Outputs the `external_subdirectories` from both the `o3de_manifest.json` file and the current engine's `engine.json` file.
+Outputs the list of external subdirectories that are registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
 ```cmd
-o3de.bat register-show --all-external-subdirectories --project-path PROJECT_PATH
+o3de.bat register-show --all-external-subdirectories
 ```
 
-Iterates over the repositories that are registered in the `o3de_manifest.json` file. Then, for each repository, outputs the `repos` array to stdout.
+<br>
+
+**Showing registered repositories**
+Outputs the list of repositories that are registered in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register-show --repos
@@ -1168,8 +1213,11 @@ o3de.bat register-show --repos
 
 
 
+<!-------------------------------------------------------------->
+
 ## `get-registered`
-Shows the registered O3DE object's path that is mapped to the specified name.
+
+Shows the path to the registered O3DE object with the specified name.
 
 ### Format
 
@@ -1181,37 +1229,37 @@ get-registered [-h]
 
 ### Usage
 
-Returns the first path of an engine that has the specified "engine_name" value. 
+Returns the first path of an engine that has the specified `engine_name` value. 
 
 ```cmd
 o3de.bat get-registered --engine-name ENGINE_NAME
 ```
 
-Returns the first path of a project that has the specified "project_name" value. 
+Returns the first path of a project that has the specified `project_name` value. 
 
 ```cmd
 o3de.bat get-registered --project-name PROJECT_NAME
 ```
 
-Returns the first path of a Gem that has the specified "gem_name" value. 
+Returns the first path of a Gem that has the specified `gem_name` value. 
 
 ```cmd
 o3de.bat get-registered --gem-name GEM_NAME
 ```
 
-Returns the first path of a template that has the specified "template_name" value.
+Returns the first path of a template that has the specified `template_name` value.
 
 ```cmd
 o3de.bat get-registered --template-name TEMPLATE_NAME
 ```
 
-Returns the first path of a restricted directory that has the specified "restricted_name" value.
+Returns the first path of a restricted directory that has the specified `restricted_name` value.
 
 ```cmd
 o3de.bat get-registered --restricted-name RESTRICTED_NAME
 ```
 
-Returns the first URI for a repository that has the specified "repo_name" value.
+Returns the first URI for a repository that has the specified `repo_name` value.
 
 ```cmd
 o3de.bat get-registered --repo-name REPO_NAME
@@ -1287,6 +1335,8 @@ o3de.bat get-registered --default-folder restricted
   Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
+<!-------------------------------------------------------------->
+
 ## `enable-gem`
 
 Enables the Gem in your project, so you can use the assets or code the Gem provides. When you enable a Gem, this command adds the Gem's name to your project's `Code/enabled_gems.cmake` file, which adds the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
@@ -1335,6 +1385,8 @@ o3de.bat enable-gem -gp GEM_PATH -pp PROJECT_PATH
 
   Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
+
+<!-------------------------------------------------------------->
 
 ## `disable-gem`
 
@@ -1385,9 +1437,69 @@ o3de.bat disable-gem -gp GEM_PATH -pp PROJECT_PATH
   Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
-<!-- ## edit-project-properties
+<!-------------------------------------------------------------->
 
-Edits a set of fields within a manifest file. 
+## `edit-engine-properties`
+
+Edits the specified engine's properties by modifying the `engine.json` file. 
+
+### Format
+
+```cmd
+edit-engine-properties [-h] (-ep ENGINE_PATH | -en ENGINE_NAME)
+                        [-enn ENGINE_NEW_NAME]
+                        [-ev ENGINE_VERSION]
+```
+
+### Usage
+
+Updates the `engine_name` field in the `engine.json` file located at the specified engine's folder. 
+
+```cmd
+o3de.bat edit-engine-properties --engine-path ENGINE_PATH --engine-new-name ENGINE_NEW_NAME
+
+// or
+
+o3de.bat edit-engine-properties --engine-name ENGINE_NAME --engine-new-name ENGINE_NEW_NAME
+```
+
+
+### Optional parameters
+
+  
+- **`-h, --help`**
+
+  Shows the help message.
+
+- **`-ep ENGINE_PATH, --engine-path ENGINE_PATH`**
+
+  The path to the engine.
+
+- **`-en ENGINE_NAME, --engine-name ENGINE_NAME`**
+
+  The name of the engine.
+
+
+**Engine properties:**
+
+The following parameters modify the specified engine's properties.
+  
+- **`-enn ENGINE_NEW_NAME, --engine-new-name ENGINE_NEW_NAME`**
+
+  Sets the engine's name. 
+
+- **`-ev ENGINE_VERSION, --engine-version ENGINE_VERSION`**
+
+  Sets the engine's version.
+
+
+<!-------------------------------------------------------------->
+
+## `edit-project-properties`
+
+Edits the specified project's properties by modifying the `project.json` file. 
+
+### Format 
 
 ```cmd
 edit-project-properties [-h]
@@ -1404,23 +1516,6 @@ edit-project-properties [-h]
 
 ### Usage
 
-Updates the `engine_name` field in the `engine.json` file located at the specified engine's folder. 
-
-```cmd
-o3de.bat edit-engine-properties --engine-path ENGINE_PATH --engine-new-name ENGINE_NEW_NAME
-
-// or
-
-o3de.bat edit-engine-properties --engine-name ENGINE_NAME --engine-new-name ENGINE_NEW_NAME
-```
-
-Updates the `gem_name` field in the `gem.json` file located at the specified Gem's folder.
-
-```cmd
-o3de.bat edit-gem-properties --gem-path GEM_PATH --gem-new-name GEM_NEW_NAME
-o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
-```
-
 Updates the "project_name" field within the gem.json located at the supplied project path or at the path of the registered project with <project-name>
 
 ```cmd
@@ -1430,60 +1525,152 @@ o3de.bat edit-project-properties --project-name PROJECT_NAME --project-new-name 
 
 ### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-The path to the project.
+  The path to the project.
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-The name of the project.
+  The name of the project.
 
-`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`
+- **`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`**
 
-Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited
+  Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited
 list (for example, `-at A B C`).
 
-`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`
+- **`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`**
 
-Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
+  Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
 
-`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`
+- **`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`**
 
-Replace the `user_tags` property with the specified space delimited list of values.
+  Replace the `user_tags` property with the specified space delimited list of values.
 
 
 **Project properties:**
-The following properties modify individual project properties.
 
-`-pnn PROJECT_NEW_NAME, --project-new-name PROJECT_NEW_NAME`
+The following parameters modify the specified project's properties.
 
-Sets the project's name.
+- **`-pnn PROJECT_NEW_NAME, --project-new-name PROJECT_NEW_NAME`**
 
-`-po PROJECT_ORIGIN, --project-origin PROJECT_ORIGIN`
+  Sets the project's name.
 
-Sets the description or url for the project origin (such as the
-project host, repository, or owner).
+- **`-po PROJECT_ORIGIN, --project-origin PROJECT_ORIGIN`**
 
-`-pd PROJECT_DISPLAY, --project-display PROJECT_DISPLAY`
+  Sets the description or URL for the project origin (such as the project host, repository, or owner).
 
-Sets the project's display name.
+- **`-pd PROJECT_DISPLAY, --project-display PROJECT_DISPLAY`**
 
-`-ps PROJECT_SUMMARY, --project-summary PROJECT_SUMMARY`
+  Sets the project's display name.
 
-Sets the project's summary description.
+- **`-ps PROJECT_SUMMARY, --project-summary PROJECT_SUMMARY`**
 
-`-pi PROJECT_ICON, --project-icon PROJECT_ICON`
+  Sets the project's summary description.
 
-Sets the project's icon resource. -->
+- **`-pi PROJECT_ICON, --project-icon PROJECT_ICON`**
 
+  Sets the path to the project's icon resource.
+
+<!-------------------------------------------------------------->
+
+## `edit-gem-properties`
+
+Edits the specified Gem's properties by modifying the `gem.json` file. 
+
+### Format
+
+```cmd
+edit-gem-properties [-h] (-gp GEM_PATH | -gn GEM_NAME)
+                        [-gnn GEM_NEW_NAME] [-gd GEM_DISPLAY]
+                        [-go GEM_ORIGIN] [-gt {Code,Tool,Asset}]
+                        [-gs GEM_SUMMARY] [-gi GEM_ICON]
+                        [-gr GEM_REQUIREMENTS]
+                        [-at [ADD_TAGS [ADD_TAGS ...]] | -dt
+                        [REMOVE_TAGS [REMOVE_TAGS ...]] | -rt
+                        [REPLACE_TAGS [REPLACE_TAGS ...]]]
+```
+
+### Usage
+
+Updates the `gem_name` field in the `gem.json` file located at the specified Gem's folder.
+
+```cmd
+o3de.bat edit-gem-properties --gem-path GEM_PATH --gem-new-name GEM_NEW_NAME
+
+// or
+
+o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
+```
+
+### Optional parameters
+
+
+- **`-h, --help`**
+- 
+  Shows the help message.
+
+- **`-gp GEM_PATH, --gem-path GEM_PATH`**
+
+  The path to the Gem.
+
+- **`-gn GEM_NAME, --gem-name GEM_NAME`**
+
+  The name of the Gem.
+
+- **`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`**
+
+  Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited list (for example, `-at A B C`).
+
+- **`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`**
+
+  Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
+
+- **`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`**
+  
+  Replace the `user_tags` property with the specified space delimited list of values.
+
+
+**Gem properties:**
+
+  The following parameters modify the specified Gem's properties.
+
+- **`-gnn GEM_NEW_NAME, --gem-new-name GEM_NEW_NAME`**
+
+  Sets the Gem's name.
+
+- **`-gd GEM_DISPLAY, --gem-display GEM_DISPLAY`**
+
+  Sets the Gem's display name.
+
+- **`-go GEM_ORIGIN, --gem-origin GEM_ORIGIN`**
+
+  Sets the description or URL for the Gem origin (such as the Gem host, repository, or owner).
+
+- **`-gt {Code,Tool,Asset}, --gem-type {Code,Tool,Asset}`**
+
+  Sets the Gem type to either Code, Tool, or Asset.
+
+- **`-gs GEM_SUMMARY, --gem-summary GEM_SUMMARY`**
+
+  Sets the Gem's summary description.
+
+- **`-gi GEM_ICON, --gem-icon GEM_ICON`**
+
+  Sets the path to the Gem's icon resource.
+
+- **`-gr GEM_REQUIREMENTS, --gem-requirements GEM_REQUIREMENTS`**
+
+  Sets the description of the requirements that are needed to use the Gem.
+
+<!-------------------------------------------------------------->
 
 ## `sha256`
 
-Creates a *secure hash algorithm* (SHA-256). This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file. 
+Creates a hash value for an O3DE object using the SHA-256 secure hash algorithm. This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file. 
 
 ### Format
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -6,7 +6,7 @@ weight: 200
 toc: true
 ---
 
-The `o3de` Python script lets you configure your project using the command line interface (CLI). The script aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so you can access them from a single point. Find the script in the engine folder at `/scripts/o3de.py`. 
+The `o3de` Python script lets you configure your project using the command line interface (CLI). The script aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so you can access them from a single point. Find the script in your engine directory at `/scripts/o3de.py`.
 
 You can use the `o3de` Python script for the following tasks:
 
@@ -111,7 +111,7 @@ The `o3de` Python script contains the following commands, with further details i
 
 ## `get-global-project`
 
-Gets the global project that is registered to the engine. By default, reads the global project from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`. You can also specify a file path using `-i`.
+Gets the global project that is registered to the engine. By default, reads the global project from `<USER_DIRECTORY>/.o3de/Registry/bootstrap.setreg`. You can also specify a file path using `-i`.
 
 ### Format
 
@@ -121,7 +121,7 @@ get-global-project [-h] [-i INPUT_PATH]
 
 ### Usage
 
-Reads the global project from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+Reads the global project from `<USER_DIRECTORY>/.o3de/Registry/bootstrap.setreg`.
 
 ```cmd
 o3de.bat get-global-project
@@ -129,7 +129,7 @@ o3de.bat get-global-project
 
 Reads the global project from a specified file.
 ```cmd
-o3de.bat get-global-project -i <USER_PATH>\.o3de\Registry\my-custom.setreg
+o3de.bat get-global-project -i <USER_DIRECTORY>\.o3de\Registry\my-custom.setreg
 ```
 
 ### Optional parameters
@@ -140,16 +140,16 @@ o3de.bat get-global-project -i <USER_PATH>\.o3de\Registry\my-custom.setreg
 
 - **`-i INPUT_PATH, --input-path INPUT_PATH`**
 
-  A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `</USER_PATH>/.o3de/Registry/bootstrap.setreg` instead.
+  A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `<USER_DIRECTORY>/.o3de/Registry/bootstrap.setreg` instead.
 
 
 <!-------------------------------------------------------------->
 
 ## `set-global-project`
 
-Sets the specified project as the engine's global project. By default sets this in `C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
+Sets the specified project as the engine's global project. By default, sets this in `<USER_DIRECTORY>\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
 
-If you set a global project, then O3DE tools (such as **Asset Processor** and **O3DE Editor**) use the global project when they are launched from an installed engine. To override the global project, specify a project with the `project-path` parameter when you launch the O3DE tools from the command line.
+If you set a global project, then O3DE tools (such as **Asset Processor** and **O3DE Editor**) use the global project when you launch them from an installed engine. To override the global project, specify a project with the `project-path` parameter when you launch the O3DE tools from the command line.
 
 ### Format 
 
@@ -160,7 +160,7 @@ set-global-project [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
 
 ### Usage
 
-Sets the specified project as the global project in `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+Sets the specified project as the global project in `<USER_DIRECTORY>/.o3de/Registry/bootstrap.setreg`.
 
 ```cmd
 o3de.bat set-global-project -pp PROJECT_PATH
@@ -169,7 +169,7 @@ o3de.bat set-global-project -pp PROJECT_PATH
 Sets the specified project as the global project in the specified path.
 
 ```cmd
-o3de.bat set-global-project -pp PROJECT_PATH -o <USER_PATH>\.o3de\Registry\my-custom.setreg
+o3de.bat set-global-project -pp PROJECT_PATH -o <USER_DIRECTORY>\.o3de\Registry\my-custom.setreg
 ```
 
 ### Optional parameters
@@ -188,7 +188,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o <USER_PATH>\.o3de\Registry\my-cu
 
 - **`-o OUTPUT_PATH, --output-path OUTPUT_PATH`**
 
-  The path and filename where the `project_path` key is written. The file should be located in `<USER_PATH>/.o3de/Registry/` and have the file extension `.setreg`. If you don't use this parameter, the key is written to `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+  The path and filename where the `project_path` key is written. The file should be located in `<USER_DIRECTORY>/.o3de/Registry/` and have the file extension `.setreg`. If you don't use this parameter, `o3de` writes the key to `<USER_DIRECTORY>/.o3de/Registry/bootstrap.setreg`.
 
 - **`-f, --force`**
 
@@ -243,7 +243,7 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-srn SOURCE_RESTRICTED_NAME, --source-restricted-name SOURCE_RESTRICTED_NAME`**
 
-  The name of the source's restricted folder. If supplied, you do not need to use the `--source-restricted-path` parameter. 
+  The name of the source's restricted folder. If supplied, you don't need to use the `--source-restricted-path` parameter.
 
 - **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
@@ -251,15 +251,15 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-  The name of the template's restricted folder. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted folder. If supplied, you don't need to use the `--template-restricted-path` parameter.
 
 - **`-sn SOURCE_NAME, --source-name SOURCE_NAME`**
 
-  Substitutes any file and path entries that match the source name -- ${Name} and ${SanitizedCppName} -- in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
+  Substitutes any file and path entries that match the source name--`${Name}` and `${SanitizedCppName}`--in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
 
 - **`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-  A path to append to `SOURCE_RESTRICTED_PATH/<platform>/`, which contains the restricted source. For example: `--source-restricted-path C:/restricted --source-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<source_name>`
+  A path to append to `SOURCE_RESTRICTED_PATH/<platform>/`, which contains the restricted source. For example: `--source-restricted-path C:/restricted --source-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<source_name>`.
 
 - **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -267,15 +267,15 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-kr, --keep-restricted-in-template`**
 
-  If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: \<TemplateName\> -> ${Name}, \<templatename\> -> ${NameLower}, \<TEMPLATENAME\> -> ${NameUpper}. 
+  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: \<TemplateName\> -> ${Name}, \<templatename\> -> ${NameLower}, \<TEMPLATENAME\> -> ${NameUpper}.
 
 - **`-f, --force`**
          
@@ -318,35 +318,35 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 - **`-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`**
 
-  The path to instantiate the new template in. The path can be absolute or relative to the O3DE development source folder. For example: Set DESTINATION_PATH = `C:/o3de/NewTemplate`. 
+  The path to instantiate the new template in. The path can be absolute or relative to the O3DE development source folder. For example: DESTINATION_PATH = `C:/o3de/NewTemplate`.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-  The path to the template you want to instantiate. The path can be absolute or relative to the O3DE development source folder. For example: Set TEMPLATE_PATH to `C:/o3de/Template/SomeTemplate`.
+  The path to the template that you want to instantiate. The path can be absolute or relative to the O3DE development source folder. For example: TEMPLATE_PATH = `C:/o3de/Template/SomeTemplate`.
 
 - **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-  The name of the registered template to instantiate. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the registered template to instantiate. If supplied, you don't need to use the `--template-path` parameter.
 
 - **`-dn DESTINATION_NAME, --destination-name DESTINATION_NAME`**
 
-  The name to replace ${Name} with in the instantiated template. The name must be alphanumeric, and can contain _ and - characters. If the destination name is not provided, this command will use the last component of the destination path.
+  The name to replace `${Name}` with in the instantiated template. The name must be alphanumeric, though it can contain underscores (_) and hyphens (-). If you don't provide the destination name, this command uses the last component of the destination path.
 
 - **`-drp DESTINATION_RESTRICTED_PATH, --destination-restricted-path DESTINATION_RESTRICTED_PATH`**
 
-  The path where the restricted files will be written to.
+  The path where `o3de` writes the restricted files.
 
 - **`-drn DESTINATION_RESTRICTED_NAME, --destination-restricted-name DESTINATION_RESTRICTED_NAME`**
 
-  The name of the registered restricted path where the restricted files will be written to. If supplied, you do not need to use the `--destination-restricted-path` parameter. 
+  The name of the registered restricted path where `o3de` writes the restricted files. If supplied, you don't need to use the `--destination-restricted-path` parameter.
 
 - **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-  The path to the template restricted directory to read from, if any.
+The path to the restricted directory that `o3de` adds restricted platform sources to, if any.
 
 - **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
-
-  The name of the registered restricted path to read from, if any. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  
+The name of the restricted directory that `o3de` adds restricted platform sources to, if any. If supplied, you don't need to use the `--template-restricted-path` parameter.
 
 - **`-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -358,26 +358,26 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 - **`-kr, --keep-restricted-in-instance`**
 
-  If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: \<DestinationName\> -> ${Name}, \<destinationname\> -> ${NameLower}, \<DESTINATIONNAME\> -> ${NameUpper}.
+  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: \<DestinationName\> -> ${Name}, \<destinationname\> -> ${NameLower}, \<DESTINATIONNAME\> -> ${NameUpper}.
 
 - **`-f, --force`**
 
-  Copies over instantiated template directory even if it exist.
+  Overwrites the instantiated template directory, even if it already exists.
 
 
 <!-------------------------------------------------------------->
 
 ## `create-project`
 
-Create a new project at the specified path.
+Creates a new project at the specified path and registers it to the `o3de_manifest.json` file. However, if you create the project in the engine directory, this command registers the project to the engine's `engine.json` file instead.
 
 ### Format
 
@@ -417,19 +417,19 @@ o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PAT
 
 - **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-  The path to create a new project at. The project's path can be absolute or relative to the O3DE development source folder. For example: PROJECT_PATH = `C:/o3de/TestProject`
+  The path to your newly created project. The project's path can be absolute or relative to the O3DE development source folder. For example: PROJECT_PATH = `C:/o3de/TestProject`.
 
 - **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-  The name of your new project. Must be alphanumeric, and can contain _ and - characters. If the project name is not provided, this command will use the last component of the project path. Ex. New_Project-123
+  The name of your new project. The name must be alphanumeric, though it can contain underscores (_) and hyphens (-). If you don't provide the project name, this command uses the last component of the project path. For example: New_Project-123.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-  The path to the template you want to create a new project from. The path can be absolute or relative to the default templates path.
+  The path to the template that you want to create a new project from. The path can be absolute or relative to the default template's path.
 
 - **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-  The name of the template that you want to create a new project from. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the template that you want to create a new project from. If supplied, you don't need to use the `--template-path` parameter.
 
 - **`-prp PROJECT_RESTRICTED_PATH, --project-restricted-path PROJECT_RESTRICTED_PATH`**
 
@@ -445,7 +445,7 @@ o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PAT
 
 - **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-  The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted path. If supplied, you don't need to use the `--template-restricted-path` parameter.
 
 - **`-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH, --project-restricted-platform-relative-path PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -453,19 +453,19 @@ o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PAT
 
 - **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-  A path to append to the `TEMPLATE_RESTRICTED_PATH/<platform>`, and that contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
+  A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, and that contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
 - **`-kr, --keep-restricted-in-project`**
 
-  If true, creates the restricted platforms in the project folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the project folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the `template.json` file) in the new project's `project.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new project's `project.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. ${Name} and all of the other standard project replacements are automatically inferred from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces all occurences of "MyUsername" with ${User}, and "1723905" with ${id}. Note: \<ProjectName\> is the last component of the template_path. The following replacement pairs already exist: \<ProjectName\> -> ${Name}, \<projectname\> -> ${NameLower}, \<PROJECTNAME\> -> ${NameUpper}.
+  Add A->B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard project replacements from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `MyUsername` with `${User}`, and `1723905` with `${id}`. Note: \<ProjectName\> is the last component of the template_path. The following replacement pairs already exist: \<ProjectName\> -> ${Name}, \<projectname\> -> ${NameLower}, \<PROJECTNAME\> -> ${NameUpper}.
 
 - **`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`**
 
@@ -491,7 +491,7 @@ class component. The default is a random UUID. For example, {b60c92eb-3139-454b-
 
 ## `create-gem`
 
-Create a new Gem at the specified path.
+Creates a new Gem at the specified path.
 
 ### Format
 
@@ -516,7 +516,7 @@ Create a new Gem at the specified path using the "DefaultGem" template.
 o3de.bat create-gem -gp GEM_PATH
 ```
 
-Create a new Gem at the specified path using the specified Gem template. The template must have a valid gem.json file.
+Create a new Gem at the specified path using the specified Gem template. The template must have a valid `gem.json` file.
 
 ```cmd
 o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
@@ -534,15 +534,15 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-  The name of your new Gem. Must be alphanumeric, and can contain _ and - characters. If the Gem name is not provided, this command will use the last component of the Gem path. Ex. New_Gem
+  The name of your new Gem. The name must be alphanumeric, though it can contain underscores (_) and hyphens (-). If you don't provide the Gem name, this command uses the last component of the Gem path. For example: New_Gem.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-  The path to the template you want to create a new Gem from. The path can be absolute or relative to the default templates path.
+  The path to the template that you want to create a new Gem from. The path can be absolute or relative to the default template's path.
 
 - **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-  The name of the template that you want to create a new Gem from. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the template that you want to create a new Gem from. If supplied, you don't need to use the `--template-path` parameter.
 
 - **`-grp GEM_RESTRICTED_PATH, --gem-restricted-path GEM_RESTRICTED_PATH`**
 
@@ -550,7 +550,7 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-grn GEM_RESTRICTED_NAME, --gem-restricted-name GEM_RESTRICTED_NAME`**
 
-  The name of the Gem's restricted path, if any. If supplied, you do not need to use the `--gem-restricted-path` parameter.
+  The name of the Gem's restricted path, if any. If supplied, you don't need to use the `--gem-restricted-path` parameter.
 
 - **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
@@ -558,11 +558,11 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-  The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted path. If supplied, you don't need to use the `--template-restricted-path` parameter.
 
 - **`-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH, --gem-restricted-platform-relative-path GEM_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-  A path to append to the `GEM_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example, `--gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<gem_name>`.
+  A path to append to `GEM_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<gem_name>`.
 
 - **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -570,31 +570,27 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  \<GemName> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMNAME\> -> ${NameUpper}.
+  Add A->B replacement pairs. `o3de` automatically infers `${Name}` and all of the other standard Gem replacements from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces `${DATE}` with `1/1/2020`, and  `${id}` with `1723905`. Note:  \<GemName> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMNAME\> -> ${NameUpper}.
 
 - **`-kr, --keep-restricted-in-gem`**
 
-  If true, creates the restricted platforms in the Gem folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the Gem folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the `template.json` file) in the new Gem's `Gem.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new Gem's `gem.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
 
 - **`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`**
 
-  A UUID that you want to associate the system class
-component with. The default is a random uuid. For example, 
-{b60c92eb-3139-454b-a917-a9d3c5819594}.
+  A UUID that you want to associate the system class component with. The default is a random UUID. For example: {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 - **`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`**
 
-  A UUID that you want to associate with the editor system
-class component. The default is a random UUID. For example,
-{b60c92eb-3139-454b-a917-a9d3c5819594}.
+  A UUID that you want to associate with the editor system class component. The default is a random UUID. For example: {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 - **`--module-id MODULE_ID`**
 
-  A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
+  A UUID that you want to associate with the module. The default is a random UUID. For example: {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 - **`-f, --force`**
 
@@ -605,7 +601,7 @@ class component. The default is a random UUID. For example,
 
 ## `register`
 
-Register O3DE objects to the `o3de_manifest.json` file.
+Registers O3DE objects to the `o3de_manifest.json` file.
 
 ### Format
 
@@ -644,19 +640,19 @@ o3de.bat register --all-engines-path ALL_ENGINES_PATH
 
 **Registering projects**
 
-Registers the specified project to the engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
+Registers the specified project to the engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file, and it sets `engine` to the engine's name in each project's `project.json` file.
 
 ```cmd
 o3de.bat register -pp PROJECT_PATH
 ```
 
-Registers the specified project to the specified engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
+Registers the specified project to the specified engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file, and it sets `engine` to the engine's name in each project's `project.json` file.
 
 ```cmd
 o3de.bat register -pp PROJECT_PATH --engine-path ENGINE_PATH
 ```
 
-Registers all of the projects in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `project.json` file. For each project, this command does two things: it adds the each project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file. 
+Registers all of the projects in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `project.json` file. This command does two things: it adds each project's path to the `o3de_manifest.json` file, and it sets `engine` to the engine's name in each project's `project.json` file.
 
 ```cmd
 o3de.bat register --all-projects-path ALL_PROJECTS_PATH
@@ -684,7 +680,7 @@ Registers the Gem to the engine's `engine.json` file. Before registering the Gem
 o3de.bat register -gp GEM_PATH -espp ENGINE_PATH
 ```
 
-Registers all of the Gems in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `gem.json` file. For each Gem, this command adds the Gem to the `o3de_manifest.json` file.
+Registers all of the Gems in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `gem.json` file. This command adds each Gem to the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register --all-gems-path ALL_GEMS_PATH
@@ -719,7 +715,7 @@ o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY --external-subdi
 Registers the specified template to the `templates` list in the `o3de_manifest.json` file.
 
 ```cmd
-o3de.bat register --template-path <template-path
+o3de.bat register --template-path <template-path>
 ```
 
 Registers the specified template to the `templates` list in the specified engine's `engine.json` file.
@@ -728,7 +724,7 @@ Registers the specified template to the `templates` list in the specified engine
 o3de.bat register --template-path TEMPLATE_PATH --engine-path ENGINE_PATH
 ```
 
-Registers all of the templates in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `template.json` file. For each template, this command adds the template to the `templates` list in the `o3de_manifest.json` file.
+Registers all of the templates in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `template.json` file. This command adds each template to the `templates` list in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register --all-templates-path ALL_TEMPLATES_PATH
@@ -738,7 +734,7 @@ o3de.bat register --all-templates-path ALL_TEMPLATES_PATH
 
 **Registering restricted paths**
 
-Registers the specified restricted directory to the `restricted` list in the `o3de_manifest.json` file. 
+Registers the specified restricted path to the `restricted` list in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register --restricted-path RESTRICTED_PATH
@@ -754,13 +750,13 @@ o3de.bat register --all-restricted-path ALL_RESTRICTED_PATH
 
 **Registering repositories**
 
-Registers the specified repository URI (uniform resource identifier) to the `repos` list in the `o3de_manifest.json` file.
+Registers the specified repository uniform resource identifier (URI) to the `repos` list in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register --repo-uri REPO_URI
 ```
 
-Registers all of the repositories in the specified URI. This command recursively scans the specified path and registers all of the repositoriesthat have a valid `repo.json` file. For each repository, this command adds the Gem to the `o3de_manifest.json` file.
+Registers all of the repositories in the specified URI. This command recursively scans the specified path and registers all of the repositories that have a valid `repo.json` file. This command adds each repository to the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat register --all-repo-uri ALL_REPO_URI
@@ -788,19 +784,19 @@ Registers the specified folder as the default Gems directory in the `o3de_manife
 o3de.bat register --default-gems-folder GEMS_FOLDER_PATH
 ```
 
-Register the specified folder as the default templates directory in the `o3de_manifest.json` file. When creating a template by using the `create-template` command, if you provide a relative path, the template saves in the default template folder.
+Registers the specified folder as the default templates directory in the `o3de_manifest.json` file. When creating a template by using the `create-template` command, if you provide a relative path, the template saves in the default template folder.
 
 ```cmd
 o3de.bat register --default-templates-folder TEMPLATES_FOLDER_PATH
 ```
 
-Register the specified folder as the default restricted directory in the `o3de_manifest.json` file. The commands - `create-from-template`, `create-project`, and `create-gem` - use the default restricted directory when instantiating a template. 
+Registers the specified folder as the default restricted directory in the `o3de_manifest.json` file. The commands--`create-from-template`, `create-project`, and `create-gem`--use the default restricted directory when instantiating a template.
 
 ```cmd
 o3de.bat register --default-restricted-folder RESTRICTED_FOLDER_PATH
 ```
 
-Register the specified folder as the default 3rd Party directory in the `o3de_manifest.json` file. The Project Manager uses the default 3rd Party directory to set the `LY_3RDPARTY_PATH` option when configuring the CMake build solution.
+Registers the specified folder as the default third-party directory in the `o3de_manifest.json` file. **Project Manager** uses the default third-party directory to set the `LY_3RDPARTY_PATH` option when configuring the CMake build solution.
 
 ```cmd
 o3de.bat register --default-third-party folder THIRD_PARTY_FOLDER_PATH
@@ -825,7 +821,7 @@ o3de.bat register --update
 
 - **`--this-engine`**
 
-  The engine that is running this o3de Python script.
+  The engine running this O3DE Python script.
 
 - **`-ep ENGINE_PATH, --engine-path ENGINE_PATH`**
 
@@ -841,7 +837,7 @@ o3de.bat register --update
 
 - **`-es EXTERNAL_SUBDIRECTORY, --external-subdirectory EXTERNAL_SUBDIRECTORY`**
 
-  The path to the the external subdirectory that you want to register or deregister.
+  The path to the external subdirectory that you want to register or deregister.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
@@ -857,27 +853,26 @@ o3de.bat register --update
 
 - **`-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`**
 
-  All of the engines in the specified folder that you want to register or deregister.
-
+  All of the engines that you want to register or deregister in the specified folder.
 - **`-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`**
 
-  All of the projects in the specified folder that you want to register or deregister.
+  All of the projects that you want to register or deregister in the specified folder.
 
 - **`-agp ALL_GEMS_PATH, --all-gems-path ALL_GEMS_PATH`**
 
-  All of the Gems in the specified folder that you want to register or deregister.
+  All of the Gems that you want to register or deregister in the specified folder.
 
 - **`-atp ALL_TEMPLATES_PATH, --all-templates-path ALL_TEMPLATES_PATH`**
 
-  All of the templates in the specified folder that you want to register or deregister.
+  All of the templates that you want to register or deregister in the specified folder.
 
 - **`-arp ALL_RESTRICTED_PATH, --all-restricted-path ALL_RESTRICTED_PATH`**
-
-  All of the restricted folders in the specified folder that you want to register or deregister.
+  
+  All of the restricted folders that you want to register or deregister in the specified folder.
 
 - **`-aru ALL_REPO_URI, --all-repo-uri ALL_REPO_URI`**
-
-  All of the repositories in the specified folder that you want to register or deregister.
+  
+  All of the repositories that you want to register or deregister in the specified folder.
 
 - **`-def DEFAULT_ENGINES_FOLDER, --default-engines-folder DEFAULT_ENGINES_FOLDER`**
 
@@ -917,11 +912,11 @@ o3de.bat register --update
 
 - **`-f, --force`**
 
-  Forces the registration information to update, if any modifications were made.
+  Forces the registration information to update, if you made any modifications.
 
  
 **external-subdirectory:**  
-The following parameters are used with the `--external-subdirectory` option.
+Use the following parameters with the `--external-subdirectory` option.
 
 - **`-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH, --external-subdirectory-engine-path EXTERNAL_SUBDIRECTORY_ENGINE_PATH`**
 
@@ -1015,7 +1010,7 @@ Outputs the list of Gems that are registered in the specified project's `project
 o3de.bat register-show --project-gems --project-path PROJECT_PATH -v
 ```
 
-Outputs the list of Gems that are registered in both the `o3de_manifest.json` file and current engine's `engine.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
+Outputs the list of Gems that are registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. If you use `-v`, then this command outputs each Gem's `gem.json` file.
 
 ```cmd
 o3de.bat register-show --all-gems -v
@@ -1043,7 +1038,7 @@ Outputs the list of templates that are registered in the specified project's `pr
 o3de.bat register-show --project-templates --project-path PROJECT_PATH -v
 ```
 
-Outputs the list of templates that are registered in both the `o3de_manifest.json` file and current engine's `engine.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
+Outputs the list of templates that are registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. If you use `-v`, then this command outputs each template's `template.json` file.
 
 ```cmd
 o3de.bat register-show --all-templates -v
@@ -1114,6 +1109,7 @@ Outputs the list of repositories that are registered in the `o3de_manifest.json`
 o3de.bat register-show --repos
 ```
 
+
 ### Optional parameters
 
 - **`-h, --help`**
@@ -1142,7 +1138,7 @@ o3de.bat register-show --repos
 
 - **`-r, --repos`**
 
-  Outputs a list of the repos that are registered in the `o3de_manifest.json` file. Ignores repos.
+  Outputs a list of the repos that are registered in the `o3de_manifest.json` file.
 
 - **`-rs, --restricted`**
 
@@ -1158,7 +1154,7 @@ o3de.bat register-show --repos
 
 - **`-et, --engine-templates`**
 
-  Outputs a list of the templates that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the Gems that are registered in the current engine's `engine.json` file. Ignores repos.
 
 - **`-ers, --engine-restricted`**
 
@@ -1170,19 +1166,19 @@ o3de.bat register-show --repos
 
 - **`-pg, --project-gems`**
 
-  Outputs a list of the gems that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+  Outputs a list of the Gems that are registered in the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options.
 
 - **`-pt, --project-templates`**
 
-  Outputs a list of the templates that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+  Outputs a list of the templates that are registered in the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options.
 
 - **`-prs, --project-restricted`**
 
-  Outputs a list of the restricted directories that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+  Outputs a list of the restricted directories that are registered in the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options.
 
 - **`-pes, --project-external-subdirectories`**
 
-  Outputs a list of the external subdirectories register with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+  Outputs a list of the external subdirectories that are registered in the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options.
 
 - **`-ap, --all-projects`**
 
@@ -1190,7 +1186,7 @@ o3de.bat register-show --repos
 
 - **`-ag, --all-gems`**
 
-  Outputs all of the gems that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos
+  Outputs all of the Gems that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
 - **`-at, --all-templates`**
 
@@ -1274,19 +1270,19 @@ Returns the first URI for a repository that has the specified `repo_name` value.
 o3de.bat get-registered --repo-name REPO_NAME
 ```
 
-Returns the default engine folder that is registered to the `o3de_manifest.json` file.
+Returns the default engine folder that is registered in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat get-registered --default-folder engines
 ```
 
-Returns the default projects folder that is registered to the `o3de_manifest.json` file. 
+Returns the default projects folder that is registered in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat get-registered --default-folder projects
 ```
 
-Returns the default Gems folder that is registered to the `o3de_manifest.json` file. 
+Returns the default Gems folder that is registered in the `o3de_manifest.json` file.
 
 ```cmd
 o3de.bat get-registered --default-folder gems
@@ -1348,7 +1344,7 @@ o3de.bat get-registered --default-folder restricted
 
 ## `enable-gem`
 
-Enables the Gem in your project, so you can use the assets or code the Gem provides. When you enable a Gem, this command adds the Gem's name to your project's `Code/enabled_gems.cmake` file, which adds the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
+Enables the specified Gem in your project, so that you can use the assets or code that the Gem provides. When you enable a Gem, this command adds its name to your project's `Code/enabled_gems.cmake` file, which adds the Gem as a build and load dependency of your project's **Game Launcher**, the Editor, and Asset Processor.
 
 ### Format
 
@@ -1380,15 +1376,15 @@ o3de.bat enable-gem -gp GEM_PATH -pp PROJECT_PATH
 
 - **`-gp GEM_PATH, --gem-path GEM_PATH`**
 
-  The path to the gem.
+  The path to the Gem.
 
 - **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-  The name of the gem.
+  The name of the Gem.
 
 - **`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`**
 
-  The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
+  The CMake file that manages the list of enabled Gems. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
 
 - **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
 
@@ -1399,7 +1395,7 @@ o3de.bat enable-gem -gp GEM_PATH -pp PROJECT_PATH
 
 ## `disable-gem`
 
-Disables the Gem in your project. When you disable a Gem, this command removes the Gem from the project's `Code/enabled_gems.cmake` file, which removes the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
+Disables the specified Gem in your project. When you disable a Gem, this command removes it from the project's `Code/enabled_gems.cmake` file, which removes the Gem as a build and load dependency of your project's Game Launcher, the Editor, and Asset Processor.
 
 ### Format
 
@@ -1439,7 +1435,7 @@ o3de.bat disable-gem -gp GEM_PATH -pp PROJECT_PATH
 
 - **`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`**
 
-  The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
+  The CMake file that manages the list of enabled Gems. When disabling a Gem, this command removes it from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
 
 - **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
 
@@ -1462,7 +1458,7 @@ edit-engine-properties [-h] (-ep ENGINE_PATH | -en ENGINE_NAME)
 
 ### Usage
 
-Updates the `engine_name` field in the `engine.json` file located at the specified engine's folder. 
+Updates the `engine_name` field in the `engine.json` file located in the specified engine's folder.
 
 ```cmd
 o3de.bat edit-engine-properties --engine-path ENGINE_PATH --engine-new-name ENGINE_NEW_NAME
@@ -1525,7 +1521,7 @@ edit-project-properties [-h]
 
 ### Usage
 
-Updates the "project_name" field within the gem.json located at the supplied project path or at the path of the registered project with <project-name>
+Updates the `project_name` field in the `gem.json` file located in the supplied project path or at the path of the registered project.
 
 ```cmd
 o3de.bat edit-project-properties --project-path PROJECT_PATH --project-new-name PROJECT_NEW_NAME
@@ -1548,16 +1544,15 @@ o3de.bat edit-project-properties --project-name PROJECT_NAME --project-new-name 
 
 - **`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`**
 
-  Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited
-list (for example, `-at A B C`).
+  Adds tags to the `user_tags` property. To add multiple tags, use a space-delimited list. For example: `-at A B C`.
 
 - **`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`**
 
-  Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
+  Removes tags from the `user_tags` property. To delete multiple tags, use a space-delimited list. For example: `-dt A B C`.
 
 - **`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`**
 
-  Replace the `user_tags` property with the specified space delimited list of values.
+  Replaces the `user_tags` property with the specified space-delimited list of values.
 
 
 **Project properties:**
@@ -1570,7 +1565,7 @@ The following parameters modify the specified project's properties.
 
 - **`-po PROJECT_ORIGIN, --project-origin PROJECT_ORIGIN`**
 
-  Sets the description or URL for the project origin (such as the project host, repository, or owner).
+  Sets the description or URL for the project origin, such as the project host, repository, or owner.
 
 - **`-pd PROJECT_DISPLAY, --project-display PROJECT_DISPLAY`**
 
@@ -1605,7 +1600,7 @@ edit-gem-properties [-h] (-gp GEM_PATH | -gn GEM_NAME)
 
 ### Usage
 
-Updates the `gem_name` field in the `gem.json` file located at the specified Gem's folder.
+Updates the `gem_name` field in the `gem.json` file located in the specified Gem's folder.
 
 ```cmd
 o3de.bat edit-gem-properties --gem-path GEM_PATH --gem-new-name GEM_NEW_NAME
@@ -1617,9 +1612,8 @@ o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
 
 ### Optional parameters
 
-
 - **`-h, --help`**
-- 
+  
   Shows the help message.
 
 - **`-gp GEM_PATH, --gem-path GEM_PATH`**
@@ -1632,15 +1626,15 @@ o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
 
 - **`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`**
 
-  Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited list (for example, `-at A B C`).
+  Adds tags to the `user_tags` property. To add multiple tags, use a space-delimited list. For example: `-at A B C`.
 
 - **`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`**
 
-  Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
+  Removes tags from the `user_tags` property. To delete multiple tags, use a space-delimited list. For example: `-dt A B C`.
 
 - **`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`**
   
-  Replace the `user_tags` property with the specified space delimited list of values.
+  Replaces the `user_tags` property with the specified space-delimited list of values.
 
 
 **Gem properties:**
@@ -1657,7 +1651,7 @@ o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
 
 - **`-go GEM_ORIGIN, --gem-origin GEM_ORIGIN`**
 
-  Sets the description or URL for the Gem origin (such as the Gem host, repository, or owner).
+  Sets the description or URL for the Gem's origin, such as the Gem host, repository, or owner.
 
 - **`-gt {Code,Tool,Asset}, --gem-type {Code,Tool,Asset}`**
 
@@ -1679,7 +1673,7 @@ o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
 
 ## `sha256`
 
-Creates a hash value for an O3DE object using the SHA-256 secure hash algorithm. This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file. 
+Creates a hash value for an O3DE object using SHA-256 (Secure Hash Algorithm 256). This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file.
 
 ### Format
 
@@ -1701,4 +1695,4 @@ o3de.bat sha256 --file-path FILE_PATH --json-path JSON_PATH
 
 - **`-j JSON_PATH, --json-path JSON_PATH`**
 
-  The path to the O3DE object's JSON file that you want to add the "sha256" element to.
+  The path to the O3DE object's JSON file that you want to add the `sha256` hash value to.

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -124,7 +124,7 @@ o3de.bat get-global-project
 
 Reads the global project from a specified file.
 ```cmd
-o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setreg
+o3de.bat get-global-project -i <USER_PATH>\.o3de\Registry\my-custom.setreg
 ```
 
 ### Optional parameters
@@ -135,7 +135,7 @@ o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setr
 
 - **`-i INPUT_PATH, --input-path INPUT_PATH`**
 
-  A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `C:/Users/USER_PATH/.o3de/Registry/bootstrap.setreg` instead.
+  A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `</USER_PATH>/.o3de/Registry/bootstrap.setreg` instead.
 
 
 <!-------------------------------------------------------------->
@@ -143,6 +143,8 @@ o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setr
 ## `set-global-project`
 
 Sets the specified project as the engine's global project. By default this is set in `C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
+
+If you set a global project, then O3DE tools (such as the Asset Processor and Editor) will use the global project. You can override the global project by specifying a project with the `project-path` parameter when you launch the O3DE tools from the command line.
 
 ### Format 
 
@@ -162,7 +164,7 @@ o3de.bat set-global-project -pp PROJECT_PATH
 Sets the specified project as the global project in the specified path.
 
 ```cmd
-o3de.bat set-global-project -pp PROJECT_PATH -o C:\Users\<USERNAME>\.o3de\Registry\my-custom.setreg
+o3de.bat set-global-project -pp PROJECT_PATH -o <USER_PATH>\.o3de\Registry\my-custom.setreg
 ```
 
 ### Optional parameters
@@ -173,7 +175,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o C:\Users\<USERNAME>\.o3de\Regist
 
 - **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-  The path to the project.
+  The path to the project. The path must contain the project manifest file, `project.json`, unless the `--force` parameter is also used.
 
 - **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
@@ -181,7 +183,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o C:\Users\<USERNAME>\.o3de\Regist
 
 - **`-o OUTPUT_PATH, --output-path OUTPUT_PATH`**
 
-  A path to the output file that you want to write the `project_path` key to. If not supplied, then  this command uses the input file `C:/Users/USER_NAME/.o3de/Registry/bootstrap.setreg` instead.
+  The path and filename where the `project_path` key is written. The file should be located in `<USER_PATH>/.o3de/Registry/` and have the file extension `.setreg`. If this parameter is not used, the key is written to `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
 
 - **`-f, --force`**
 
@@ -266,7 +268,7 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. FFor example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <TemplateName> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: <TemplateName> -> ${Name}, <templatename> -> ${NameLower}, <TEMPLATENAME> -> ${NameUpper}. 
+  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: \<TemplateName\> -> ${Name}, \<templatename\> -> ${NameLower}, \<TEMPLATENAME\> -> ${NameUpper}. 
 
 - **`-f, --force`**
          
@@ -295,7 +297,7 @@ create-from-template [-h] -dp DESTINATION_PATH
 
 ### Usage
 
-Creates a template based on the specified template and saves it in the specified path. 
+Instantiates a template based on the specified template and saves it in the specified path.
 
 ```cmd
 o3de.bat create-from-template --destination-path DESTINATION_PATH --template-path TEMPLATE_PATH
@@ -561,7 +563,7 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  \<GemNam> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMANME\> -> ${NameUpper}.
+  Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  \<GemName> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMNAME\> -> ${NameUpper}.
 
 - **`-kr, --keep-restricted-in-gem`**
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -2,6 +2,1344 @@
 linktitle: CLI Reference
 title: Project Configuration CLI Reference
 weight: 200
+toc: true
 ---
 
-{{< placeholder >}}
+The `o3de` Python script provides a solution to accomplish project configuration tasks using the command line interface (CLI). It aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so users can access them from a single point. The main driver script is located in the engine folder at `[/scripts/o3de.py](http://o3de.py)`. 
+
+The `o3de` Python script is responsible for multiple tasks:
+
+- Creating projects
+- Creating Gems
+- Creating templates
+- [Enabling and disabling Gems for your project](add-remove-gems/)
+- [Registering the engine](/docs/welcome-guide/setup/setup-from-github#register-the-engine)
+- Registering projects and Gems
+
+
+## Prerequisites
+
+To use the `o3de` Python script, you must have Python runtime set up. Python runtime was downloaded when you set up the engine. For more information, refer to instructions on how to get Python runtime in the [Register the engine](/docs/welcome-guide/setup/setup-from-github/#register-the-engine) section of the Setup From GitHub page.
+
+
+## Quick Start
+
+{{< tabs name="Python runtime setup" >}}
+{{% tab name="Windows" %}}
+
+For Windows, open a command prompt. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
+
+- Launch python and run the `o3de.py` script.
+
+    ```cmd
+    <engine>/python/python.cmd <engine>/scripts/o3de.py <command>
+    ```
+
+- Run the `o3de.bat` batch file directly.
+
+    ```cmd
+    <engine>/scripts/o3de.bat <command>
+    ```
+
+**Example**
+
+For example, to register the engine, you can enter the following command. 
+
+```cmd
+<engine>/scripts/o3de.bat register --this-engine
+```
+
+{{% /tab %}}
+{{% tab name="Linux" %}}
+
+For Linux, open a terminal. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
+
+- Launch python and run the `o3de.py` script.
+
+    ```bash
+    <engine>/python/python.sh <engine/scripts/o3de.py
+    ```
+
+- Run the `o3de.sh` shell script file directly.
+
+    ```bash
+    <engine>/scripts/o3de.sh
+    ```
+
+**Example**
+
+For example, to register the engine, you can enter the following command. 
+
+```bash
+<engine>/scripts/o3de.sh register --this-engine
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+
+## Commands
+
+
+| Command | Description | 
+| - | - |
+| [`get-global-project`](#get-global-project) | Gets the global project that is registered to the engine. |
+| [`set-global-project`](#set-global-project) | Sets the specified project as the engine's global project. |
+| [`create-template`](#create-template) | Creates a template out of the specified source path. |
+| [`create-from-template`](#create-from-template) | Creates a template from an existing template.  |
+| [`create-project`](#create-project) | Creates a new project. |
+| [`create-gem`](#create-gem) | Creates a new Gem. |
+| [`register`](#register) | Register an O3DE object. |
+| [`register-show`](#register-show) | Shows the registered O3DE objects. |
+| [`get-registered`](#get-registered) | Shows the registered O3DE object's path that is mapped to the specified name. |
+| [`enable-gem`](#enable-gem) | Enables the Gem in your project, so you can use the assets or code the Gem provides. |
+| [`disable-gem`](#disable-gem) | Disables the Gem in your project. |
+| [`sha256`](#sha256) | Creates a secure hash algorithm (SHA-256). |
+<!-- | [`edit-project-properties`](#edit-project-properties) |  | -->
+
+
+
+## `get-global-project`
+
+Gets the global project that is registered to the engine in the specified `.setreg` file at `<user>/.o3de/Registry/`.
+
+
+```cmd
+usage: o3de.py get-global-project [-h] [-i INPUT_PATH]
+```
+
+### Usage
+
+```cmd
+o3de.bat get-global-project -i SETREG_PATH
+```
+
+### Optional Parameters
+
+`-h, --help`
+show this help message and exit
+
+`-i INPUT_PATH, --input-path INPUT_PATH`
+
+Optional path to file to read `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then
+`C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg` is used instead
+
+
+
+## `set-global-project`
+
+Sets the specified project as the engine's global project in the specified `.setreg` file at `<user>/.o3de/Registry/`
+
+```cmd
+usage: o3de.oy set-global-project [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+                                  [-o OUTPUT_PATH] [-f]
+```
+
+### Usage
+
+```cmd
+o3de.bat set-global-project -pp PROJECT_PATH -o SETREG_PATH
+```
+
+### Optional Parameters
+
+`-h, --help`
+
+show this help message and exit
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
+The path to the project.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+The name of the project.
+
+`-o OUTPUT_PATH, --output-path OUTPUT_PATH`
+
+Optional path to output file to write project_path key to. If not supplied, then `C:\Users\USER_NAME\.o3de\Registry\bootstrap.setreg` is used instead
+
+`-f, --force`
+
+Force the setting of the project path in the supplied setreg file
+
+
+## `create-template`
+
+Creates a template out of the specified source path.
+
+``` cmd
+usage: o3de.py create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
+                    [-srp SOURCE_RESTRICTED_PATH | -srn SOURCE_RESTRICTED_NAME]
+                    [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
+                    [-sn SOURCE_NAME]
+                    [-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                    [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PAT
+```
+
+### Usage
+
+Creates a template from the source folder and saves the template into the specified path.
+
+```cmd
+o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
+```
+
+### Optional Parameters
+  
+`-h, --help`
+
+show this help message and exit
+
+`-sp SOURCE_PATH, --source-path SOURCE_PATH`
+
+The path to the source that you want to make into a template
+
+`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+
+The path to the template to create, can be absolute or relative to default templates path
+
+`-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`
+
+The path to the source restricted folder.
+
+`-srn SOURCE_RESTRICTED_NAME, --source-restricted-name SOURCE_RESTRICTED_NAME`
+
+The name of the source restricted folder. If supplied this will resolve the --source-restricted-path.
+
+`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+
+The path to the templates restricted folder.
+
+`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+
+The name of the templates restricted folder. If supplied this will resolve the --template-restricted- path.
+
+`-sn SOURCE_NAME, --source-name SOURCE_NAME`
+
+Substitutes any file and path entries which match the source name within the source-path directory with the ${Name} and ${SanitizedCppName}.Ex: Path substitution --source-name Foo<source-path>/Code/Include/FooBus.h -> <source-path>/Code/Include/${Name}Bus.hEx: File content substitution.class FooRequests -> class ${SanitizedCppName}Requests
+
+`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --source-restricted- path/<platform> to where the restricted source is. EX. --source-restricted-path C:/restricted --source- restricted-platform-relative-path some/folder => C:/restricted/<platform>/some/folder/<source_name>
+
+`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --template-restricted- path/<platform> to where the restricted template source is. --template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder => C:/restricted/<platform>/some/folder/<template_name>
+
+`-kr, --keep-restricted-in-template`
+
+Should the template keep the restricted platforms in the template, or create the restricted files in the restricted folder, default is False so it will create a restricted folder by default
+
+`-kl, --keep-license-text`
+
+Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+
+`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+
+String that specifies A->B replacement pairs. Ex. --replace CoolThing ${the_thing} 1723905 ${id} Note: <TemplateName> is the last component of template_path Note: <TemplateName> is automatically ${Name} Note: <templatename> is automatically ${NameLower} Note: <TEMPLATENAME> is automatically ${NameUpper}
+
+`-f, --force`           
+Copies to new template directory even if it exist.
+
+
+## `create-from-template`
+
+Creates a template with a `template.json` file. 
+
+```cmd
+usage: o3de.py create-from-template [-h] -dp DESTINATION_PATH
+                                    (-tp TEMPLATE_PATH | -tn TEMPLATE_NAME)
+                                    [-dn DESTINATION_NAME]
+                                    [-drp DESTINATION_RESTRICTED_PATH | -drn DESTINATION_RESTRICTED_NAME]
+                                    [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
+                                    [-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                                    [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                                    [-kr] [-kl] [-r [REPLACE [REPLACE ...]]]
+                                    [-f]
+```
+
+### Usage
+
+Creates a generic template and saves it in the specified path. 
+
+```cmd
+o3de.bat create-from-template --destination-path DESTINATION_PATH
+```
+
+Creates a template based on the specified template and saves it in the specified path. 
+
+```cmd
+o3de.bat create-from-template --destination-path DESTINATION_PATH --template-path TEMPLATE_PATH
+```
+
+### Optional Parameters
+
+`-h, --help`
+
+show this help message and exit
+
+`-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`
+
+The path to where you want the template instantiated, can be absolute or dev root relative. Ex. C:/o3de/TestTest = \<destination_name\>
+
+`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+
+The path to the template you want to instantiate, can be absolute or dev root/Templates relative. Ex. C:/o3de/Template/TestTemplateTestTemplate = \<template_name\>
+
+`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+
+The name to the registered template you want to
+instantiate. If supplied this will resolve the
+--template-path.
+
+`-dn DESTINATION_NAME, --destination-name DESTINATION_NAME`
+
+The name to use when substituting the ${Name} placeholder in instantiated template, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of destination path. Ex. New_Gem
+
+`-drp DESTINATION_RESTRICTED_PATH, --destination-restricted-path DESTINATION_RESTRICTED_PATH`
+
+The destination restricted path is where the restricted files will be written to.
+
+`-drn DESTINATION_RESTRICTED_NAME, --destination-restricted-name DESTINATION_RESTRICTED_NAME`
+
+The name the registered restricted path where the restricted files will be written to. If supplied this will resolve the --destination-restricted-path.
+
+`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+
+The template restricted path to read from if any
+
+`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+
+The name of the registered restricted path to read from if any. If supplied this will resolve the --template-restricted-path.
+
+`-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --destination-restricted -path//<platform/> to where the restricted destination is. --destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder =/> C:/instance//<platform/>/some/folder//<destination_name/>
+
+`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --template-restricted- path//<platform/> to where the restricted template is. --template-restricted-path C:/restricted --template-
+restricted-platform-relaive-path some/folder =/> C:/restricted//<platform/>/some/folder//<template_name/>
+
+`-kr, --keep-restricted-in-instance`
+
+Should the instance keep the restricted platforms in the instance, or create the restricted files in the restricted folder, default is False.
+
+`-kl, --keep-license-text`
+
+Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as
+all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}. 
+
+`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+
+String that specifies A-/>B replacement pairs. Ex. --replace CoolThing ${the_thing} ${id} 1723905 Note: /<DestinationName/> is the last component of destination_path Note: ${Name} is automatically /<DestinationName/> Note: ${NameLower} is automatically /<destinationname/> Note: ${NameUpper} is automatically
+/<DESTINATIONNAME/> 
+
+`-f, --force`
+
+Copies over instantiated template directory even if it exist.
+
+
+## `create-project`
+
+Create a new project at the specified path.
+
+``` cmd
+usage: o3de.py create-project [-h] -pp PROJECT_PATH [-pn PROJECT_NAME]
+                    [-tp TEMPLATE_PATH | -tn TEMPLATE_NAME]
+                    [-prp PROJECT_RESTRICTED_PATH | -prn PROJECT_RESTRICTED_NAME]
+                    [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
+                    [-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                    [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                    [-kr] [-kl] [-r [REPLACE [REPLACE ...]]]
+                    [--system-component-class-id SYSTEM_COMPONENT_CLASS_ID]
+                    [--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID]
+                    [--module-id MODULE_ID] [-f]
+```
+
+### Usage
+
+Creates a new project at the specified path using the "DefaultProject" template. 
+
+```cmd
+o3de.bat create-project -pp PROJECT_PATH
+```
+
+Creates a new project at the specified path using the specified project template. The template must have a valid `project.json` file.
+
+```cmd
+o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PATH
+```
+
+### Optional Parameters
+
+  
+`-h, --help`
+
+show this help message and exit
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
+The location of the project you wish to create from the template, can be an absolute path or dev root relative. Ex. C:/o3de/TestProject TestProject = \<project_name\> if --project-name not provided
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+The name of the project you wish to use, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of project path. Ex. New_Project-123
+
+`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+
+the path to the template you want to instance, can be absolute or relative to default templates path
+
+`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+
+The name the registered template you want to instance, defaults to DefaultProject. If supplied this will resolve the --template-path.
+
+`-prp PROJECT_RESTRICTED_PATH, --project-restricted-path PROJECT_RESTRICTED_PATH`
+
+path to the projects restricted folder, can be absolute or relative to the restricted="projects"
+
+`-prn PROJECT_RESTRICTED_NAME, --project-restricted-name PROJECT_RESTRICTED_NAME`
+
+The name of the registered projects restricted path. If supplied this will resolve the --project- restricted-path.
+
+`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+
+The templates restricted path can be absolute or relative to restricted="templates"
+
+`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+
+The name of the registered templates restricted path. If supplied this will resolve the --template- restricted-path.
+
+`-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH, --project-restricted-platform-relative-path PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --project-restricted- path/\<platform\> to where the restricted project is. --project-restricted-path C:/restricted --project- restricted-platform-relative-path some/folder =\> C:/restricted/\<platform\>/some/folder/\<project_name\>
+
+`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --template-restricted- path/\<platform\> to where the restricted template is. --template-restricted-path C:/restricted --template- restricted-platform-relative-path some/folder =\> C:/restricted/\<platform\>/some/folder/\<template_name\>
+
+`-kr, --keep-restricted-in-project`
+
+Should the new project keep the restricted platforms in the project, orcreate the restricted files in the restricted folder, default is False
+
+`-kl, --keep-license-text`
+
+Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+
+`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+
+String that specifies ADDITIONAL A-\>B replacement pairs. ${Name} and all other standard project replacements will be automatically inferred from the project name. These replacements will superseded all inferred replacements. Ex. --replace ${DATE} 1/1/2020 ${id} 1723905 Note: \<ProjectName\> is the last component of project_path Note: ${Name} is automatically \<ProjectName\> Note: ${NameLower} is automatically \<projectname\> Note: ${NameUpper} is automatically \<PROJECTNAME\>
+
+`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
+
+The uuid you want to associate with the system class
+component, default is a random uuid Ex.
+{b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
+
+The uuid you want to associate with the editor system
+class component, default is a random uuid Ex.
+{b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`--module-id MODULE_ID`
+
+The uuid you want to associate with the module,
+default is a random uuid Ex.
+{b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`-f, --force`
+
+Copies over instantiated template directory even if it
+exist.
+
+
+## `create-gem`
+
+Create a new Gem at the specified path.
+
+```cmd
+create-gem [-h] -gp GEM_PATH [-gn GEM_NAME]
+                    [-tp TEMPLATE_PATH | -tn TEMPLATE_NAME]
+                    [-grp GEM_RESTRICTED_PATH | -grn GEM_RESTRICTED_NAME]
+                    [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
+                    [-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                    [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                    [-r [REPLACE [REPLACE ...]]] [-kr] [-kl]
+                    [--system-component-class-id SYSTEM_COMPONENT_CLASS_ID]
+                    [--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID]
+                    [--module-id MODULE_ID] [-f]
+```
+
+### Usage
+
+Create a new Gem at the specified path using the "DefaultGem" template.
+
+```cmd
+o3de.bat create-gem -gp GEM_PATH
+```
+
+Create a new Gem at the specified path using the specified Gem template. The template must have a valid gem.json file.
+
+```cmd
+o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
+```
+
+### Optional parameters
+
+`-h, --help`
+
+show this help message and exit
+
+`-gp GEM_PATH, --gem-path GEM_PATH`
+
+The gem path, can be absolute or relative to default gems path
+
+`-gn GEM_NAME, --gem-name GEM_NAME`
+
+The name to use when substituting the ${Name} placeholder for the gem, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of gem path. Ex. New_Gem
+
+`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+
+The template path you want to instance, can be absolute or relative to default templates path
+
+`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+
+The name of the registered template you want to instance, defaults to DefaultGem. If supplied this will resolve the --template-path.
+
+`-grp GEM_RESTRICTED_PATH, --gem-restricted-path GEM_RESTRICTED_PATH`
+
+The path to the gem restricted to write to folder if any, can beabsolute or dev root relative, default is dev root/restricted.
+
+`-grn GEM_RESTRICTED_NAME, --gem-restricted-name GEM_RESTRICTED_NAME`
+
+The path to the gem restricted to write to folder if any, can beabsolute or dev root relative, default is dev root/restricted. If supplied this will resolve the --gem-restricted-path.
+
+`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+
+The templates restricted path, can be absolute or relative to the restricted="templates"
+
+`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+
+The name of the registered templates restricted path. If supplied this will resolve the --template- restricted-path.
+
+`-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH, --gem-restricted-platform-relative-path GEM_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --gem-restricted- path/ \<platform \> to where the restricted template is. --gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder = \> C:/restricted/ \<platform \>/some/folder/ \<gem_name \>
+
+`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+
+Any path to append to the --template-restricted- path/ \<platform \> to where the restricted template is. --template-restricted-path C:/restricted --template- restricted-platform-relative-path some/folder = \> C:/restricted/ \<platform \>/some/folder/ \<template_name \>
+
+`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+
+String that specifies ADDITIONAL A- \>B replacement pairs. ${Name} and all other standard gem replacements will be automatically inferred from the gem name. These replacements will superseded all inferred replacement pairs. Ex. --replace ${DATE} 1/1/2020 ${id} 1723905 Note:  \<GemName \> is the last component of gem_path Note: ${Name} is automatically  \<GemName \> Note: ${NameLower} is automatically  \<gemname \> Note: ${NameUpper} is automatically  \<GEMANME \>
+
+`-kr, --keep-restricted-in-gem`
+
+Should the new gem keep the restricted platforms in the project, orcreate the restricted files in the restricted folder, default is False
+
+`-kl, --keep-license-text`
+
+Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+
+`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
+
+The uuid you want to associate with the system class component, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
+
+The uuid you want to associate with the editor system class component, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`--module-id MODULE_ID`
+
+The uuid you want to associate with the gem module, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+
+`-f, --force`
+
+Copies over instantiated template directory even if it exist.
+
+
+## `register`
+
+Register O3DE objects to the `o3de_manifest.json` file.
+
+
+```cmd
+usage: o3de.py register [-h]
+                        (--this-engine | -ep ENGINE_PATH | -pp PROJECT_PATH | -gp GEM_PATH | -es EXTERNAL_SUBDIRECTORY | -tp TEMPLATE_PATH | -rp RESTRICTED_PATH | -ru REPO_URI | -aep ALL_ENGINES_PATH | -app ALL_PROJECTS_PATH | -agp ALL_GEMS_PATH | -atp ALL_TEMPLATES_PATH | -arp ALL_RESTRICTED_PATH | -aru ALL_REPO_URI | -def DEFAULT_ENGINES_FOLDER | -dpf DEFAULT_PROJECTS_FOLDER | -dgf DEFAULT_GEMS_FOLDER | -dtf DEFAULT_TEMPLATES_FOLDER | -drf DEFAULT_RESTRICTED_FOLDER | -dtpf DEFAULT_THIRD_PARTY_FOLDER | -u)
+                        [-ohf OVERRIDE_HOME_FOLDER] [-r] [-f]
+                        [-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH | -espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH]
+```
+
+
+### Usage
+
+#### Registering engines
+
+Registers this engine to the `o3de_manifest.json` file.  This command maps the engine's name to its path in JSON. 
+
+```cmd
+o3de.bat register --this-engine
+```
+
+Registers the specified engine to the `o3de_manifest.json` file.  This command maps the engine's name to its path in JSON.  
+
+```cmd
+o3de.bat register --engine-path ENGINE_PATH
+```
+
+Registers all of the engines in the specified path to the `o3de_manifest.json` file. This command recursively scans the specified path and registers all of the paths that have a valid `engine.json` file. It maps each engine's name to its path in JSON.  
+
+```cmd
+o3de.bat register --all-engines-path ALL_ENGINES_PATH
+```
+
+#### Registering projects
+
+Registers the specified project to the engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
+
+```cmd
+o3de.bat register -pp PROJECT_PATH
+```
+
+Registers the specified project to the specified engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
+
+```cmd
+o3de.bat register -pp PROJECT_PATH --engine-path ENGINE_PATH
+```
+
+Registers all of the projects in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `project.json` file. For each project, this command does two things: it adds the each project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file. 
+
+```cmd
+o3de.bat register --all-projects-path ALL_PROJECTS_PATH
+```
+
+#### Registering Gems
+
+Registers the Gem to the `o3de_manifest.json` file. Before registering the Gem, this command verifies that the Gem has a valid `gem.json` file. Then, it adds the Gem's path to the `external_subdirectories` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --gem-path GEM_PATH
+```
+
+Registers the Gem to the project's `project.json` file. Before registering the Gem, this command verifies that the Gem has a valid `gem.json` file. Then, it adds the Gem's path to the `external_subdirectories` list in the `project.json` file. This adds the Gem to the project's build solution, so the project can recognize the Gem.
+
+```cmd
+o3de.bat register -gp GEM_PATH -espp PROJECT_PATH
+```
+
+Registers the Gem to the engine's `engine.json` file. Before registering the Gem, this command verifies that the Gem has a valid `gem.json` file. Then, it adds the Gem's path to the `external_subdirectories` list in the `engine.json` file. This adds the Gem to the engine's build solution, so the engine can recognize the Gem.
+
+```cmd
+o3de.bat register -gp GEM_PATH -espp ENGINE_PATH
+```
+
+Registers all of the Gems in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `gem.json` file. For each Gem, this command adds the Gem to the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --all-gems-path ALL_GEMS_PATH
+```
+
+#### Registering external subdirectories
+
+Registers the specified subdirectory path to the `external_subdirectories` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY
+```
+
+Registers the specified subdirectory path into `external_subdirectories` in the specified engine's `engine.json` file.
+
+```cmd
+o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY --external-subdirectory-engine-path ENGINE_PATH
+```
+
+Registers the specified subdirectory path into `external_subdirectories` in the specified project's `project.json` file.
+
+```cmd
+o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY --external-subdirectory-project-path PROJECT_PATH
+```
+
+#### Registering templates
+
+Registers the specified template to the `templates` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --template-path <template-path
+```
+
+Registers the specified template to the `templates` list in the specified engine's `engine.json` file.
+
+```cmd
+o3de.bat register --template-path TEMPLATE_PATH --engine-path ENGINE_PATH
+```
+
+Registers all of the templates in the specified path. This command recursively scans the specified path and registers all of the paths that have a valid `template.json` file. For each template, this command adds the template to the `templates` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --all-templates-path ALL_TEMPLATES_PATH
+```
+
+#### Registering restricted paths
+
+Registers the specified restricted directory to the `restricted` list in the `o3de_manifest.json` file. 
+
+```cmd
+o3de.bat register --restricted-path RESTRICTED_PATH
+```
+
+Registers all of the restricted paths in the specified path to the `restricted` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --all-restricted-path ALL_RESTRICTED_PATH
+```
+#### Registering repositories
+
+Registers the specified repository URI (uniform resource identifier) to the `repos` list in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --repo-uri REPO_URI
+```
+
+Registers all of the repositories in the specified URI. This command recursively scans the specified path and registers all of the repositoriesthat have a valid `repo.json` file. For each repository, this command adds the Gem to the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --all-repo-uri ALL_REPO_URI
+```
+
+#### Registering default folders
+
+Registers the specified folder as the default engines directory in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register --default-engines-folder ENGINES_FOLDER_PATH
+```
+
+Registers the specified folder as the default projects directory in the `o3de_manifest.json` file. When creating a project by using the `create-project` command, if you provide a relative path, the project saves in the default project folder.
+
+```cmd
+o3de.bat register --default-projects-folder PROJECTS_FOLDER_PATH
+```
+
+Registers the specified folder as the default Gems directory in the `o3de_manifest.json` file. When creating a Gem by using the `create-gem` command, if you provide a relative path, the Gem saves in the default Gems folder.
+
+```cmd
+o3de.bat register --default-gems-folder GEMS_FOLDER_PATH
+```
+
+Register the specified folder as the default templates directory in the `o3de_manifest.json` file. When creating a template by using the `create-template` command, if you provide a relative path, the template saves in the default template folder.
+
+```cmd
+o3de.bat register --default-templates-folder TEMPLATES_FOLDER_PATH
+```
+
+Register the specified folder as the default restricted directory in the `o3de_manifest.json` file. The commands - `create-from-template`, `create-project`, and `create-gem` - use the default restricted directory when instantiating a template. 
+
+```cmd
+o3de.bat register --default-restricted-folder RESTRICTED_FOLDER_PATH
+```
+
+Register the specified folder as the default 3rd Party directory in the `o3de_manifest.json` file. The Project Manager uses the default 3rd Party directory to set the `LY_3RDPARTY_PATH` option when configuring the CMake build solution.
+
+```cmd
+o3de.bat register --default-third-party folder THIRD_PARTY_FOLDER_PATH
+```
+
+#### Updating the `o3de_manifest.json` file
+
+Updates the `o3de_manifest.json` file. This command validates all of the registered objects, and then removes invalid objects.
+
+```cmd
+o3de.bat register --update
+```
+
+
+### Optional parameters
+`-h, --help`  
+show this help message and exit
+
+`--this-engine`  
+Registers the engine this script is running from.
+
+`-ep ENGINE_PATH, --engine-path ENGINE_PATH`  
+
+Engine path to register/remove.
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`  
+
+Project path to register/remove.
+
+`-gp GEM_PATH, --gem-path GEM_PATH`  
+
+Gem path to register/remove.
+
+`-es EXTERNAL_SUBDIRECTORY, --external-subdirectory EXTERNAL_SUBDIRECTORY`  
+
+External subdirectory path to register/remove.
+
+`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`  
+
+Template path to register/remove.
+
+`-rp RESTRICTED_PATH, --restricted-path RESTRICTED_PATH`  
+
+A restricted folder to register/remove.
+
+`-ru REPO_URI, --repo-uri REPO_URI`  
+
+A repo uri to register/remove.
+
+`-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`  
+
+All engines under this folder to register/remove.
+
+`-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`  
+
+All projects under this folder to register/remove.
+
+`-agp ALL_GEMS_PATH, --all-gems-path ALL_GEMS_PATH`  
+
+All gems under this folder to register/remove.
+
+`-atp ALL_TEMPLATES_PATH, --all-templates-path ALL_TEMPLATES_PATH`  
+
+All templates under this folder to register/remove.
+
+`-arp ALL_RESTRICTED_PATH, --all-restricted-path ALL_RESTRICTED_PATH`  
+
+All templates under this folder to register/remove.
+
+`-aru ALL_REPO_URI, --all-repo-uri ALL_REPO_URI`  
+
+All repos under this folder to register/remove.
+
+`-def DEFAULT_ENGINES_FOLDER, --default-engines-folder DEFAULT_ENGINES_FOLDER`  
+
+The default engines folder to register/remove.
+
+`-dpf DEFAULT_PROJECTS_FOLDER, --default-projects-folder DEFAULT_PROJECTS_FOLDER`  
+
+The default projects folder to register/remove.
+
+`-dgf DEFAULT_GEMS_FOLDER, --default-gems-folder DEFAULT_GEMS_FOLDER`  
+
+The default gems folder to register/remove.
+
+`-dtf DEFAULT_TEMPLATES_FOLDER, --default-templates-folder DEFAULT_TEMPLATES_FOLDER`  
+
+The default templates folder to register/remove.
+
+`-drf DEFAULT_RESTRICTED_FOLDER, --default-restricted-folder DEFAULT_RESTRICTED_FOLDER`  
+
+The default restricted folder to register/remove.
+
+`-dtpf DEFAULT_THIRD_PARTY_FOLDER, --default-third-party-folder DEFAULT_THIRD_PARTY_FOLDER`  
+
+The default 3rd Party folder to register/remove.
+
+`-u, --update`  
+
+Refresh the repo cache.
+
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`  
+
+By default the home folder is `the user folder, override it to this folder.
+  
+`-r, --remove`  
+
+Remove entry.
+
+`-f, --force`  
+
+For the update of the registration field being modified.
+
+ 
+**external-subdirectory:**  
+path arguments to use with the --external-subdirectory option
+
+`-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH, --external-subdirectory-engine-path EXTERNAL_SUBDIRECTORY_ENGINE_PATH`  
+
+If supplied, registers the external subdirectory with the engine.json at the engine-path location
+
+`-espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH, --external-subdirectory-project-path EXTERNAL_SUBDIRECTORY_PROJECT_PATH`
+
+If supplied, registers the external subdirectory with the project.json at the project-path location
+
+
+## `register-show`
+Shows the registered O3DE objects in the `o3de_manifest.json` file. 
+
+
+```cmd
+usage: o3de.py register-show [-h]
+                             [-te | -e | -p | -g | -t | -r | -rs | -ep | -eg | -et | -ers | -ees | -pg | -pt | -prs | -pes | -ap | -ag | -at | -ares | -aes]
+                             [-v] [-pp PROJECT_PATH | -pn PROJECT_NAME]
+                             [-ohf OVERRIDE_HOME_FOLDER]
+```
+
+### Usage
+
+Outputs the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register-show
+```
+
+Outputs the current engine that is registered in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register-show --this-engine
+```
+
+Iterates over each engine that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --engines
+```
+
+Iterates over each project that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --projects
+```
+
+Iterates over each engine that is registered in the current engine's `engine.json` file. Then, for each iteration, outputs the `engine.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --engine-projects
+```
+
+Iterates over each project that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the `project.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --all-projects
+```
+
+Iterators over each Gem that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --gems
+```
+
+Iterates over each Gem that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --engine-gems
+```
+
+Iterates over each gem in the project.json at the specified path. Then, for each iteration, outputs the `gem.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --project-gems --project-path PROJECT_PATH
+```
+
+Iterates over each gem that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the Gem's path to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --all-gems
+```
+
+Outputs the templates that is registered in the `o3de_manifest.json` file. Then, for each iteration, outputs the `template.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --templates
+```
+
+Iterates over each template that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `template.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --engine-templates
+```
+
+Iterates over each template in the `project.json` file that is located at the specified project path. Then, for each iteration, outputs the `template.json` to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --project-templates --project-path C:/Projects/TestProject
+```
+
+Iterates over each template that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json`. Then, for each iteration, outputs the `template.json` file path to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --all-templates
+```
+
+Outputs the restricted directories that are registered in the `o3de_manifest.json` file. For each restricted directory, this command outputs the `restricted.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --restricted
+```
+
+Iterates over each restricted directory that is registered in the current engine's `engine.json`. Then, for each iteration, outputs the `restricted.json` file to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --engine-restricted
+```
+
+Iterates over each restricted directory in the `project.json` file that is located at the specified project path. Then, for each iteration outputs the restricted directory's path to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --project-templates --project-path C:/Projects/TestProject
+```
+
+Iterates over each restricted directory that is registered in both the `o3de_manifest.json` file and the current engine's `engine.json` file. Then, for each iteration, outputs the restricted directory's path to stdout if verbose > 0 (`-v`).
+
+```cmd
+o3de.bat register-show --all-restricted
+```
+
+Outputs the `external_subdirectories` array in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat register-show --external-subdirectories
+```
+
+Outputs the `external_subdirectories` array in the current engine's `engine.json` file. 
+
+```cmd
+o3de.bat register-show --engine-external-subdirectories
+```
+
+Outputs the `external_subdirectories` array in the `project.json` that is located at the specified project path.
+
+```cmd
+o3de.bat register-show --project-external-subdirectories --project-path PROJECT_PATH
+```
+
+Outputs the `external_subdirectories` from both the `o3de_manifest.json` file and the current engine's `engine.json` file.
+
+```cmd
+o3de.bat register-show --all-external-subdirectories --project-path PROJECT_PATH
+```
+
+Iterates over the repositories that are registered in the `o3de_manifest.json` file. Then, for each repository, outputs the `repos` array to stdout.
+
+```cmd
+o3de.bat register-show --repos
+```
+
+### Optional parameters
+
+`-h, --help`
+Shows the help message.
+
+`-te, --this-engine`
+Outputs the current engine's path.
+
+`-e, --engines`
+Outputs the engines registered in the `o3de_manifest.json` file.
+
+`-p, --projects`
+Output the projects registered in the `o3de_manifest.json` file.
+
+`-g, --gems`
+Output the gems registered in the `o3de_manifest.json` file.
+
+`-t, --templates`
+Output the templates registered in the `o3de_manifest.json` file.
+
+`-r, --repos`
+Output the repos registered in the `o3de_manifest.json` file. Ignores repos.
+
+`-rs, --restricted`
+Output the restricted directories registered in the `o3de_manifest.json` file.
+
+`-ep, --engine-projects`
+Output the projects registered in the current engine engine.json. Ignores repos.
+
+`-eg, --engine-gems`
+Output the gems registered in the current engine engine.json. Ignores repos
+
+`-et, --engine-templates`
+Output the templates registered in the current engine engine.json. Ignores repos.
+
+`-ers, --engine-restricted`
+Output the restricted directories registered in the current engine engine.json.
+
+`-ees, --engine-external-subdirectories`
+Output the external subdirectories registered in the current engine engine.json.
+
+`-pg, --project-gems`
+Returns the gems registered with the project.json.
+
+`-pt, --project-templates`
+Returns the templates registered with the project.json.
+
+`-prs, --project-restricted`
+Returns the restricted directories registered with the project.json.
+
+`-pes, --project-external-subdirectories`
+Returns the external subdirectories register with the project.json.
+
+`-ap, --all-projects`
+Output all projects registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos.
+
+`-ag, --all-gems`
+Output all gems registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos
+
+`-at, --all-templates`
+Output all templates registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos.
+
+`-ares, --all-restricted`
+Output all restricted directory registered in the `o3de_manifest.json` file.and the current engine.json.
+
+`-aes, --all-external-subdirectories`
+Output all external subdirectories registered in the `o3de_manifest.json` file.and the current engine.json.
+
+`-v, --verbose`
+How verbose do you want the output to be.
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+The path to a project.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+The name of a project.
+
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+ By default the home folder is the user folder, override it to this folder.
+
+
+
+## `get-registered`
+ShowS the registered O3DE object's path that is mapped to the specified name.
+
+
+```cmd
+usage: o3de.py get-registered [-h]
+                    (-en ENGINE_NAME | -pn PROJECT_NAME | -gn GEM_NAME | -tn TEMPLATE_NAME | -df {engines,projects,gems,templates,restricted} | -rn REPO_NAME | -rsn RESTRICTED_NAME)
+                    [-ohf OVERRIDE_HOME_FOLDER]
+```
+
+### Usage
+
+Returns the first path of an engine that has the specified "engine_name" value. 
+
+```cmd
+o3de.bat get-registered --engine-name ENGINE_NAME
+```
+
+Returns the first path of a project that has the specified "project_name" value. 
+
+```cmd
+o3de.bat get-registered --project-name PROJECT_NAME
+```
+
+Returns the first path of a Gem that has the specified "gem_name" value. 
+
+```cmd
+o3de.bat get-registered --gem-name GEM_NAME
+```
+
+Returns the first path of a template that has the specified "template_name" value.
+
+```cmd
+o3de.bat get-registered --template-name TEMPLATE_NAME
+```
+
+Returns the first path of a restricted directory that has the specified "restricted_name" value.
+
+```cmd
+o3de.bat get-registered --restricted-name RESTRICTED_NAME
+```
+
+Returns the first URI for a repository that has the specified "repo_name" value.
+
+```cmd
+o3de.bat get-registered --repo-name REPO_NAME
+```
+
+Returns the default engine folder that is registered to the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat get-registered --default-folder engines
+```
+
+Returns the default projects folder that is registered to the `o3de_manifest.json` file. 
+
+```cmd
+o3de.bat get-registered --default-folder projects
+```
+
+Returns the default Gems folder that is registered to the `o3de_manifest.json` file. 
+
+```cmd
+o3de.bat get-registered --default-folder gems
+```
+
+Returns the default templates folder that is registered in the `o3de_manifest.json` file. 
+
+```cmd
+o3de.bat get-registered --default-folder templates
+```
+
+Returns the default restricted folder that is registered in the `o3de_manifest.json` file.
+
+```cmd
+o3de.bat get-registered --default-folder restricted
+```
+
+
+### Optional Parameters
+
+`-h, --help`
+
+show this help message and exit
+
+`-en ENGINE_NAME, --engine-name ENGINE_NAME`
+
+Engine name.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+Project name.
+
+`-gn GEM_NAME, --gem-name GEM_NAME`
+
+Gem name.
+
+`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+
+Template name.
+
+`-df {engines,projects,gems,templates,restricted}, --default-folder {engines,projects,gems,templates,restricted}`
+
+The default folders for o3de.
+
+`-rn REPO_NAME, --repo-name REPO_NAME`
+
+Repo name.
+
+`-rsn RESTRICTED_NAME, --restricted-name RESTRICTED_NAME`
+
+Restricted name.
+
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+
+By default the home folder is the user folder, override it to this folder.
+
+
+## `enable-gem`
+
+Enables the Gem in your project, so you can use the assets or code the Gem provides. When you enable a Gem, this command adds the Gem's name to your project's `Code/enabled_gems.cmake` file, which adds the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
+
+```cmd
+usage: o3de.py enable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+                          (-gp GEM_PATH | -gn GEM_NAME)
+                          [-egf ENABLED_GEM_FILE] [-ohf OVERRIDE_HOME_FOLDER]
+```
+
+### Usage
+
+```cmd
+o3de.bat enable-gem -gp GEM_PATH -pp PROJECT_PATH
+```
+
+### Optional Parameters
+
+`-h, --help`
+
+show this help message and exit
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
+The path to the project.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+The name of the project.
+
+`-gp GEM_PATH, --gem-path GEM_PATH`
+
+The path to the gem.
+
+`-gn GEM_NAME, --gem-name GEM_NAME`
+
+The name of the gem.
+
+`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`
+
+The cmake enabled_gem file in which the gem names are
+specified.If not specified it will assume
+enabled_gems.cmake
+
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+
+By default the home folder is the user folder,
+override it to this folder.
+
+
+## `disable-gem`
+
+Disables the Gem in your project. When you disable a Gem, this command removes the Gem from the project's `Code/enabled_gems.cmake` file, which removes the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
+
+```cmd
+usage: o3de.py disable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+                (-gp GEM_PATH | -gn GEM_NAME)
+                [-egf ENABLED_GEM_FILE] [-ohf OVERRIDE_HOME_FOLDER]
+```
+
+### Usage
+
+```cmd
+o3de.bat disable-gem -gp GEM_PATH -pp PROJECT_PATH
+```
+
+### Optional Parameters
+
+`-h, --help`
+show this help message and exit
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
+The path to the project.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+The name of the project.
+
+`-gp GEM_PATH, --gem-path GEM_PATH`
+
+The path to the gem.
+
+`-gn GEM_NAME, --gem-name GEM_NAME`
+
+The name of the gem.
+
+`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`
+
+The cmake enabled gem file in which gem names are to be removed from.If not specified it will assume
+
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+
+By default the home folder is the user folder, override it to this folder.
+
+
+<!-- ## edit-project-properties -->
+
+
+## `sha256`
+
+Creates a *secure hash algorithm* (SHA-256). This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file. 
+
+
+```cmd
+usage: o3de.py sha256 [-h] -f FILE_PATH [-j JSON_PATH]
+```
+
+### Usage
+
+```cmd
+o3de.bat sha256 --file-path FILE_PATH --json-path JSON_PATH
+```
+
+### Optional Parameters
+
+`-f FILE_PATH, --file-path FILE_PATH`
+
+The path to the file you want to sha256.
+
+`-j JSON_PATH, --json-path JSON_PATH`
+
+optional path to an o3de json file to add the "sha256" element to.
+

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -117,13 +117,13 @@ o3de.bat get-global-project -i SETREG_PATH
 ### Optional Parameters
 
 `-h, --help`
-show this help message and exit
+
+Shows the help message.
 
 `-i INPUT_PATH, --input-path INPUT_PATH`
 
-Optional path to file to read `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then
-`C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg` is used instead
-
+An optional path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file
+`C:/Users/USER_PATH/.o3de/Registry/bootstrap.setreg` instead.
 
 
 ## `set-global-project`
@@ -145,7 +145,7 @@ o3de.bat set-global-project -pp PROJECT_PATH -o SETREG_PATH
 
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-pp PROJECT_PATH, --project-path PROJECT_PATH`
 
@@ -153,15 +153,15 @@ The path to the project.
 
 `-pn PROJECT_NAME, --project-name PROJECT_NAME`
 
-The name of the project.
+The name of the project. You can find the name in the project's `project.json` file.
 
 `-o OUTPUT_PATH, --output-path OUTPUT_PATH`
 
-Optional path to output file to write project_path key to. If not supplied, then `C:\Users\USER_NAME\.o3de\Registry\bootstrap.setreg` is used instead
+An optional path to the output file that you want to write the `project_path` key to. If not supplied, then  this command uses the input file `C:/Users/USER_NAME/.o3de/Registry/bootstrap.setreg` instead.
 
 `-f, --force`
 
-Force the setting of the project path in the supplied setreg file
+Forces the project path to be set in the supplied setreg file. 
 
 
 ## `create-template`
@@ -170,11 +170,12 @@ Creates a template out of the specified source path.
 
 ``` cmd
 usage: o3de.py create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
-                    [-srp SOURCE_RESTRICTED_PATH | -srn SOURCE_RESTRICTED_NAME]
-                    [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
-                    [-sn SOURCE_NAME]
-                    [-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH]
-                    [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PAT
+                [-srp SOURCE_RESTRICTED_PATH | -srn SOURCE_RESTRICTED_NAME]
+                [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
+                [-sn SOURCE_NAME]
+                [-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
+                [-kr] [-kl] [-r [REPLACE [REPLACE ...]]] [-f]
 ```
 
 ### Usage
@@ -189,58 +190,59 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
   
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-sp SOURCE_PATH, --source-path SOURCE_PATH`
 
-The path to the source that you want to make into a template
+The path to the source folder that you want to create into a template.
 
 `-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
 
-The path to the template to create, can be absolute or relative to default templates path
+The path to an existing template you want to create a new template from. The path can be absolute or relative to the default templates path.
 
 `-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`
 
-The path to the source restricted folder.
+The path to the source's restricted folder.
 
 `-srn SOURCE_RESTRICTED_NAME, --source-restricted-name SOURCE_RESTRICTED_NAME`
 
-The name of the source restricted folder. If supplied this will resolve the --source-restricted-path.
+The name of the source's restricted folder. If supplied, you do not need to use the `--source-restricted-path` parameter. 
 
 `-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
 
-The path to the templates restricted folder.
+The path to the template's restricted folder.
 
 `-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
 
-The name of the templates restricted folder. If supplied this will resolve the --template-restricted- path.
+The name of the template's restricted folder. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
 `-sn SOURCE_NAME, --source-name SOURCE_NAME`
 
-Substitutes any file and path entries which match the source name within the source-path directory with the ${Name} and ${SanitizedCppName}.Ex: Path substitution --source-name Foo<source-path>/Code/Include/FooBus.h -> <source-path>/Code/Include/${Name}Bus.hEx: File content substitution.class FooRequests -> class ${SanitizedCppName}Requests
+Substitutes any file and path entries that match the source name - ${Name} and ${SanitizedCppName} - in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
 
 `-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --source-restricted- path/<platform> to where the restricted source is. EX. --source-restricted-path C:/restricted --source- restricted-platform-relative-path some/folder => C:/restricted/<platform>/some/folder/<source_name>
+A path to append to `SOURCE_RESTRICTED_PATH/<platform>/`, which contains the restricted source. For example: `--source-restricted-path C:/restricted --source-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<source_name>`
 
 `-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --template-restricted- path/<platform> to where the restricted template source is. --template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder => C:/restricted/<platform>/some/folder/<template_name>
+A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
 `-kr, --keep-restricted-in-template`
 
-Should the template keep the restricted platforms in the template, or create the restricted files in the restricted folder, default is False so it will create a restricted folder by default
+If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 `-kl, --keep-license-text`
 
-Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
 `-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
 
-String that specifies A->B replacement pairs. Ex. --replace CoolThing ${the_thing} 1723905 ${id} Note: <TemplateName> is the last component of template_path Note: <TemplateName> is automatically ${Name} Note: <templatename> is automatically ${NameLower} Note: <TEMPLATENAME> is automatically ${NameUpper}
+Add A->B replacement pairs. FFor example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <TemplateName> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: <TemplateName> -> ${Name}, <templatename> -> ${NameLower}, <TEMPLATENAME> -> ${NameUpper}. 
 
-`-f, --force`           
-Copies to new template directory even if it exist.
+`-f, --force`  
+         
+Forces the new template directory to override the existing one, if one exists. 
 
 
 ## `create-from-template`
@@ -277,29 +279,27 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`
 
-The path to where you want the template instantiated, can be absolute or dev root relative. Ex. C:/o3de/TestTest = \<destination_name\>
+The path to instantiate the new template in. The path can be absolute or relative to the O3DE development source folder. For example: DESTINATION_PATH = `C:/o3de/NewTemplate`. 
 
 `-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
 
-The path to the template you want to instantiate, can be absolute or dev root/Templates relative. Ex. C:/o3de/Template/TestTemplateTestTemplate = \<template_name\>
+The path to the template you want to instantiate. The path can be absolute or relative to the O3DE development source folder. For example: Set TEMPLATE_PATH to `C:/o3de/Template/SomeTemplate`.
 
 `-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
 
-The name to the registered template you want to
-instantiate. If supplied this will resolve the
---template-path.
+The name of the registered template to instantiate. If supplied, you do not need to use the `--template-path` parameter. 
 
 `-dn DESTINATION_NAME, --destination-name DESTINATION_NAME`
 
-The name to use when substituting the ${Name} placeholder in instantiated template, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of destination path. Ex. New_Gem
+The name to replace ${Name} with in the instantiated template. The name must be alphanumeric, and can contain _ and - characters. If the destination name is not provided, this command will use the last component of the destination path.
 
 `-drp DESTINATION_RESTRICTED_PATH, --destination-restricted-path DESTINATION_RESTRICTED_PATH`
 
-The destination restricted path is where the restricted files will be written to.
+The path where the restricted files will be written to.
 
 `-drn DESTINATION_RESTRICTED_NAME, --destination-restricted-name DESTINATION_RESTRICTED_NAME`
 
@@ -315,26 +315,23 @@ The name of the registered restricted path to read from if any. If supplied this
 
 `-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --destination-restricted -path//<platform/> to where the restricted destination is. --destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder =/> C:/instance//<platform/>/some/folder//<destination_name/>
+A path to append to `DESTINATION_RESTRICTED_PATH/<platform>`, which contains the restricted destination. For example: `--destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder` => `C:/instance/<platform>/some/folder/<destination_name>`
 
 `-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --template-restricted- path//<platform/> to where the restricted template is. --template-restricted-path C:/restricted --template-
-restricted-platform-relaive-path some/folder =/> C:/restricted//<platform/>/some/folder//<template_name/>
+A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
 `-kr, --keep-restricted-in-instance`
 
-Should the instance keep the restricted platforms in the instance, or create the restricted files in the restricted folder, default is False.
+If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 `-kl, --keep-license-text`
 
-Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as
-all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}. 
+If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
 `-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
 
-String that specifies A-/>B replacement pairs. Ex. --replace CoolThing ${the_thing} ${id} 1723905 Note: /<DestinationName/> is the last component of destination_path Note: ${Name} is automatically /<DestinationName/> Note: ${NameLower} is automatically /<destinationname/> Note: ${NameUpper} is automatically
-/<DESTINATIONNAME/> 
+Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <DestinationName> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: <DestinationName> -> ${Name}, <destinationname> -> ${NameLower}, <DESTINATIONNAME> -> ${NameUpper}.
 
 `-f, --force`
 
@@ -377,82 +374,78 @@ o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PAT
   
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-pp PROJECT_PATH, --project-path PROJECT_PATH`
 
-The location of the project you wish to create from the template, can be an absolute path or dev root relative. Ex. C:/o3de/TestProject TestProject = \<project_name\> if --project-name not provided
+The path to create a new project at. The project's path can be absolute or relative to the O3DE development source folder. For example: PROJECT_PATH = `C:/o3de/TestProject`
 
 `-pn PROJECT_NAME, --project-name PROJECT_NAME`
 
-The name of the project you wish to use, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of project path. Ex. New_Project-123
+The name of your new project. Must be alphanumeric, and can contain _ and - characters. If the project name is not provided, this command will use the last component of the project path. Ex. New_Project-123
 
 `-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
 
-the path to the template you want to instance, can be absolute or relative to default templates path
+The path to the template you want to create a new project from. The path can be absolute or relative to the default templates path.
 
 `-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
 
-The name the registered template you want to instance, defaults to DefaultProject. If supplied this will resolve the --template-path.
+The name of the template that you want to create a new project from. If supplied, you do not need to use the `--template-path` parameter. 
 
 `-prp PROJECT_RESTRICTED_PATH, --project-restricted-path PROJECT_RESTRICTED_PATH`
 
-path to the projects restricted folder, can be absolute or relative to the restricted="projects"
+The path to the project's restricted folder. The path can be absolute or relative to `restricted="projects"`. 
 
 `-prn PROJECT_RESTRICTED_NAME, --project-restricted-name PROJECT_RESTRICTED_NAME`
 
-The name of the registered projects restricted path. If supplied this will resolve the --project- restricted-path.
+The name of the project's restricted path. If supplied, you do not need to use the `--project-restricted-path` parameter.
 
 `-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
 
-The templates restricted path can be absolute or relative to restricted="templates"
+The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
 
 `-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
 
-The name of the registered templates restricted path. If supplied this will resolve the --template- restricted-path.
+The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
 `-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH, --project-restricted-platform-relative-path PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --project-restricted- path/\<platform\> to where the restricted project is. --project-restricted-path C:/restricted --project- restricted-platform-relative-path some/folder =\> C:/restricted/\<platform\>/some/folder/\<project_name\>
+A path to append to `PROJECT_RESTRICTED_PATH/<platform>`, and that contains the restricted project. For example: `--project-restricted-path C:/restricted --project- restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<project_name>`.
 
 `-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --template-restricted- path/\<platform\> to where the restricted template is. --template-restricted-path C:/restricted --template- restricted-platform-relative-path some/folder =\> C:/restricted/\<platform\>/some/folder/\<template_name\>
+A path to append to the `TEMPLATE_RESTRICTED_PATH/<platform>`, and that contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
 `-kr, --keep-restricted-in-project`
 
-Should the new project keep the restricted platforms in the project, orcreate the restricted files in the restricted folder, default is False
+If true, creates the restricted platforms in the project folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 `-kl, --keep-license-text`
 
-Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+If true, keeps the license text (located in the `template.json` file) in the new project's `project.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
 `-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
 
-String that specifies ADDITIONAL A-\>B replacement pairs. ${Name} and all other standard project replacements will be automatically inferred from the project name. These replacements will superseded all inferred replacements. Ex. --replace ${DATE} 1/1/2020 ${id} 1723905 Note: \<ProjectName\> is the last component of project_path Note: ${Name} is automatically \<ProjectName\> Note: ${NameLower} is automatically \<projectname\> Note: ${NameUpper} is automatically \<PROJECTNAME\>
+Add A->B replacement pairs. ${Name} and all of the other standard project replacements are automatically inferred from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces all occurences of "MyUsername" with ${User}, and "1723905" with ${id}. Note: <ProjectName> is the last component of the template_path. The following replacement pairs already exist: <ProjectName> -> ${Name}, <projectname> -> ${NameLower}, <PROJECTNAME> -> ${NameUpper}.
 
 `--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
 
-The uuid you want to associate with the system class
-component, default is a random uuid Ex.
-{b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate with the system class
+component. The default is a random UUID. For example, 
+{b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 `--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
 
-The uuid you want to associate with the editor system
-class component, default is a random uuid Ex.
-{b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate with the editor system
+class component. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 `--module-id MODULE_ID`
 
-The uuid you want to associate with the module,
-default is a random uuid Ex.
-{b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
 
 `-f, --force`
 
-Copies over instantiated template directory even if it
-exist.
+Forces the new project directory to override the existing one, if one exists. 
 
 
 ## `create-gem`
@@ -490,75 +483,79 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-gp GEM_PATH, --gem-path GEM_PATH`
 
-The gem path, can be absolute or relative to default gems path
+The path to create a new Gem at. The Gem's path can be absolute or relative to the default Gems path.  
 
 `-gn GEM_NAME, --gem-name GEM_NAME`
 
-The name to use when substituting the ${Name} placeholder for the gem, must be alphanumeric, and can contain _ and - characters. If no name is provided, will use last component of gem path. Ex. New_Gem
+The name of your new Gem. Must be alphanumeric, and can contain _ and - characters. If the Gem name is not provided, this command will use the last component of the Gem path. Ex. New_Gem
 
 `-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
 
-The template path you want to instance, can be absolute or relative to default templates path
+The path to the template you want to create a new Gem from. The path can be absolute or relative to the default templates path.
 
 `-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
 
-The name of the registered template you want to instance, defaults to DefaultGem. If supplied this will resolve the --template-path.
+The name of the template that you want to create a new Gem from. If supplied, you do not need to use the `--template-path` parameter. 
 
 `-grp GEM_RESTRICTED_PATH, --gem-restricted-path GEM_RESTRICTED_PATH`
 
-The path to the gem restricted to write to folder if any, can beabsolute or dev root relative, default is dev root/restricted.
+The path to the Gem's restricted folder, if any. The path can be absolute or relative to the O3DE development source folder. The default is `<o3de-development-source>/restricted`.
 
 `-grn GEM_RESTRICTED_NAME, --gem-restricted-name GEM_RESTRICTED_NAME`
 
-The path to the gem restricted to write to folder if any, can beabsolute or dev root relative, default is dev root/restricted. If supplied this will resolve the --gem-restricted-path.
+The name of the Gem's restricted path, if any. If supplied, you do not need to use the `--gem-restricted-path` parameter.
 
 `-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
 
-The templates restricted path, can be absolute or relative to the restricted="templates"
+The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
 
 `-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
 
-The name of the registered templates restricted path. If supplied this will resolve the --template- restricted-path.
+The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
 `-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH, --gem-restricted-platform-relative-path GEM_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --gem-restricted- path/ \<platform \> to where the restricted template is. --gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder = \> C:/restricted/ \<platform \>/some/folder/ \<gem_name \>
+A path to append to the `GEM_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example, `--gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<gem_name>`.
 
 `-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
 
-Any path to append to the --template-restricted- path/ \<platform \> to where the restricted template is. --template-restricted-path C:/restricted --template- restricted-platform-relative-path some/folder = \> C:/restricted/ \<platform \>/some/folder/ \<template_name \>
+A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
 `-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
 
-String that specifies ADDITIONAL A- \>B replacement pairs. ${Name} and all other standard gem replacements will be automatically inferred from the gem name. These replacements will superseded all inferred replacement pairs. Ex. --replace ${DATE} 1/1/2020 ${id} 1723905 Note:  \<GemName \> is the last component of gem_path Note: ${Name} is automatically  \<GemName \> Note: ${NameLower} is automatically  \<gemname \> Note: ${NameUpper} is automatically  \<GEMANME \>
+Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  `<GemName>` is the last component of the GEM_PATH. The following replacement pairs already exist: <GemName> -> ${Name}, <gemname> -> ${NameLower}, <GEMANME> -> ${NameUpper}.
 
 `-kr, --keep-restricted-in-gem`
 
-Should the new gem keep the restricted platforms in the project, orcreate the restricted files in the restricted folder, default is False
+If true, creates the restricted platforms in the Gem folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 `-kl, --keep-license-text`
 
-Should license in the template files text be kept in the instantiation, default is False, so will not keep license text by default. License text is defined as all lines of text starting on a line with {BEGIN_LICENSE} and ending line {END_LICENSE}.
+If true, keeps the license text (located in the `template.json` file) in the new Gem's `Gem.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
 `--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
 
-The uuid you want to associate with the system class component, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate the system class
+component with. The default is a random uuid. For example, 
+{b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 `--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
 
-The uuid you want to associate with the editor system class component, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate with the editor system
+class component. The default is a random UUID. For example,
+{b60c92eb-3139-454b-a917-a9d3c5819594}.
 
 `--module-id MODULE_ID`
 
-The uuid you want to associate with the gem module, default is a random uuid Ex. {b60c92eb-3139-454b-a917-a9d3c5819594}
+A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
 
 `-f, --force`
 
-Copies over instantiated template directory even if it exist.
+Forces the new Gem directory to override the existing one, if one exists.
 
 
 ## `register`
@@ -758,114 +755,116 @@ o3de.bat register --update
 
 ### Optional parameters
 `-h, --help`  
-show this help message and exit
+
+Shows the help message.
 
 `--this-engine`  
-Registers the engine this script is running from.
+
+The engine that is running this o3de Python script.
 
 `-ep ENGINE_PATH, --engine-path ENGINE_PATH`  
 
-Engine path to register/remove.
+The path to the engine that you want to register or deregister.
 
 `-pp PROJECT_PATH, --project-path PROJECT_PATH`  
 
-Project path to register/remove.
+The path to the project that you want to register or deregister.
 
 `-gp GEM_PATH, --gem-path GEM_PATH`  
 
-Gem path to register/remove.
+The path to the Gem that you want to register or deregister.
 
 `-es EXTERNAL_SUBDIRECTORY, --external-subdirectory EXTERNAL_SUBDIRECTORY`  
 
-External subdirectory path to register/remove.
+The path to the the external subdirectory that you want to register or deregister.
 
 `-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`  
 
-Template path to register/remove.
+The path to the template that you want to register or deregister.
 
 `-rp RESTRICTED_PATH, --restricted-path RESTRICTED_PATH`  
 
-A restricted folder to register/remove.
+The path to the restricted folder that you want to register or deregister.
 
 `-ru REPO_URI, --repo-uri REPO_URI`  
 
-A repo uri to register/remove.
+The path to the repository that you want to register or deregister.
 
 `-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`  
 
-All engines under this folder to register/remove.
+All of the engines in the specified folder that you want to register or deregister.
 
 `-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`  
 
-All projects under this folder to register/remove.
+All of the projects in the specified folder that you want to register or deregister.
 
 `-agp ALL_GEMS_PATH, --all-gems-path ALL_GEMS_PATH`  
 
-All gems under this folder to register/remove.
+All of the Gems in the specified folder that you want to register or deregister.
 
 `-atp ALL_TEMPLATES_PATH, --all-templates-path ALL_TEMPLATES_PATH`  
 
-All templates under this folder to register/remove.
+All of the templates in the specified folder that you want to register or deregister.
 
 `-arp ALL_RESTRICTED_PATH, --all-restricted-path ALL_RESTRICTED_PATH`  
 
-All templates under this folder to register/remove.
+All of the restricted folders in the specified folder that you want to register or deregister.
 
 `-aru ALL_REPO_URI, --all-repo-uri ALL_REPO_URI`  
 
-All repos under this folder to register/remove.
+All of the repositories in the specified folder that you want to register or deregister.
 
 `-def DEFAULT_ENGINES_FOLDER, --default-engines-folder DEFAULT_ENGINES_FOLDER`  
 
-The default engines folder to register/remove.
+The path to the default engines folder that you want to register or deregister.
 
 `-dpf DEFAULT_PROJECTS_FOLDER, --default-projects-folder DEFAULT_PROJECTS_FOLDER`  
 
-The default projects folder to register/remove.
+The path to the default projects folder that you want to register or deregister.
 
 `-dgf DEFAULT_GEMS_FOLDER, --default-gems-folder DEFAULT_GEMS_FOLDER`  
 
-The default gems folder to register/remove.
+The path to the default Gems folder that you want to register or deregister.
 
 `-dtf DEFAULT_TEMPLATES_FOLDER, --default-templates-folder DEFAULT_TEMPLATES_FOLDER`  
 
-The default templates folder to register/remove.
+The path to the default templates folder that you want to register or deregister.
 
 `-drf DEFAULT_RESTRICTED_FOLDER, --default-restricted-folder DEFAULT_RESTRICTED_FOLDER`  
 
-The default restricted folder to register/remove.
+The path to the default restricted folder that you want to register or deregister.
 
 `-dtpf DEFAULT_THIRD_PARTY_FOLDER, --default-third-party-folder DEFAULT_THIRD_PARTY_FOLDER`  
 
-The default 3rd Party folder to register/remove.
+The path to the default 3rd party folder that you want to register or deregister.
 
 `-u, --update`  
 
-Refresh the repo cache.
+Refreshes the repository cache.
 
 `-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`  
 
-By default the home folder is `the user folder, override it to this folder.
+Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
   
 `-r, --remove`  
 
-Remove entry.
+Deregisters the specified entry.
 
 `-f, --force`  
 
-For the update of the registration field being modified.
+Forces the registration information to update, if any modifications were made.
 
  
 **external-subdirectory:**  
-path arguments to use with the --external-subdirectory option
+The following parameters are used with the `--external-subdirectory` option.
 
 `-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH, --external-subdirectory-engine-path EXTERNAL_SUBDIRECTORY_ENGINE_PATH`  
 
-If supplied, registers the external subdirectory with the engine.json at the engine-path location
+If supplied, registers the external subdirectory with the `engine.json` file at the specified engine path.
 
 `-espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH, --external-subdirectory-project-path EXTERNAL_SUBDIRECTORY_PROJECT_PATH`
 
-If supplied, registers the external subdirectory with the project.json at the project-path location
+If supplied, registers the external subdirectory with the `project.json` file at the specified project path. 
 
 
 ## `register-show`
@@ -1022,82 +1021,107 @@ o3de.bat register-show --repos
 ### Optional parameters
 
 `-h, --help`
+
 Shows the help message.
 
 `-te, --this-engine`
+
 Outputs the current engine's path.
 
 `-e, --engines`
-Outputs the engines registered in the `o3de_manifest.json` file.
+
+Outputs a list of the engines that are registered in the `o3de_manifest.json` file.
 
 `-p, --projects`
-Output the projects registered in the `o3de_manifest.json` file.
+
+Outputs a list of the projects that are registered in the `o3de_manifest.json` file.
 
 `-g, --gems`
-Output the gems registered in the `o3de_manifest.json` file.
+
+Outputs a list of the Gems that are registered in the `o3de_manifest.json` file.
 
 `-t, --templates`
-Output the templates registered in the `o3de_manifest.json` file.
+
+Outputs a list of the templates that are registered in the `o3de_manifest.json` file.
 
 `-r, --repos`
-Output the repos registered in the `o3de_manifest.json` file. Ignores repos.
+
+Outputs a list of the repos that are registered in the `o3de_manifest.json` file. Ignores repos.
 
 `-rs, --restricted`
-Output the restricted directories registered in the `o3de_manifest.json` file.
+
+Outputs a list of the restricted directories that are registered in the `o3de_manifest.json` file.
 
 `-ep, --engine-projects`
-Output the projects registered in the current engine engine.json. Ignores repos.
+
+Outputs a list of the projects that are registered in the current engine's `engine.json` file. Ignores repos.
 
 `-eg, --engine-gems`
-Output the gems registered in the current engine engine.json. Ignores repos
+
+Outputs a list of the gems that are registered in the current engine's `engine.json` file. Ignores repos.
 
 `-et, --engine-templates`
-Output the templates registered in the current engine engine.json. Ignores repos.
+Outputs a list of the templates that are registered in the current engine's `engine.json` file. Ignores repos.
 
 `-ers, --engine-restricted`
-Output the restricted directories registered in the current engine engine.json.
+
+Outputs a list of the restricted directories that are registered in the current engine's `engine.json` file.
 
 `-ees, --engine-external-subdirectories`
-Output the external subdirectories registered in the current engine engine.json.
+
+Outputs a list of the external subdirectories that are registered in the current engine's `engine.json` file.
 
 `-pg, --project-gems`
-Returns the gems registered with the project.json.
+
+Outputs a list of the gems that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
 `-pt, --project-templates`
-Returns the templates registered with the project.json.
+
+Outputs a list of the templates that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
 `-prs, --project-restricted`
-Returns the restricted directories registered with the project.json.
+
+Outputs a list of the restricted directories that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
 `-pes, --project-external-subdirectories`
-Returns the external subdirectories register with the project.json.
+
+Outputs a list of the external subdirectories register with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
 `-ap, --all-projects`
-Output all projects registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos.
+
+Outputs all of the projects that are registered in the `o3de_manifest.json` file and the current engine's `engine.json`. Ignores repos.
 
 `-ag, --all-gems`
-Output all gems registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos
+
+Outputs all of the gems that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos
 
 `-at, --all-templates`
-Output all templates registered in the `o3de_manifest.json` file.and the current engine.json. Ignores repos.
+
+Outputs all of the templates that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos.
 
 `-ares, --all-restricted`
-Output all restricted directory registered in the `o3de_manifest.json` file.and the current engine.json.
+
+Outputs all restricted directory that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
 `-aes, --all-external-subdirectories`
-Output all external subdirectories registered in the `o3de_manifest.json` file.and the current engine.json.
+
+Outputs all external subdirectories that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
 `-v, --verbose`
-How verbose do you want the output to be.
+
+If verbose > 0, outputs the contents of the specified files.
 
 `-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
 The path to a project.
 
 `-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
 The name of a project.
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
- By default the home folder is the user folder, override it to this folder.
+`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`  
+
+Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 
@@ -1184,39 +1208,39 @@ o3de.bat get-registered --default-folder restricted
 
 `-h, --help`
 
-show this help message and exit
+Shows the help message.
 
 `-en ENGINE_NAME, --engine-name ENGINE_NAME`
 
-Engine name.
+The name of an engine.
 
 `-pn PROJECT_NAME, --project-name PROJECT_NAME`
 
-Project name.
+The name of a project.
 
 `-gn GEM_NAME, --gem-name GEM_NAME`
 
-Gem name.
+The name of a Gem.
 
 `-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
 
-Template name.
+The name of a template.
 
 `-df {engines,projects,gems,templates,restricted}, --default-folder {engines,projects,gems,templates,restricted}`
 
-The default folders for o3de.
+The default folders for engines, projects, Gems, templates, and restricted folders in O3DE.
 
 `-rn REPO_NAME, --repo-name REPO_NAME`
 
-Repo name.
+The name of a repository. 
 
 `-rsn RESTRICTED_NAME, --restricted-name RESTRICTED_NAME`
 
-Restricted name.
+The name of a restricted folder.
 
 `-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
 
-By default the home folder is the user folder, override it to this folder.
+Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 ## `enable-gem`
@@ -1288,7 +1312,7 @@ o3de.bat disable-gem -gp GEM_PATH -pp PROJECT_PATH
 ### Optional Parameters
 
 `-h, --help`
-show this help message and exit
+Shows the help message.
 
 `-pp PROJECT_PATH, --project-path PROJECT_PATH`
 
@@ -1300,22 +1324,115 @@ The name of the project.
 
 `-gp GEM_PATH, --gem-path GEM_PATH`
 
-The path to the gem.
+The path to the Gem.
 
 `-gn GEM_NAME, --gem-name GEM_NAME`
 
-The name of the gem.
+The name of the Gem.
 
 `-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`
 
-The cmake enabled gem file in which gem names are to be removed from.If not specified it will assume
+The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
 
 `-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
 
-By default the home folder is the user folder, override it to this folder.
+Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
-<!-- ## edit-project-properties -->
+<!-- ## edit-project-properties
+
+Edits a set of fields within a manifest file. 
+
+```cmd
+usage: o3de.py edit-project-properties [-h]
+                        (-pp PROJECT_PATH | -pn PROJECT_NAME)
+                        [-pnn PROJECT_NEW_NAME]
+                        [-po PROJECT_ORIGIN]
+                        [-pd PROJECT_DISPLAY]
+                        [-ps PROJECT_SUMMARY]
+                        [-pi PROJECT_ICON]
+                        [-at [ADD_TAGS [ADD_TAGS ...]] | -dt
+                        [DELETE_TAGS [DELETE_TAGS ...]] | -rt
+                        [REPLACE_TAGS [REPLACE_TAGS ...]]]
+```
+
+### Usage
+
+Updates the `engine_name` field in the `engine.json` file located at the specified engine's folder. 
+
+```cmd
+o3de.bat edit-engine-properties --engine-path ENGINE_PATH --engine-new-name ENGINE_NEW_NAME
+
+// or
+
+o3de.bat edit-engine-properties --engine-name ENGINE_NAME --engine-new-name ENGINE_NEW_NAME
+```
+
+Updates the `gem_name` field in the `gem.json` file located at the specified Gem's folder.
+
+```cmd
+o3de.bat edit-gem-properties --gem-path GEM_PATH --gem-new-name GEM_NEW_NAME
+o3de.bat edit-gem-properties --gem-name GEM_NAME --gem-new-name GEM_NEW_NAME
+```
+
+Updates the "project_name" field within the gem.json located at the supplied project path or at the path of the registered project with <project-name>
+
+```cmd
+o3de.bat edit-project-properties --project-path PROJECT_PATH --project-new-name PROJECT_NEW_NAME
+o3de.bat edit-project-properties --project-name PROJECT_NAME --project-new-name PROJECT_NEW_NAME
+```
+
+### Optional parameters
+
+`-h, --help`
+
+Shows the help message.
+
+`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+
+The path to the project.
+
+`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+
+The name of the project.
+
+`-at [ADD_TAGS [ADD_TAGS ...]], --add-tags [ADD_TAGS [ADD_TAGS ...]]`
+
+Adds tag(s) to the `user_tags` property. To add multiple tags, use a space delimited
+list (for example, `-at A B C`).
+
+`-dt [DELETE_TAGS [DELETE_TAGS ...]], --delete-tags [DELETE_TAGS [DELETE_TAGS ...]]`
+
+Removes tag(s) from the `user_tags` property. To delete multiple tags, use a space delimited list (for example, `-dt A B C`).
+
+`-rt [REPLACE_TAGS [REPLACE_TAGS ...]], --replace-tags [REPLACE_TAGS [REPLACE_TAGS ...]]`
+
+Replace the `user_tags` property with the specified space delimited list of values.
+
+
+**Project properties:**
+The following properties modify individual project properties.
+
+`-pnn PROJECT_NEW_NAME, --project-new-name PROJECT_NEW_NAME`
+
+Sets the project's name.
+
+`-po PROJECT_ORIGIN, --project-origin PROJECT_ORIGIN`
+
+Sets the description or url for the project origin (such as the
+project host, repository, or owner).
+
+`-pd PROJECT_DISPLAY, --project-display PROJECT_DISPLAY`
+
+Sets the project's display name.
+
+`-ps PROJECT_SUMMARY, --project-summary PROJECT_SUMMARY`
+
+Sets the project's summary description.
+
+`-pi PROJECT_ICON, --project-icon PROJECT_ICON`
+
+Sets the project's icon resource. -->
 
 
 ## `sha256`
@@ -1337,9 +1454,9 @@ o3de.bat sha256 --file-path FILE_PATH --json-path JSON_PATH
 
 `-f FILE_PATH, --file-path FILE_PATH`
 
-The path to the file you want to sha256.
+The path to the O3DE object.
 
 `-j JSON_PATH, --json-path JSON_PATH`
 
-optional path to an o3de json file to add the "sha256" element to.
+The path to the O3DE object's JSON file that you want to add the "sha256" element to.
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -5,7 +5,7 @@ weight: 200
 toc: true
 ---
 
-The `o3de` Python script provides a solution to accomplish project configuration tasks using the command line interface (CLI). It aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so users can access them from a single point. The main driver script is located in the engine folder at `[/scripts/o3de.py](http://o3de.py)`. 
+The `o3de` Python script provides a solution to accomplish project configuration tasks using the command line interface (CLI). It aggregates all of the functions from lower-level scripts in Open 3D Engine (O3DE), so users can access them from a single point. The script is located in the engine folder at `/scripts/o3de.py`. 
 
 The `o3de` Python script is responsible for multiple tasks:
 
@@ -22,23 +22,21 @@ The `o3de` Python script is responsible for multiple tasks:
 To use the `o3de` Python script, you must have Python runtime set up. Python runtime was downloaded when you set up the engine. For more information, refer to instructions on how to get Python runtime in the [Register the engine](/docs/welcome-guide/setup/setup-from-github/#register-the-engine) section of the Setup From GitHub page.
 
 
-## Quick Start
+## Quick start
 
 {{< tabs name="Python runtime setup" >}}
 {{% tab name="Windows" %}}
 
 For Windows, open a command prompt. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
 
-- Launch python and run the `o3de.py` script.
-
+- Run the `o3de.bat` batch file directly.
     ```cmd
-    <engine>/python/python.cmd <engine>/scripts/o3de.py <command>
+    <engine>\scripts\o3de.bat <command>
     ```
 
-- Run the `o3de.bat` batch file directly.
-
+- Launch python and run the `o3de.py` script.
     ```cmd
-    <engine>/scripts/o3de.bat <command>
+    <engine>\python\python.cmd <engine>\scripts\o3de.py <command>
     ```
 
 **Example**
@@ -46,7 +44,7 @@ For Windows, open a command prompt. Then, run the O3DE Python runtime using one 
 For example, to register the engine, you can enter the following command. 
 
 ```cmd
-<engine>/scripts/o3de.bat register --this-engine
+<engine>\scripts\o3de.bat register --this-engine
 ```
 
 {{% /tab %}}
@@ -54,16 +52,14 @@ For example, to register the engine, you can enter the following command.
 
 For Linux, open a terminal. Then, run the O3DE Python runtime using one of the following ways, and enter the command you want to perform. Note: Replace `<engine>` with the path to your engine. 
 
-- Launch python and run the `o3de.py` script.
-
+- Run the `o3de.sh` shell script file directly.
     ```bash
-    <engine>/python/python.sh <engine/scripts/o3de.py
+    <engine>/scripts/o3de.sh <command>
     ```
 
-- Run the `o3de.sh` shell script file directly.
-
+- Launch python and run the `o3de.py` script.
     ```bash
-    <engine>/scripts/o3de.sh
+    <engine>/python/python.sh <engine>/scripts/o3de.py <command>
     ```
 
 **Example**
@@ -79,14 +75,14 @@ For example, to register the engine, you can enter the following command.
 
 
 ## Commands
-
+The `o3de` Python script contains the following commands, with further details in the following sections. 
 
 | Command | Description | 
 | - | - |
 | [`get-global-project`](#get-global-project) | Gets the global project that is registered to the engine. |
 | [`set-global-project`](#set-global-project) | Sets the specified project as the engine's global project. |
 | [`create-template`](#create-template) | Creates a template out of the specified source path. |
-| [`create-from-template`](#create-from-template) | Creates a template from an existing template.  |
+| [`create-from-template`](#create-from-template) | Creates an instance from a generic template.  |
 | [`create-project`](#create-project) | Creates a new project. |
 | [`create-gem`](#create-gem) | Creates a new Gem. |
 | [`register`](#register) | Register an O3DE object. |
@@ -94,7 +90,7 @@ For example, to register the engine, you can enter the following command.
 | [`get-registered`](#get-registered) | Shows the registered O3DE object's path that is mapped to the specified name. |
 | [`enable-gem`](#enable-gem) | Enables the Gem in your project, so you can use the assets or code the Gem provides. |
 | [`disable-gem`](#disable-gem) | Disables the Gem in your project. |
-| [`sha256`](#sha256) | Creates a secure hash algorithm (SHA-256). |
+| [`sha256`](#sha256) | Creates a hash value for an O3DE object using the SHA-256 secure hash algorithm. |
 <!-- | [`edit-project-properties`](#edit-project-properties) |  | -->
 
 
@@ -103,73 +99,92 @@ For example, to register the engine, you can enter the following command.
 
 Gets the global project that is registered to the engine in the specified `.setreg` file at `<user>/.o3de/Registry/`.
 
+### Format
 
 ```cmd
-usage: o3de.py get-global-project [-h] [-i INPUT_PATH]
+get-global-project [-h] [-i INPUT_PATH]
 ```
 
 ### Usage
 
+Reads the global project from `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+
 ```cmd
-o3de.bat get-global-project -i SETREG_PATH
+o3de.bat get-global-project
 ```
 
-### Optional Parameters
+Reads the global project from a specified path.
+```cmd
+o3de.bat get-global-project -i C:\Users\<USERNAME>\.o3de\Registry\my-custom.setreg
+```
 
-`-h, --help`
+### Optional parameters
 
-Shows the help message.
+- **`-h, --help`**
 
-`-i INPUT_PATH, --input-path INPUT_PATH`
+  Shows the help message.
 
-An optional path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file
-`C:/Users/USER_PATH/.o3de/Registry/bootstrap.setreg` instead.
+- **`-i INPUT_PATH, --input-path INPUT_PATH`**
+
+  A path to the input file that you want to read the  `/Amazon/AzCore/Bootstrap/project_path` key from. If not supplied, then this command uses the input file `C:/Users/USER_PATH/.o3de/Registry/bootstrap.setreg` instead.
 
 
 ## `set-global-project`
 
-Sets the specified project as the engine's global project in the specified `.setreg` file at `<user>/.o3de/Registry/`
+Sets the specified project as the engine's global project. By default this is set in `C:\Users\USER_PATH\.o3de\Registry\bootstrap.setreg`. You can also specify a file path using `-o`.
+
+### Format 
 
 ```cmd
-usage: o3de.oy set-global-project [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+set-global-project [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
                                   [-o OUTPUT_PATH] [-f]
 ```
 
 ### Usage
 
+Sets the specified project as the global project in `<USER_PATH>/.o3de/Registry/bootstrap.setreg`.
+
 ```cmd
-o3de.bat set-global-project -pp PROJECT_PATH -o SETREG_PATH
+o3de.bat set-global-project -pp PROJECT_PATH
 ```
 
-### Optional Parameters
+Sets the specified project as the global project in the specified path.
 
-`-h, --help`
+```cmd
+o3de.bat set-global-project -pp PROJECT_PATH -o C:\Users\<USERNAME>\.o3de\Registry\my-custom.setreg
+```
 
-Shows the help message.
+### Optional parameters
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+- **`-h, --help`**
 
-The path to the project.
+  Shows the help message.
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-The name of the project. You can find the name in the project's `project.json` file.
+  The path to the project.
 
-`-o OUTPUT_PATH, --output-path OUTPUT_PATH`
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-An optional path to the output file that you want to write the `project_path` key to. If not supplied, then  this command uses the input file `C:/Users/USER_NAME/.o3de/Registry/bootstrap.setreg` instead.
+  The name of the project. You can find the name in the project's `project.json` file.
 
-`-f, --force`
+- **`-o OUTPUT_PATH, --output-path OUTPUT_PATH`**
 
-Forces the project path to be set in the supplied setreg file. 
+  A path to the output file that you want to write the `project_path` key to. If not supplied, then  this command uses the input file `C:/Users/USER_NAME/.o3de/Registry/bootstrap.setreg` instead.
+
+- **`-f, --force`**
+
+  Forces the project path to be set in the supplied setreg file. 
 
 
 ## `create-template`
 
 Creates a template out of the specified source path.
 
+### Format
+
 ``` cmd
-usage: o3de.py create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
+create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
                 [-srp SOURCE_RESTRICTED_PATH | -srn SOURCE_RESTRICTED_NAME]
                 [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
                 [-sn SOURCE_NAME]
@@ -186,71 +201,73 @@ Creates a template from the source folder and saves the template into the specif
 o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
   
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-sp SOURCE_PATH, --source-path SOURCE_PATH`
+- **`-sp SOURCE_PATH, --source-path SOURCE_PATH`**
 
-The path to the source folder that you want to create into a template.
+  The path to the source folder that you want to create into a template.
 
-`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+- **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-The path to an existing template you want to create a new template from. The path can be absolute or relative to the default templates path.
+  The path to an existing template you want to create a new template from. The path can be absolute or relative to the default templates path.
 
-`-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`
+- **`-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`**
 
-The path to the source's restricted folder.
+  The path to the source's restricted folder.
 
-`-srn SOURCE_RESTRICTED_NAME, --source-restricted-name SOURCE_RESTRICTED_NAME`
+- **`-srn SOURCE_RESTRICTED_NAME, --source-restricted-name SOURCE_RESTRICTED_NAME`**
 
-The name of the source's restricted folder. If supplied, you do not need to use the `--source-restricted-path` parameter. 
+  The name of the source's restricted folder. If supplied, you do not need to use the `--source-restricted-path` parameter. 
 
-`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+- **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-The path to the template's restricted folder.
+  The path to the template's restricted folder.
 
-`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+- **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-The name of the template's restricted folder. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted folder. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
-`-sn SOURCE_NAME, --source-name SOURCE_NAME`
+- **`-sn SOURCE_NAME, --source-name SOURCE_NAME`**
 
-Substitutes any file and path entries that match the source name - ${Name} and ${SanitizedCppName} - in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
+  Substitutes any file and path entries that match the source name - ${Name} and ${SanitizedCppName} - in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
 
-`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `SOURCE_RESTRICTED_PATH/<platform>/`, which contains the restricted source. For example: `--source-restricted-path C:/restricted --source-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<source_name>`
+  A path to append to `SOURCE_RESTRICTED_PATH/<platform>/`, which contains the restricted source. For example: `--source-restricted-path C:/restricted --source-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<source_name>`
 
-`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
+  A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
-`-kr, --keep-restricted-in-template`
+- **`-kr, --keep-restricted-in-template`**
 
-If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
-`-kl, --keep-license-text`
+- **`-kl, --keep-license-text`**
 
-If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
-`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+- **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-Add A->B replacement pairs. FFor example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <TemplateName> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: <TemplateName> -> ${Name}, <templatename> -> ${NameLower}, <TEMPLATENAME> -> ${NameUpper}. 
+  Add A->B replacement pairs. FFor example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <TemplateName> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: <TemplateName> -> ${Name}, <templatename> -> ${NameLower}, <TEMPLATENAME> -> ${NameUpper}. 
 
-`-f, --force`  
+- **`-f, --force`**
          
-Forces the new template directory to override the existing one, if one exists. 
+  Forces the new template directory to override the existing one, if one exists. 
 
 
 ## `create-from-template`
 
 Creates a template with a `template.json` file. 
 
+### Format
+
 ```cmd
-usage: o3de.py create-from-template [-h] -dp DESTINATION_PATH
+create-from-template [-h] -dp DESTINATION_PATH
                                     (-tp TEMPLATE_PATH | -tn TEMPLATE_NAME)
                                     [-dn DESTINATION_NAME]
                                     [-drp DESTINATION_RESTRICTED_PATH | -drn DESTINATION_RESTRICTED_NAME]
@@ -275,75 +292,77 @@ Creates a template based on the specified template and saves it in the specified
 o3de.bat create-from-template --destination-path DESTINATION_PATH --template-path TEMPLATE_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`
+- **`-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`**
 
-The path to instantiate the new template in. The path can be absolute or relative to the O3DE development source folder. For example: DESTINATION_PATH = `C:/o3de/NewTemplate`. 
+  The path to instantiate the new template in. The path can be absolute or relative to the O3DE development source folder. For example: Set DESTINATION_PATH = `C:/o3de/NewTemplate`. 
 
-`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+- **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-The path to the template you want to instantiate. The path can be absolute or relative to the O3DE development source folder. For example: Set TEMPLATE_PATH to `C:/o3de/Template/SomeTemplate`.
+  The path to the template you want to instantiate. The path can be absolute or relative to the O3DE development source folder. For example: Set TEMPLATE_PATH to `C:/o3de/Template/SomeTemplate`.
 
-`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+- **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-The name of the registered template to instantiate. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the registered template to instantiate. If supplied, you do not need to use the `--template-path` parameter. 
 
-`-dn DESTINATION_NAME, --destination-name DESTINATION_NAME`
+- **`-dn DESTINATION_NAME, --destination-name DESTINATION_NAME`**
 
-The name to replace ${Name} with in the instantiated template. The name must be alphanumeric, and can contain _ and - characters. If the destination name is not provided, this command will use the last component of the destination path.
+  The name to replace ${Name} with in the instantiated template. The name must be alphanumeric, and can contain _ and - characters. If the destination name is not provided, this command will use the last component of the destination path.
 
-`-drp DESTINATION_RESTRICTED_PATH, --destination-restricted-path DESTINATION_RESTRICTED_PATH`
+- **`-drp DESTINATION_RESTRICTED_PATH, --destination-restricted-path DESTINATION_RESTRICTED_PATH`**
 
-The path where the restricted files will be written to.
+  The path where the restricted files will be written to.
 
-`-drn DESTINATION_RESTRICTED_NAME, --destination-restricted-name DESTINATION_RESTRICTED_NAME`
+- **`-drn DESTINATION_RESTRICTED_NAME, --destination-restricted-name DESTINATION_RESTRICTED_NAME`**
 
-The name the registered restricted path where the restricted files will be written to. If supplied this will resolve the --destination-restricted-path.
+  The name of the registered restricted path where the restricted files will be written to. If supplied, you do not need to use the `--destination-restricted-path` parameter. 
 
-`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+- **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-The template restricted path to read from if any
+  The path to the template restricted directory to read from, if any.
 
-`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+- **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-The name of the registered restricted path to read from if any. If supplied this will resolve the --template-restricted-path.
+  The name of the registered restricted path to read from, if any. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
-`-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH, --destination-restricted-platform-relative-path DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `DESTINATION_RESTRICTED_PATH/<platform>`, which contains the restricted destination. For example: `--destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder` => `C:/instance/<platform>/some/folder/<destination_name>`
+  A path to append to `DESTINATION_RESTRICTED_PATH/<platform>`, which contains the restricted destination. For example: `--destination-restricted-path C:/instance --destination-restricted-platform-relative-path some/folder` => `C:/instance/<platform>/some/folder/<destination_name>`
 
-`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
+  A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
-`-kr, --keep-restricted-in-instance`
+- **`-kr, --keep-restricted-in-instance`**
 
-If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
-`-kl, --keep-license-text`
+- **`-kl, --keep-license-text`**
 
-If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
-`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+- **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: <DestinationName> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: <DestinationName> -> ${Name}, <destinationname> -> ${NameLower}, <DESTINATIONNAME> -> ${NameUpper}.
+  Add A->B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces ${User}with "MyUsername", and ${id} with "1723905". Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: \<DestinationName\> -> ${Name}, \<destinationname\> -> ${NameLower}, \<DESTINATIONNAME\> -> ${NameUpper}.
 
-`-f, --force`
+- **`-f, --force`**
 
-Copies over instantiated template directory even if it exist.
+  Copies over instantiated template directory even if it exist.
 
 
 ## `create-project`
 
 Create a new project at the specified path.
 
+### Format
+
 ``` cmd
-usage: o3de.py create-project [-h] -pp PROJECT_PATH [-pn PROJECT_NAME]
+create-project [-h] -pp PROJECT_PATH [-pn PROJECT_NAME]
                     [-tp TEMPLATE_PATH | -tn TEMPLATE_NAME]
                     [-prp PROJECT_RESTRICTED_PATH | -prn PROJECT_RESTRICTED_NAME]
                     [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
@@ -369,88 +388,90 @@ Creates a new project at the specified path using the specified project template
 o3de.bat create-project --project-path PROJECT_PATH --template-path TEMPLATE_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
 
   
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-The path to create a new project at. The project's path can be absolute or relative to the O3DE development source folder. For example: PROJECT_PATH = `C:/o3de/TestProject`
+  The path to create a new project at. The project's path can be absolute or relative to the O3DE development source folder. For example: PROJECT_PATH = `C:/o3de/TestProject`
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-The name of your new project. Must be alphanumeric, and can contain _ and - characters. If the project name is not provided, this command will use the last component of the project path. Ex. New_Project-123
+  The name of your new project. Must be alphanumeric, and can contain _ and - characters. If the project name is not provided, this command will use the last component of the project path. Ex. New_Project-123
 
-`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+- **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-The path to the template you want to create a new project from. The path can be absolute or relative to the default templates path.
+  The path to the template you want to create a new project from. The path can be absolute or relative to the default templates path.
 
-`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+- **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-The name of the template that you want to create a new project from. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the template that you want to create a new project from. If supplied, you do not need to use the `--template-path` parameter. 
 
-`-prp PROJECT_RESTRICTED_PATH, --project-restricted-path PROJECT_RESTRICTED_PATH`
+- **`-prp PROJECT_RESTRICTED_PATH, --project-restricted-path PROJECT_RESTRICTED_PATH`**
 
-The path to the project's restricted folder. The path can be absolute or relative to `restricted="projects"`. 
+  The path to the project's restricted folder. The path can be absolute or relative to `restricted="projects"`. 
 
-`-prn PROJECT_RESTRICTED_NAME, --project-restricted-name PROJECT_RESTRICTED_NAME`
+- **`-prn PROJECT_RESTRICTED_NAME, --project-restricted-name PROJECT_RESTRICTED_NAME`**
 
-The name of the project's restricted path. If supplied, you do not need to use the `--project-restricted-path` parameter.
+  The name of the project's restricted path. If supplied, you do not need to use the `--project-restricted-path` parameter.
 
-`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+- **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
+  The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
 
-`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+- **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
-`-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH, --project-restricted-platform-relative-path PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-prprp PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH, --project-restricted-platform-relative-path PROJECT_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `PROJECT_RESTRICTED_PATH/<platform>`, and that contains the restricted project. For example: `--project-restricted-path C:/restricted --project- restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<project_name>`.
+  A path to append to `PROJECT_RESTRICTED_PATH/<platform>`, and that contains the restricted project. For example: `--project-restricted-path C:/restricted --project- restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<project_name>`.
 
-`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to the `TEMPLATE_RESTRICTED_PATH/<platform>`, and that contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
+  A path to append to the `TEMPLATE_RESTRICTED_PATH/<platform>`, and that contains the restricted template source. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
-`-kr, --keep-restricted-in-project`
+- **`-kr, --keep-restricted-in-project`**
 
-If true, creates the restricted platforms in the project folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the project folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
-`-kl, --keep-license-text`
+- **`-kl, --keep-license-text`**
 
-If true, keeps the license text (located in the `template.json` file) in the new project's `project.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new project's `project.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
-`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+- **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-Add A->B replacement pairs. ${Name} and all of the other standard project replacements are automatically inferred from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces all occurences of "MyUsername" with ${User}, and "1723905" with ${id}. Note: <ProjectName> is the last component of the template_path. The following replacement pairs already exist: <ProjectName> -> ${Name}, <projectname> -> ${NameLower}, <PROJECTNAME> -> ${NameUpper}.
+  Add A->B replacement pairs. ${Name} and all of the other standard project replacements are automatically inferred from the project name. These replacements supersede all inferred replacements. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces all occurences of "MyUsername" with ${User}, and "1723905" with ${id}. Note: \<ProjectName\> is the last component of the template_path. The following replacement pairs already exist: \<ProjectName\> -> ${Name}, \<projectname\> -> ${NameLower}, \<PROJECTNAME\> -> ${NameUpper}.
 
-`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
+- **`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`**
 
-A UUID that you want to associate with the system class
+  A UUID that you want to associate with the system class
 component. The default is a random UUID. For example, 
 {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
-`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
+- **`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`**
 
-A UUID that you want to associate with the editor system
+  A UUID that you want to associate with the editor system
 class component. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
-`--module-id MODULE_ID`
+- **`--module-id MODULE_ID`**
 
-A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
+  A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
 
-`-f, --force`
+- **`-f, --force`**
 
-Forces the new project directory to override the existing one, if one exists. 
+  Forces the new project directory to override the existing one, if one exists. 
 
 
 ## `create-gem`
 
 Create a new Gem at the specified path.
+
+### Format
 
 ```cmd
 create-gem [-h] -gp GEM_PATH [-gn GEM_NAME]
@@ -481,90 +502,91 @@ o3de.bat create-gem -gp GEM_PATH --template-path TEMPLATE_PATH
 
 ### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-gp GEM_PATH, --gem-path GEM_PATH`
+- **`-gp GEM_PATH, --gem-path GEM_PATH`**
 
-The path to create a new Gem at. The Gem's path can be absolute or relative to the default Gems path.  
+  The path to create a new Gem at. The Gem's path can be absolute or relative to the default Gems path.  
 
-`-gn GEM_NAME, --gem-name GEM_NAME`
+- **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-The name of your new Gem. Must be alphanumeric, and can contain _ and - characters. If the Gem name is not provided, this command will use the last component of the Gem path. Ex. New_Gem
+  The name of your new Gem. Must be alphanumeric, and can contain _ and - characters. If the Gem name is not provided, this command will use the last component of the Gem path. Ex. New_Gem
 
-`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`
+- **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-The path to the template you want to create a new Gem from. The path can be absolute or relative to the default templates path.
+  The path to the template you want to create a new Gem from. The path can be absolute or relative to the default templates path.
 
-`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+- **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-The name of the template that you want to create a new Gem from. If supplied, you do not need to use the `--template-path` parameter. 
+  The name of the template that you want to create a new Gem from. If supplied, you do not need to use the `--template-path` parameter. 
 
-`-grp GEM_RESTRICTED_PATH, --gem-restricted-path GEM_RESTRICTED_PATH`
+- **`-grp GEM_RESTRICTED_PATH, --gem-restricted-path GEM_RESTRICTED_PATH`**
 
-The path to the Gem's restricted folder, if any. The path can be absolute or relative to the O3DE development source folder. The default is `<o3de-development-source>/restricted`.
+  The path to the Gem's restricted folder, if any. The path can be absolute or relative to the O3DE development source folder. The default is `<o3de-development-source>/restricted`.
 
-`-grn GEM_RESTRICTED_NAME, --gem-restricted-name GEM_RESTRICTED_NAME`
+- **`-grn GEM_RESTRICTED_NAME, --gem-restricted-name GEM_RESTRICTED_NAME`**
 
-The name of the Gem's restricted path, if any. If supplied, you do not need to use the `--gem-restricted-path` parameter.
+  The name of the Gem's restricted path, if any. If supplied, you do not need to use the `--gem-restricted-path` parameter.
 
-`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`
+- **`-trp TEMPLATE_RESTRICTED_PATH, --template-restricted-path TEMPLATE_RESTRICTED_PATH`**
 
-The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
+  The path to the template's restricted folder. The path can be absolute or relative to `restricted="templates"`.
 
-`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`
+- **`-trn TEMPLATE_RESTRICTED_NAME, --template-restricted-name TEMPLATE_RESTRICTED_NAME`**
 
-The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
+  The name of the template's restricted path. If supplied, you do not need to use the `--template-restricted-path` parameter.
 
-`-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH, --gem-restricted-platform-relative-path GEM_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-grprp GEM_RESTRICTED_PLATFORM_RELATIVE_PATH, --gem-restricted-platform-relative-path GEM_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to the `GEM_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example, `--gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<gem_name>`.
+  A path to append to the `GEM_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example, `--gem-restricted-path C:/restricted --gem-restricted- platform-relative-path some/folder` => `C:/restricted/<platform>/some/folder/<gem_name>`.
 
-`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`
+- **`-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH, --template-restricted-platform-relative-path TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
-A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
+  A path to append to `TEMPLATE_RESTRICTED_PATH/<platform>`, which contains the restricted template. For example: `--template-restricted-path C:/restricted --template-restricted-platform-relaive-path some/folder` => `C:/restricted/<platform>/some/folder/<template_name>`.
 
-`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`
+- **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  `<GemName>` is the last component of the GEM_PATH. The following replacement pairs already exist: <GemName> -> ${Name}, <gemname> -> ${NameLower}, <GEMANME> -> ${NameUpper}.
+  Add A->B replacement pairs. ${Name} and all of the other standard Gem replacements are automatically inferred from the Gem name. These replacements supersede all inferred replacement pairs. For example: `--replace ${DATE} 1/1/2020 ${id} 1723905`. This replaces ${DATE} with `1/1/2020`, and  ${id} with `1723905`. Note:  \<GemNam> is the last component of the GEM_PATH. The following replacement pairs already exist: \<GemName\> -> ${Name}, \<gemname\> -> ${NameLower}, \<GEMANME\> -> ${NameUpper}.
 
-`-kr, --keep-restricted-in-gem`
+- **`-kr, --keep-restricted-in-gem`**
 
-If true, creates the restricted platforms in the Gem folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If true, creates the restricted platforms in the Gem folder. If false, creates the restricted files in the restricted folder, located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
-`-kl, --keep-license-text`
+- **`-kl, --keep-license-text`**
 
-If true, keeps the license text (located in the `template.json` file) in the new Gem's `Gem.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
+  If true, keeps the license text (located in the `template.json` file) in the new Gem's `Gem.json` file. If false, the license text will not be included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. 
 
-`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`
+- **`--system-component-class-id SYSTEM_COMPONENT_CLASS_ID`**
 
-A UUID that you want to associate the system class
+  A UUID that you want to associate the system class
 component with. The default is a random uuid. For example, 
 {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
-`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`
+- **`--editor-system-component-class-id EDITOR_SYSTEM_COMPONENT_CLASS_ID`**
 
-A UUID that you want to associate with the editor system
+  A UUID that you want to associate with the editor system
 class component. The default is a random UUID. For example,
 {b60c92eb-3139-454b-a917-a9d3c5819594}.
 
-`--module-id MODULE_ID`
+- **`--module-id MODULE_ID`**
 
-A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
+  A UUID that you want to associate with the module. The default is a random UUID. For example, {b60c92eb-3139-454b-a917-a9d3c5819594}. 
 
-`-f, --force`
+- **`-f, --force`**
 
-Forces the new Gem directory to override the existing one, if one exists.
+  Forces the new Gem directory to override the existing one, if one exists.
 
 
 ## `register`
 
 Register O3DE objects to the `o3de_manifest.json` file.
 
+### Format
 
 ```cmd
-usage: o3de.py register [-h]
+register [-h]
                         (--this-engine | -ep ENGINE_PATH | -pp PROJECT_PATH | -gp GEM_PATH | -es EXTERNAL_SUBDIRECTORY | -tp TEMPLATE_PATH | -rp RESTRICTED_PATH | -ru REPO_URI | -aep ALL_ENGINES_PATH | -app ALL_PROJECTS_PATH | -agp ALL_GEMS_PATH | -atp ALL_TEMPLATES_PATH | -arp ALL_RESTRICTED_PATH | -aru ALL_REPO_URI | -def DEFAULT_ENGINES_FOLDER | -dpf DEFAULT_PROJECTS_FOLDER | -dgf DEFAULT_GEMS_FOLDER | -dtf DEFAULT_TEMPLATES_FOLDER | -drf DEFAULT_RESTRICTED_FOLDER | -dtpf DEFAULT_THIRD_PARTY_FOLDER | -u)
                         [-ohf OVERRIDE_HOME_FOLDER] [-r] [-f]
                         [-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH | -espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH]
@@ -572,6 +594,7 @@ usage: o3de.py register [-h]
 
 
 ### Usage
+<br>
 
 #### Registering engines
 
@@ -593,6 +616,8 @@ Registers all of the engines in the specified path to the `o3de_manifest.json` f
 o3de.bat register --all-engines-path ALL_ENGINES_PATH
 ```
 
+<br>
+
 #### Registering projects
 
 Registers the specified project to the engine. This command does two things: it adds the project's path to the `o3de_manifest.json` file; and it sets `engine` to the engine's name in each project's `project.json` file.
@@ -612,6 +637,8 @@ Registers all of the projects in the specified path. This command recursively sc
 ```cmd
 o3de.bat register --all-projects-path ALL_PROJECTS_PATH
 ```
+
+<br>
 
 #### Registering Gems
 
@@ -639,6 +666,8 @@ Registers all of the Gems in the specified path. This command recursively scans 
 o3de.bat register --all-gems-path ALL_GEMS_PATH
 ```
 
+<br>
+
 #### Registering external subdirectories
 
 Registers the specified subdirectory path to the `external_subdirectories` list in the `o3de_manifest.json` file.
@@ -658,6 +687,8 @@ Registers the specified subdirectory path into `external_subdirectories` in the 
 ```cmd
 o3de.bat register --external-subdirectory EXTERNAL_SUBDIRECTORY --external-subdirectory-project-path PROJECT_PATH
 ```
+
+<br>
 
 #### Registering templates
 
@@ -679,6 +710,8 @@ Registers all of the templates in the specified path. This command recursively s
 o3de.bat register --all-templates-path ALL_TEMPLATES_PATH
 ```
 
+<br>
+
 #### Registering restricted paths
 
 Registers the specified restricted directory to the `restricted` list in the `o3de_manifest.json` file. 
@@ -692,6 +725,9 @@ Registers all of the restricted paths in the specified path to the `restricted` 
 ```cmd
 o3de.bat register --all-restricted-path ALL_RESTRICTED_PATH
 ```
+
+<br>
+
 #### Registering repositories
 
 Registers the specified repository URI (uniform resource identifier) to the `repos` list in the `o3de_manifest.json` file.
@@ -705,6 +741,8 @@ Registers all of the repositories in the specified URI. This command recursively
 ```cmd
 o3de.bat register --all-repo-uri ALL_REPO_URI
 ```
+
+<br>
 
 #### Registering default folders
 
@@ -744,6 +782,8 @@ Register the specified folder as the default 3rd Party directory in the `o3de_ma
 o3de.bat register --default-third-party folder THIRD_PARTY_FOLDER_PATH
 ```
 
+<br>
+
 #### Updating the `o3de_manifest.json` file
 
 Updates the `o3de_manifest.json` file. This command validates all of the registered objects, and then removes invalid objects.
@@ -754,125 +794,127 @@ o3de.bat register --update
 
 
 ### Optional parameters
-`-h, --help`  
 
-Shows the help message.
+- **`-h, --help`**
 
-`--this-engine`  
+  Shows the help message.
 
-The engine that is running this o3de Python script.
+- **`--this-engine`**
 
-`-ep ENGINE_PATH, --engine-path ENGINE_PATH`  
+  The engine that is running this o3de Python script.
 
-The path to the engine that you want to register or deregister.
+- **`-ep ENGINE_PATH, --engine-path ENGINE_PATH`**
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`  
+  The path to the engine that you want to register or deregister.
 
-The path to the project that you want to register or deregister.
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-`-gp GEM_PATH, --gem-path GEM_PATH`  
+  The path to the project that you want to register or deregister.
 
-The path to the Gem that you want to register or deregister.
+- **`-gp GEM_PATH, --gem-path GEM_PATH`**
 
-`-es EXTERNAL_SUBDIRECTORY, --external-subdirectory EXTERNAL_SUBDIRECTORY`  
+  The path to the Gem that you want to register or deregister.
 
-The path to the the external subdirectory that you want to register or deregister.
+- **`-es EXTERNAL_SUBDIRECTORY, --external-subdirectory EXTERNAL_SUBDIRECTORY`**
 
-`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`  
+  The path to the the external subdirectory that you want to register or deregister.
 
-The path to the template that you want to register or deregister.
+- **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-`-rp RESTRICTED_PATH, --restricted-path RESTRICTED_PATH`  
+  The path to the template that you want to register or deregister.
 
-The path to the restricted folder that you want to register or deregister.
+- **`-rp RESTRICTED_PATH, --restricted-path RESTRICTED_PATH`**
 
-`-ru REPO_URI, --repo-uri REPO_URI`  
+  The path to the restricted folder that you want to register or deregister.
 
-The path to the repository that you want to register or deregister.
+- **`-ru REPO_URI, --repo-uri REPO_URI`**
 
-`-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`  
+  The path to the repository that you want to register or deregister.
 
-All of the engines in the specified folder that you want to register or deregister.
+- **`-aep ALL_ENGINES_PATH, --all-engines-path ALL_ENGINES_PATH`**
 
-`-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`  
+  All of the engines in the specified folder that you want to register or deregister.
 
-All of the projects in the specified folder that you want to register or deregister.
+- **`-app ALL_PROJECTS_PATH, --all-projects-path ALL_PROJECTS_PATH`**
 
-`-agp ALL_GEMS_PATH, --all-gems-path ALL_GEMS_PATH`  
+  All of the projects in the specified folder that you want to register or deregister.
 
-All of the Gems in the specified folder that you want to register or deregister.
+- **`-agp ALL_GEMS_PATH, --all-gems-path ALL_GEMS_PATH`**
 
-`-atp ALL_TEMPLATES_PATH, --all-templates-path ALL_TEMPLATES_PATH`  
+  All of the Gems in the specified folder that you want to register or deregister.
 
-All of the templates in the specified folder that you want to register or deregister.
+- **`-atp ALL_TEMPLATES_PATH, --all-templates-path ALL_TEMPLATES_PATH`**
 
-`-arp ALL_RESTRICTED_PATH, --all-restricted-path ALL_RESTRICTED_PATH`  
+  All of the templates in the specified folder that you want to register or deregister.
 
-All of the restricted folders in the specified folder that you want to register or deregister.
+- **`-arp ALL_RESTRICTED_PATH, --all-restricted-path ALL_RESTRICTED_PATH`**
 
-`-aru ALL_REPO_URI, --all-repo-uri ALL_REPO_URI`  
+  All of the restricted folders in the specified folder that you want to register or deregister.
 
-All of the repositories in the specified folder that you want to register or deregister.
+- **`-aru ALL_REPO_URI, --all-repo-uri ALL_REPO_URI`**
 
-`-def DEFAULT_ENGINES_FOLDER, --default-engines-folder DEFAULT_ENGINES_FOLDER`  
+  All of the repositories in the specified folder that you want to register or deregister.
 
-The path to the default engines folder that you want to register or deregister.
+- **`-def DEFAULT_ENGINES_FOLDER, --default-engines-folder DEFAULT_ENGINES_FOLDER`**
 
-`-dpf DEFAULT_PROJECTS_FOLDER, --default-projects-folder DEFAULT_PROJECTS_FOLDER`  
+  The path to the default engines folder that you want to register or deregister.
 
-The path to the default projects folder that you want to register or deregister.
+- **`-dpf DEFAULT_PROJECTS_FOLDER, --default-projects-folder DEFAULT_PROJECTS_FOLDER`**
 
-`-dgf DEFAULT_GEMS_FOLDER, --default-gems-folder DEFAULT_GEMS_FOLDER`  
+  The path to the default projects folder that you want to register or deregister.
 
-The path to the default Gems folder that you want to register or deregister.
+- **`-dgf DEFAULT_GEMS_FOLDER, --default-gems-folder DEFAULT_GEMS_FOLDER`**
 
-`-dtf DEFAULT_TEMPLATES_FOLDER, --default-templates-folder DEFAULT_TEMPLATES_FOLDER`  
+  The path to the default Gems folder that you want to register or deregister.
 
-The path to the default templates folder that you want to register or deregister.
+- **`-dtf DEFAULT_TEMPLATES_FOLDER, --default-templates-folder DEFAULT_TEMPLATES_FOLDER`**
 
-`-drf DEFAULT_RESTRICTED_FOLDER, --default-restricted-folder DEFAULT_RESTRICTED_FOLDER`  
+  The path to the default templates folder that you want to register or deregister.
 
-The path to the default restricted folder that you want to register or deregister.
+- **`-drf DEFAULT_RESTRICTED_FOLDER, --default-restricted-folder DEFAULT_RESTRICTED_FOLDER`**
 
-`-dtpf DEFAULT_THIRD_PARTY_FOLDER, --default-third-party-folder DEFAULT_THIRD_PARTY_FOLDER`  
+  The path to the default restricted folder that you want to register or deregister.
 
-The path to the default 3rd party folder that you want to register or deregister.
+- **`-dtpf DEFAULT_THIRD_PARTY_FOLDER, --default-third-party-folder DEFAULT_THIRD_PARTY_FOLDER`**
 
-`-u, --update`  
+  The path to the default 3rd party folder that you want to register or deregister.
 
-Refreshes the repository cache.
+- **`-u, --update`**
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`  
+  Refreshes the repository cache.
 
-Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
+- **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
+
+  Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
   
-`-r, --remove`  
+- **`-r, --remove`**
 
-Deregisters the specified entry.
+  Deregisters the specified entry.
 
-`-f, --force`  
+- **`-f, --force`**
 
-Forces the registration information to update, if any modifications were made.
+  Forces the registration information to update, if any modifications were made.
 
  
 **external-subdirectory:**  
 The following parameters are used with the `--external-subdirectory` option.
 
-`-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH, --external-subdirectory-engine-path EXTERNAL_SUBDIRECTORY_ENGINE_PATH`  
+- **`-esep EXTERNAL_SUBDIRECTORY_ENGINE_PATH, --external-subdirectory-engine-path EXTERNAL_SUBDIRECTORY_ENGINE_PATH`**
 
-If supplied, registers the external subdirectory with the `engine.json` file at the specified engine path.
+  If supplied, registers the external subdirectory with the `engine.json` file at the specified engine path.
 
-`-espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH, --external-subdirectory-project-path EXTERNAL_SUBDIRECTORY_PROJECT_PATH`
+- **`-espp EXTERNAL_SUBDIRECTORY_PROJECT_PATH, --external-subdirectory-project-path EXTERNAL_SUBDIRECTORY_PROJECT_PATH`**
 
-If supplied, registers the external subdirectory with the `project.json` file at the specified project path. 
+  If supplied, registers the external subdirectory with the `project.json` file at the specified project path. 
 
 
 ## `register-show`
 Shows the registered O3DE objects in the `o3de_manifest.json` file. 
 
+### Format
 
 ```cmd
-usage: o3de.py register-show [-h]
+register-show [-h]
                              [-te | -e | -p | -g | -t | -r | -rs | -ep | -eg | -et | -ers | -ees | -pg | -pt | -prs | -pes | -ap | -ag | -at | -ares | -aes]
                              [-v] [-pp PROJECT_PATH | -pn PROJECT_NAME]
                              [-ohf OVERRIDE_HOME_FOLDER]
@@ -1020,117 +1062,119 @@ o3de.bat register-show --repos
 
 ### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-te, --this-engine`
+- **`-te, --this-engine`**
 
-Outputs the current engine's path.
+  Outputs the current engine's path.
 
-`-e, --engines`
+- **`-e, --engines`**
 
-Outputs a list of the engines that are registered in the `o3de_manifest.json` file.
+  Outputs a list of the engines that are registered in the `o3de_manifest.json` file.
 
-`-p, --projects`
+- **`-p, --projects`**
 
-Outputs a list of the projects that are registered in the `o3de_manifest.json` file.
+  Outputs a list of the projects that are registered in the `o3de_manifest.json` file.
 
-`-g, --gems`
+- **`-g, --gems`**
 
-Outputs a list of the Gems that are registered in the `o3de_manifest.json` file.
+  Outputs a list of the Gems that are registered in the `o3de_manifest.json` file.
 
-`-t, --templates`
+- **`-t, --templates`**
 
-Outputs a list of the templates that are registered in the `o3de_manifest.json` file.
+  Outputs a list of the templates that are registered in the `o3de_manifest.json` file.
 
-`-r, --repos`
+- **`-r, --repos`**
 
-Outputs a list of the repos that are registered in the `o3de_manifest.json` file. Ignores repos.
+  Outputs a list of the repos that are registered in the `o3de_manifest.json` file. Ignores repos.
 
-`-rs, --restricted`
+- **`-rs, --restricted`**
 
-Outputs a list of the restricted directories that are registered in the `o3de_manifest.json` file.
+  Outputs a list of the restricted directories that are registered in the `o3de_manifest.json` file.
 
-`-ep, --engine-projects`
+- **`-ep, --engine-projects`**
 
-Outputs a list of the projects that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the projects that are registered in the current engine's `engine.json` file. Ignores repos.
 
-`-eg, --engine-gems`
+- **`-eg, --engine-gems`**
 
-Outputs a list of the gems that are registered in the current engine's `engine.json` file. Ignores repos.
+  Outputs a list of the gems that are registered in the current engine's `engine.json` file. Ignores repos.
 
-`-et, --engine-templates`
-Outputs a list of the templates that are registered in the current engine's `engine.json` file. Ignores repos.
+- **`-et, --engine-templates`**
 
-`-ers, --engine-restricted`
+  Outputs a list of the templates that are registered in the current engine's `engine.json` file. Ignores repos.
 
-Outputs a list of the restricted directories that are registered in the current engine's `engine.json` file.
+- **`-ers, --engine-restricted`**
 
-`-ees, --engine-external-subdirectories`
+  Outputs a list of the restricted directories that are registered in the current engine's `engine.json` file.
 
-Outputs a list of the external subdirectories that are registered in the current engine's `engine.json` file.
+- **`-ees, --engine-external-subdirectories`**
 
-`-pg, --project-gems`
+  Outputs a list of the external subdirectories that are registered in the current engine's `engine.json` file.
 
-Outputs a list of the gems that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+- **`-pg, --project-gems`**
 
-`-pt, --project-templates`
+  Outputs a list of the gems that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
-Outputs a list of the templates that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+- **`-pt, --project-templates`**
 
-`-prs, --project-restricted`
+  Outputs a list of the templates that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
-Outputs a list of the restricted directories that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+- **`-prs, --project-restricted`**
 
-`-pes, --project-external-subdirectories`
+  Outputs a list of the restricted directories that are registered with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
-Outputs a list of the external subdirectories register with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
+- **`-pes, --project-external-subdirectories`**
 
-`-ap, --all-projects`
+  Outputs a list of the external subdirectories register with the specified project's `project.json` file. You must specify the project using the `-pp` or `-pn` options..
 
-Outputs all of the projects that are registered in the `o3de_manifest.json` file and the current engine's `engine.json`. Ignores repos.
+- **`-ap, --all-projects`**
 
-`-ag, --all-gems`
+  Outputs all of the projects that are registered in the `o3de_manifest.json` file and the current engine's `engine.json`. Ignores repos.
 
-Outputs all of the gems that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos
+- **`-ag, --all-gems`**
 
-`-at, --all-templates`
+  Outputs all of the gems that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos
 
-Outputs all of the templates that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos.
+- **`-at, --all-templates`**
 
-`-ares, --all-restricted`
+  Outputs all of the templates that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file. Ignores repos.
 
-Outputs all restricted directory that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
+- **`-ares, --all-restricted`**
 
-`-aes, --all-external-subdirectories`
+  Outputs all of the restricted directories that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
-Outputs all external subdirectories that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
+- **`-aes, --all-external-subdirectories`**
 
-`-v, --verbose`
+  Outputs all of the external subdirectories that are registered in the `o3de_manifest.json` file and the current engine's `engine.json` file.
 
-If verbose > 0, outputs the contents of the specified files.
+- **`-v, --verbose`**
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+  If verbose > 0, outputs the contents of the specified files.
 
-The path to a project.
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+  The path to a project.
 
-The name of a project.
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`  
+  The name of a project.
 
-Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
+- **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
+
+  Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 
 ## `get-registered`
-ShowS the registered O3DE object's path that is mapped to the specified name.
+Shows the registered O3DE object's path that is mapped to the specified name.
 
+### Format
 
 ```cmd
-usage: o3de.py get-registered [-h]
+get-registered [-h]
                     (-en ENGINE_NAME | -pn PROJECT_NAME | -gn GEM_NAME | -tn TEMPLATE_NAME | -df {engines,projects,gems,templates,restricted} | -rn REPO_NAME | -rsn RESTRICTED_NAME)
                     [-ohf OVERRIDE_HOME_FOLDER]
 ```
@@ -1204,51 +1248,53 @@ o3de.bat get-registered --default-folder restricted
 ```
 
 
-### Optional Parameters
+### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-Shows the help message.
+  Shows the help message.
 
-`-en ENGINE_NAME, --engine-name ENGINE_NAME`
+- **`-en ENGINE_NAME, --engine-name ENGINE_NAME`**
 
-The name of an engine.
+  The name of an engine.
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-The name of a project.
+  The name of a project.
 
-`-gn GEM_NAME, --gem-name GEM_NAME`
+- **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-The name of a Gem.
+  The name of a Gem.
 
-`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`
+- **`-tn TEMPLATE_NAME, --template-name TEMPLATE_NAME`**
 
-The name of a template.
+  The name of a template.
 
-`-df {engines,projects,gems,templates,restricted}, --default-folder {engines,projects,gems,templates,restricted}`
+- **`-df {engines,projects,gems,templates,restricted}, --default-folder {engines,projects,gems,templates,restricted}`**
 
-The default folders for engines, projects, Gems, templates, and restricted folders in O3DE.
+  The default folders for engines, projects, Gems, templates, and restricted folders in O3DE.
 
-`-rn REPO_NAME, --repo-name REPO_NAME`
+- **`-rn REPO_NAME, --repo-name REPO_NAME`**
 
-The name of a repository. 
+  The name of a repository. 
 
-`-rsn RESTRICTED_NAME, --restricted-name RESTRICTED_NAME`
+- **`-rsn RESTRICTED_NAME, --restricted-name RESTRICTED_NAME`**
 
-The name of a restricted folder.
+  The name of a restricted folder.
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+- **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
 
-Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
+  Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 ## `enable-gem`
 
 Enables the Gem in your project, so you can use the assets or code the Gem provides. When you enable a Gem, this command adds the Gem's name to your project's `Code/enabled_gems.cmake` file, which adds the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
 
+### Format
+
 ```cmd
-usage: o3de.py enable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+enable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
                           (-gp GEM_PATH | -gn GEM_NAME)
                           [-egf ENABLED_GEM_FILE] [-ohf OVERRIDE_HOME_FOLDER]
 ```
@@ -1259,46 +1305,45 @@ usage: o3de.py enable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
 o3de.bat enable-gem -gp GEM_PATH -pp PROJECT_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
 
-`-h, --help`
+- **`-h, --help`**
 
-show this help message and exit
+  Shows the help message.
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-The path to the project.
+  The path to the project.
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-The name of the project.
+  The name of the project.
 
-`-gp GEM_PATH, --gem-path GEM_PATH`
+- **`-gp GEM_PATH, --gem-path GEM_PATH`**
 
-The path to the gem.
+  The path to the gem.
 
-`-gn GEM_NAME, --gem-name GEM_NAME`
+- **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-The name of the gem.
+  The name of the gem.
 
-`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`
+- **`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`**
 
-The cmake enabled_gem file in which the gem names are
-specified.If not specified it will assume
-enabled_gems.cmake
+  The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+- **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
 
-By default the home folder is the user folder,
-override it to this folder.
+  Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 ## `disable-gem`
 
 Disables the Gem in your project. When you disable a Gem, this command removes the Gem from the project's `Code/enabled_gems.cmake` file, which removes the Gem as a build and load dependency of your project's **Game Launcher**, the **Editor**, and the **Asset Processor**.
 
+### Format
+
 ```cmd
-usage: o3de.py disable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
+disable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
                 (-gp GEM_PATH | -gn GEM_NAME)
                 [-egf ENABLED_GEM_FILE] [-ohf OVERRIDE_HOME_FOLDER]
 ```
@@ -1309,34 +1354,35 @@ usage: o3de.py disable-gem [-h] (-pp PROJECT_PATH | -pn PROJECT_NAME)
 o3de.bat disable-gem -gp GEM_PATH -pp PROJECT_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
 
-`-h, --help`
-Shows the help message.
+- **`-h, --help`**
 
-`-pp PROJECT_PATH, --project-path PROJECT_PATH`
+  Shows the help message.
 
-The path to the project.
+- **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 
-`-pn PROJECT_NAME, --project-name PROJECT_NAME`
+  The path to the project.
 
-The name of the project.
+- **`-pn PROJECT_NAME, --project-name PROJECT_NAME`**
 
-`-gp GEM_PATH, --gem-path GEM_PATH`
+  The name of the project.
 
-The path to the Gem.
+- **`-gp GEM_PATH, --gem-path GEM_PATH`**
 
-`-gn GEM_NAME, --gem-name GEM_NAME`
+  The path to the Gem.
 
-The name of the Gem.
+- **`-gn GEM_NAME, --gem-name GEM_NAME`**
 
-`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`
+  The name of the Gem.
 
-The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
+- **`-egf ENABLED_GEM_FILE, --enabled-gem-file ENABLED_GEM_FILE`**
 
-`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`
+  The CMake file that manages the list of Gems that are enabled. When disabling a Gem, this command removes the Gem from the specified file. If not specified, this command uses the `Code/enabled_gem.cmake` file.
 
-Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
+- **`-ohf OVERRIDE_HOME_FOLDER, --override-home-folder OVERRIDE_HOME_FOLDER`**
+
+  Overrides the default home folder with the specified folder. By default, the home folder is the user folder. 
 
 
 <!-- ## edit-project-properties
@@ -1344,7 +1390,7 @@ Overrides the default home folder with the specified folder. By default, the hom
 Edits a set of fields within a manifest file. 
 
 ```cmd
-usage: o3de.py edit-project-properties [-h]
+edit-project-properties [-h]
                         (-pp PROJECT_PATH | -pn PROJECT_NAME)
                         [-pnn PROJECT_NEW_NAME]
                         [-po PROJECT_ORIGIN]
@@ -1439,9 +1485,10 @@ Sets the project's icon resource. -->
 
 Creates a *secure hash algorithm* (SHA-256). This command outputs the specified file path and writes the value to the `sha256` field in the specified JSON file. 
 
+### Format
 
 ```cmd
-usage: o3de.py sha256 [-h] -f FILE_PATH [-j JSON_PATH]
+sha256 [-h] -f FILE_PATH [-j JSON_PATH]
 ```
 
 ### Usage
@@ -1450,13 +1497,12 @@ usage: o3de.py sha256 [-h] -f FILE_PATH [-j JSON_PATH]
 o3de.bat sha256 --file-path FILE_PATH --json-path JSON_PATH
 ```
 
-### Optional Parameters
+### Optional parameters
 
-`-f FILE_PATH, --file-path FILE_PATH`
+- **`-f FILE_PATH, --file-path FILE_PATH`**
 
-The path to the O3DE object.
+  The path to the O3DE object.
 
-`-j JSON_PATH, --json-path JSON_PATH`
+- **`-j JSON_PATH, --json-path JSON_PATH`**
 
-The path to the O3DE object's JSON file that you want to add the "sha256" element to.
-
+  The path to the O3DE object's JSON file that you want to add the "sha256" element to.


### PR DESCRIPTION
The CLI Reference page is a reference guide for the CLI commands that are provided by the `o3de` Python script. For each command, this page contains a description, usage examples, and a full list of parameters and their descriptions. 
