### PR TITLE
LYN-5183 | Article ToC rendering at bottom of pages

### DIFF
--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -10,17 +10,17 @@
           <div class="col-12 col-md-12 col-xl-12 order-1 order-xl-1">
           {{ partial "single-header.html" . }}
           </div>
-          <div class="col order-3 order-xl-2">
-            <h1 class="title">{{ .Page.Title | markdownify }}</h1>
-            {{ partial "docs/content.html" . }}  
-            <hr class="mt-5" />   
-            {{ partial "footer-content.html" . }}
-          </div>
           {{ if and (ge (len .TableOfContents) 100) (ne .Params.toc "false") }}
             <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
               {{ partial "docs/docs-nav.html" . }}
             </div>
           {{ end }}
+          <div class="col-12 col-xl-10 order-3 order-xl-2">
+            <h1 class="title">{{ .Page.Title | markdownify }}</h1>
+            {{ partial "docs/content.html" . }}  
+            <hr class="mt-5" />   
+            {{ partial "footer-content.html" . }}
+          </div>
         </div>
       </section>
     </section>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -10,17 +10,17 @@
           <div class="col-12 col-md-12 col-xl-12 order-1 order-xl-1">
           {{ partial "single-header.html" . }}
           </div>
-          <div class="col order-3 order-xl-2">
-            <h1 class="title">{{ .Page.Title | markdownify }}</h1>
-            {{ partial "docs/content.html" . }}  
-            <hr class="mt-5" />   
-            {{ partial "footer-content.html" . }}
-          </div>
           {{ if and (ge (len .TableOfContents) 100) (ne .Params.toc "false") }}
             <div class="col-12 col-xl-2 pt-5 order-2 order-xl-3">
               {{ partial "docs/docs-nav.html" . }}
             </div>
           {{ end }}
+          <div class="col-12 col-xl-10 order-3 order-xl-2">
+            <h1 class="title">{{ .Page.Title | markdownify }}</h1>
+            {{ partial "docs/content.html" . }}  
+            <hr class="mt-5" />   
+            {{ partial "footer-content.html" . }}
+          </div>
         </div>
       </section>
     </section>


### PR DESCRIPTION
Fix for bug where docs pages with pre/code boxes would push the right ToC box to the bottom of the page.

Before
![image](https://user-images.githubusercontent.com/82231674/126711447-ab092f28-bca9-46c8-9af7-1d133ac4d513.png)

After
![image](https://user-images.githubusercontent.com/82231674/126711474-2a779d11-e4d3-43b5-9b55-ba5ff18ceeae.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>