### PR TITLE
Adding instructions on how to Create an Asset-Only Gem

### DIFF
--- a/content/docs/user-guide/gems/development/creating/_index.md
+++ b/content/docs/user-guide/gems/development/creating/_index.md
@@ -14,13 +14,13 @@ Although you can create a Gem manually by creating all of the files yourself, it
 o3de create-gem -gp <path to create gem at>
 ```
 
-This will create your Gem with a standard file structure and CMake files created from templates.
+This will create your Gem with a standard file structure and CMake files created from [templates](https://github.com/o3de/o3de/tree/development/Templates).
 
 ## Gem Assets
 
 Each Gem has an `Assets` directory that can contain models, textures, scripts, animations, and more. Asset files are accessed the same way as they are in a game project. O3DE uses this root directory to find the asset file path. For example, when O3DE looks for the `textures/rain/rainfall_ddn.tif` file, it looks in the `<GemName>/Assets/textures/rain/` directory.
 
-## Gem Code
+## Gem Code (Optional)
 
 Gem code can be contained in any directory that is picked up by the `CMakeLists.txt` file of the Gem, although, by convention, Gems with only one source module
 use `Code` for the directory name.
@@ -45,3 +45,18 @@ Your `CMakeLists.txt` file is like any other CMake file. When you create it, kee
   This will be the active target during the invocation of your Gem's `CMakeLists.txt`.
 * You can use the functions available in the core O3DE build system. See the contents of the `cmake` directory in source.
 * Avoid the use of `file(DOWNLOAD ...)`. The package system of O3DE is a robust replacement, and should be used instead.
+
+# Creating an Asset-Only Gem
+
+When a gem is created using the o3de `o3de create-gem -gp <path to create gem at>` command, by default it creates a Gem that can used for packaging code and assets.
+This Gem is actually created using the "DefaultGem" template.
+There is a way to create a gem that is only meant for providing asset only and not code.
+This can can be done by specifying the "AssetGem" template through the `create-gem` command
+```cmd
+o3de create-gem -gp <path to create gem at> -tn AssetGem
+# or
+o3de create-gem -gp <path to create gem at> -tp <engine-root>\Templates\AssetGem
+```
+
+## Gem Templates
+The list of Gem Templates that are provided with O3DE can be found in the [Templates](https://github.com/o3de/o3de/tree/development/Templates) directory in the main O3DE repo

--- a/content/docs/user-guide/gems/development/creating/_index.md
+++ b/content/docs/user-guide/gems/development/creating/_index.md
@@ -50,15 +50,11 @@ Your `CMakeLists.txt` file is like any other CMake file. When you create it, kee
 
 # Creating an Asset-Only Gem
 
-When a gem is created using the o3de `o3de create-gem -gp <path to create gem at>` command, by default it creates a Gem that can used for packaging code and assets.
-This Gem is actually created using the "DefaultGem" template.
-There is a way to create a gem that is only meant for providing asset only and not code.
-This can can be done by specifying the "AssetGem" template through the `create-gem` command
-```cmd
-o3de create-gem -gp <path to create gem at> -tn AssetGem
-# or
-o3de create-gem -gp <path to create gem at> -tp <engine-root>\Templates\AssetGem
-```
+When you create a Gem without a specified template by using the command `o3de create-gem -gp <path to create a gem at>`, it's created from the "DefaultGem" template. This creates a Gem for packaging both code and assets. You can also create a Gem that provides only assets by specifying the "AssetGem" template through the `create-gem` command:
 
+```cmd
+o3de create-gem --gem-path <path to create gem at> --template-name AssetGem
+# or
+o3de create-gem --gem-path <path to create gem at> --template-path <engine-root>\Templates\AssetGem
 ## Gem Templates
-The list of Gem Templates that are provided with O3DE can be found in the [Templates](https://github.com/o3de/o3de/tree/development/Templates) directory in the main O3DE repo
+O3DE provides a list of Gem templates, which can be found in the [Templates](https://github.com/o3de/o3de/tree/development/Templates) directory in the O3DE repository.

--- a/content/docs/user-guide/gems/development/creating/_index.md
+++ b/content/docs/user-guide/gems/development/creating/_index.md
@@ -16,6 +16,8 @@ o3de create-gem -gp <path to create gem at>
 
 This will create your Gem with a standard file structure and CMake files created from [templates](https://github.com/o3de/o3de/tree/development/Templates).
 
+For more information on how to use the `o3de` tool, refer to [Project Configuration CLI Reference](/docs/user-guide/project-config/cli-reference/)
+
 ## Gem Assets
 
 Each Gem has an `Assets` directory that can contain models, textures, scripts, animations, and more. Asset files are accessed the same way as they are in a game project. O3DE uses this root directory to find the asset file path. For example, when O3DE looks for the `textures/rain/rainfall_ddn.tif` file, it looks in the `<GemName>/Assets/textures/rain/` directory.

--- a/content/docs/user-guide/gems/development/creating/_index.md
+++ b/content/docs/user-guide/gems/development/creating/_index.md
@@ -16,7 +16,7 @@ o3de create-gem -gp <path to create gem at>
 
 This will create your Gem with a standard file structure and CMake files created from [templates](https://github.com/o3de/o3de/tree/development/Templates).
 
-For more information on how to use the `o3de` tool, refer to [Project Configuration CLI Reference](/docs/user-guide/project-config/cli-reference/)
+For more information on how to use the `o3de` tool, refer to [Project Configuration CLI Reference](/docs/user-guide/project-config/cli-reference/).
 
 ## Gem Assets
 
@@ -48,7 +48,7 @@ Your `CMakeLists.txt` file is like any other CMake file. When you create it, kee
 * You can use the functions available in the core O3DE build system. See the contents of the `cmake` directory in source.
 * Avoid the use of `file(DOWNLOAD ...)`. The package system of O3DE is a robust replacement, and should be used instead.
 
-# Creating an Asset-Only Gem
+## Creating an Asset-Only Gem
 
 When you create a Gem without a specified template by using the command `o3de create-gem -gp <path to create a gem at>`, it's created from the "DefaultGem" template. This creates a Gem for packaging both code and assets. You can also create a Gem that provides only assets by specifying the "AssetGem" template through the `create-gem` command:
 
@@ -56,5 +56,8 @@ When you create a Gem without a specified template by using the command `o3de cr
 o3de create-gem --gem-path <path to create gem at> --template-name AssetGem
 # or
 o3de create-gem --gem-path <path to create gem at> --template-path <engine-root>\Templates\AssetGem
+```
+
 ## Gem Templates
+
 O3DE provides a list of Gem templates, which can be found in the [Templates](https://github.com/o3de/o3de/tree/development/Templates) directory in the O3DE repository.


### PR DESCRIPTION
A new section has been added that provides the o3de.py script commands on how to create an asset-only gem.

It also gives insight that the "DefaultGem" template is being used to Create a Gem normally.

resolves #781

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>