### PR TITLE
User Guide banner fix 1: Includes main _index, /appendix, and /assets…

### DIFF
--- a/content/docs/user-guide/_index.md
+++ b/content/docs/user-guide/_index.md
@@ -10,8 +10,6 @@ guide_img: "/images/user-guide/guide_img.png"
 primary: true
 ---
 
-{{< preview-new >}}
-
 Welcome to the O3DE User Guide! This documentation contains information and guidance for users working on an O3DE project.
 
 Read about [the features provided by Open 3D Engine](/docs/welcome-guide/features-intro.md).
@@ -37,7 +35,7 @@ Read about [the features provided by Open 3D Engine](/docs/welcome-guide/feature
 | Documentation                        | Details |
 |--------------------------------------|---------|
 | [Asset file types](appendix/asset-file-types.md) | Reference for the asset file types supported in O3DE by default. |
-| [Command-line tools](appendix/command-line-tools.md) | Reference for the O3DE tools available from the command line. |
 | [Console variable reference](appendix/cvars/) | Reference for the O3DE console variables. |
-| [File format support](appendix/file-formats.md) | Reference for file formats supported in O3DE by default. |
 | [Glossary](appendix/glossary.md) | Common terms and concepts used in O3DE development. |
+<!--| [File format support](appendix/file-formats.md) | Reference for file formats supported in O3DE by default. | DRAFT TOPIC -->
+<!--| [Command-line tools](appendix/command-line-tools.md) | Reference for the O3DE tools available from the command line. | DRAFT TOPIC -->

--- a/content/docs/user-guide/appendix/_index.md
+++ b/content/docs/user-guide/appendix/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Appendix
-date: 2021-03-04
 weight: 5000
 draft: true
 ---

--- a/content/docs/user-guide/appendix/_index.md
+++ b/content/docs/user-guide/appendix/_index.md
@@ -2,4 +2,5 @@
 title: Appendix
 date: 2021-03-04
 weight: 5000
+draft: true
 ---

--- a/content/docs/user-guide/appendix/asset-file-types.md
+++ b/content/docs/user-guide/appendix/asset-file-types.md
@@ -4,8 +4,6 @@ linktitle: Asset file types
 title: 'O3DE Asset File Types'
 ---
 
-{{< preview-migrated >}}
-
 See the following tables for supported asset data file types in O3DE.
 
 O3DE supports the `.xml` file format and the following image file formats:

--- a/content/docs/user-guide/appendix/available-ebus.md
+++ b/content/docs/user-guide/appendix/available-ebus.md
@@ -4,8 +4,6 @@ title: Common Tasks, EBuses, and Handlers
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 The following are some common game programming tasks and the EBuses and handlers that you can use to implement them.
 
 ## Detect Mouse, Keyboard, or Other Button Events 

--- a/content/docs/user-guide/appendix/command-line-tools.md
+++ b/content/docs/user-guide/appendix/command-line-tools.md
@@ -1,6 +1,5 @@
 ---
 title: "Command line tool reference"
-date: 2021-03-02T00:23:56-05:00
 draft: true
 ---
 

--- a/content/docs/user-guide/appendix/command-line-tools.md
+++ b/content/docs/user-guide/appendix/command-line-tools.md
@@ -1,7 +1,6 @@
 ---
 title: "Command line tool reference"
 date: 2021-03-02T00:23:56-05:00
+draft: true
 ---
-
-{{< preview-migrated >}}
 

--- a/content/docs/user-guide/appendix/cvars/_index.md
+++ b/content/docs/user-guide/appendix/cvars/_index.md
@@ -1,6 +1,5 @@
 ---
 title: CVARs
-date: 2021-03-04
 ---
 
 Console variables (CVARs) can be used to set various editor and runtime options in O3DE.

--- a/content/docs/user-guide/appendix/cvars/_index.md
+++ b/content/docs/user-guide/appendix/cvars/_index.md
@@ -2,3 +2,7 @@
 title: CVARs
 date: 2021-03-04
 ---
+
+Console variables (CVARs) can be used to set various editor and runtime options in O3DE.
+
+[Debug CVARs](./debugging)

--- a/content/docs/user-guide/appendix/cvars/debugging.md
+++ b/content/docs/user-guide/appendix/cvars/debugging.md
@@ -1,6 +1,6 @@
 ---
 description: ' Debug and fix performance issues for Open 3D Engine. '
-title: Debugging Issues
+title: Debug CVARs
 ---
 
 O3DE provides the following built-in debugging and profiling tools that you can use to locate and fix performance issues.

--- a/content/docs/user-guide/appendix/cvars/debugging.md
+++ b/content/docs/user-guide/appendix/cvars/debugging.md
@@ -3,8 +3,6 @@ description: ' Debug and fix performance issues for Open 3D Engine. '
 title: Debugging Issues
 ---
 
-{{< preview-migrated >}}
-
 O3DE provides the following built-in debugging and profiling tools that you can use to locate and fix performance issues.
 
 + [Cinematics debugging](/docs/user-guide/visualization/cinematics/debugging) - Debug cinematics issues.

--- a/content/docs/user-guide/appendix/file-formats.md
+++ b/content/docs/user-guide/appendix/file-formats.md
@@ -1,6 +1,5 @@
 ---
 title: "File format definitions"
-date: 2021-03-02T00:23:56-05:00
 draft: true
 ---
 

--- a/content/docs/user-guide/appendix/file-formats.md
+++ b/content/docs/user-guide/appendix/file-formats.md
@@ -1,7 +1,6 @@
 ---
 title: "File format definitions"
 date: 2021-03-02T00:23:56-05:00
+draft: true
 ---
-
-{{< preview-migrated >}}
 

--- a/content/docs/user-guide/appendix/glossary.md
+++ b/content/docs/user-guide/appendix/glossary.md
@@ -4,8 +4,6 @@ weight: 1000
 toc: true
 ---
 
-{{< preview-new >}}
-
 ### actor
 A specialized [entity](#entity) that is the basis for characters in a game.
 

--- a/content/docs/user-guide/assets/_index.md
+++ b/content/docs/user-guide/assets/_index.md
@@ -6,10 +6,6 @@ title: Working with assets in O3DE
 weight: 700
 ---
 
-{{< preview-migrated >}}
-
-## Working with assets in O3DE 
-
 Learn how to manage, process, and package the assets for your O3DE game. This documentation covers the O3DE Asset Browser tool, the asset pipeline, managing and organizing game assets, and packaging (bundling) game assets for delivery.
 
 

--- a/content/docs/user-guide/assets/asset-editor.md
+++ b/content/docs/user-guide/assets/asset-editor.md
@@ -2,7 +2,6 @@
 title: "Asset Editor"
 date: 2021-03-02T00:23:57-05:00
 weight: 50
+draft: true
 ---
-
-{{< preview-migrated >}}
 

--- a/content/docs/user-guide/assets/builder/_index.md
+++ b/content/docs/user-guide/assets/builder/_index.md
@@ -5,8 +5,6 @@ title: Python Asset Builder gem
 weight: 300
 ---
 
-{{< preview-migrated >}}
-
 With **Python Asset Builder**, you can create Python scripts that process custom assets that are produced from content creation tools such as Maya and Houdini, or any content tool with a known file format.
 
 For information on using **Python Asset Builder**, see [Process custom assets with Python Asset Builder](/docs/user-guide/assets/builder/intro.md).

--- a/content/docs/user-guide/assets/builder/bootstrap.md
+++ b/content/docs/user-guide/assets/builder/bootstrap.md
@@ -4,8 +4,6 @@ title: Create or modify a bootstrap script
 weight: 200
 ---
 
-{{< preview-migrated >}}
-
 To make your Python Asset Builder script available to the asset processing system, you must add a `bootstrap.py` file to the path or modify an existing `bootstrap.py` file. We recommend you use a location that is relative to where your Python Asset Builder scripts will be stored, such as one of the following:
 + In your project: `Editor\Scripts\bootstrap.py`
 + In a Gem: `Editor\Scripts\bootstrap.py`

--- a/content/docs/user-guide/assets/builder/create-job.md
+++ b/content/docs/user-guide/assets/builder/create-job.md
@@ -5,8 +5,6 @@ title: Create jobs with Python Asset Builder
 weight: 400
 ---
 
-{{< preview-migrated >}}
-
 When you create a job with the Python Asset Builder, the callback for `OnCreateJobsRequest` will be called with a `CreateJobsRequest` in a tuple. The callback will return a `CreateJobsResponse` as the response using the data inside the request.
 
 **Contents**

--- a/content/docs/user-guide/assets/builder/intro.md
+++ b/content/docs/user-guide/assets/builder/intro.md
@@ -5,8 +5,6 @@ title: Process custom assets with Python Asset Builder
 weight: 100
 ---
 
-{{< preview-migrated >}}
-
  With Python Asset Builder, you can create Python scripts that process custom assets produced from content creation tools such as Maya and Houdini, or any content tool with a known file format.
 
 To use Python Asset Builder you must enable the [Python Asset Builder gem](/docs/user-guide/assets/builder/_index.md).

--- a/content/docs/user-guide/assets/builder/process-job.md
+++ b/content/docs/user-guide/assets/builder/process-job.md
@@ -5,8 +5,6 @@ title: Process job with Python Asset Builder
 weight: 500
 ---
 
-{{< preview-migrated >}}
-
 **Asset Processor** calls the registered callback when it has a job for the builder to begin processing. The callback processes the source asset file, performs all the work inside the temporary directory, creates at least one product asset file, registers the product asset files via a `JobProduct` entry inside a `ProcessJobResponse` instance, and returns a success value inside the `ProcessJobResponse`.
 
 **Contents**

--- a/content/docs/user-guide/assets/builder/register.md
+++ b/content/docs/user-guide/assets/builder/register.md
@@ -4,8 +4,6 @@ title: Register a Python Asset Builder
 weight: 300
 ---
 
-{{< preview-migrated >}}
-
  A Python Asset Builder script must register a file pattern and unique builder ID for the asset builder. To describe the asset builder, use `azlmbr.asset.builder.AssetBuilderDesc`. To bind the script to the asset building process, use `azlmbr.asset.builder.PythonAssetBuilderRequestBus`. You can register the asset builder by a file extension pattern such as `*.myasset` or by a folder and file regular expression pattern such as `^[a-zA-Z]:\\MyAssets[\\\S|*\S]?.*$)`.
 
 When the Python Asset Builder is successfully registered, a handler for the builder ID is used to handle asset builder events to create jobs and process jobs. The script creates a `azlmbr.asset.builder.PythonBuilderNotificationBusHandler` in the module to add the callback handlers.

--- a/content/docs/user-guide/assets/fbx-settings/_index.md
+++ b/content/docs/user-guide/assets/fbx-settings/_index.md
@@ -6,8 +6,6 @@ title: Customize FBX asset export with FBX Settings
 weight: 200
 ---
 
-{{< preview-migrated >}}
-
 Meshes, actors, PhysX colliders, and motions created in third-party content creation tools must be exported to a runtime format for your project. To export your assets to O3DE, save the assets from your content application as `.fbx` files. Then, place the `.fbx` files in one of the asset directories of your project. O3DE uses `.fbx` as an intermediate file format because most modeling and animation applications can read and create `.fbx` files.
 
 **Topics**

--- a/content/docs/user-guide/assets/fbx-settings/actor-export.md
+++ b/content/docs/user-guide/assets/fbx-settings/actor-export.md
@@ -3,8 +3,6 @@ description: ' Export actors from .fbx files with FBX Settings to Open 3D Engine
 title: FBX Settings actor export
 ---
 
-{{< preview-migrated >}}
-
 **Actors** contain geometry that has a skeleton and skinning data. An **Actor** is not necessarily a character. Assets that use a skeleton and skinning data to drive animation such as weapons, machines, and foliage, are **Actors**. **Actors** can be animated through keyframe animation imported as **Motions** or through PhysX simulation and other dynamic solvers such as **Touch Bending**.
 
 ## Export an actor 

--- a/content/docs/user-guide/assets/fbx-settings/import/_index.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Import
 date: 2021-03-04
+draft: true
 ---

--- a/content/docs/user-guide/assets/fbx-settings/import/_index.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/_index.md
@@ -1,5 +1,4 @@
 ---
 title: Import
-date: 2021-03-04
 draft: true
 ---

--- a/content/docs/user-guide/assets/fbx-settings/import/create-skinned-meshes-best-practices.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/create-skinned-meshes-best-practices.md
@@ -4,8 +4,6 @@ description: ' See the best practices for working with skinned meshes actors for
 title: Creating Skinned Meshes for Actors
 ---
 
-{{< preview-migrated >}}
-
 Use the following best practices when you create your character for the **Animation Editor**. In O3DE, a character is a skinned mesh.
 
 ## Setting up the World Coordinate System and Root Joint 

--- a/content/docs/user-guide/assets/fbx-settings/import/export-actors-motons.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/export-actors-motons.md
@@ -4,8 +4,6 @@ description: ' See the best practices for exporting skinned meshes for actors fo
 title: Exporting Actors and Motions
 ---
 
-{{< preview-migrated >}}
-
 Use the following best practices when you export your skinned meshes using the **FBX Settings** tool.
 + If you use the z-up world coordinate system, use the following guidelines:
   + Ensure that your DCC scene is set to z for the up-axis world coordinate system.

--- a/content/docs/user-guide/assets/fbx-settings/import/export-skinned-meshes-troubleshooting.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/export-skinned-meshes-troubleshooting.md
@@ -3,8 +3,6 @@ description: ' You can troubleshoot your skinned meshes for Open 3D Engine. '
 title: Troubleshooting Skinned Meshes
 ---
 
-{{< preview-migrated >}}
-
 If your character's skinning appears visually broken in the **Animation Editor**, the following issues could be why:
 + The **Coordinate system change** modifier isn't identical for the `.actor` and `.motion` files
 + You might need to reset the bind pose

--- a/content/docs/user-guide/assets/fbx-settings/import/motion-additive.md
+++ b/content/docs/user-guide/assets/fbx-settings/import/motion-additive.md
@@ -3,8 +3,6 @@ description: ' Create additive animations in Open 3D Engine. '
 title: Creating Additive Animations
 ---
 
-{{< preview-migrated >}}
-
 Additive animations are animations that you can add as layers on top of a base animation. They are commonly used to add a partial-body animation to a full-body animation. Because additive animations do not interfere with base animation functionality, you can reuse the same base to create many variations in motion. Reusing the base also has the advantage of greatly reducing the overall asset count.
 
 Because additive animations preserve the underlying animation's style, they are useful for adding poses and animations to a character's upper body. For example, you can use additive animations to make a character breathe, look around, flinch, or change posture. This adds variety to the animations and avoids what might otherwise be a monotonous look.

--- a/content/docs/user-guide/assets/fbx-settings/mesh-export.md
+++ b/content/docs/user-guide/assets/fbx-settings/mesh-export.md
@@ -3,8 +3,6 @@ description: ' Export meshes from .fbx files with FBX Settings to Open 3D Engine
 title: FBX Settings mesh export
 ---
 
-{{< preview-migrated >}}
-
 **Meshes** contain geometry that doesn't have a skeleton and skinning data. These assets are also called *static* **Meshes**. Static meshes are most often used as props and environment objects, but can be used as interactive objects and even player avatars. Entities containing static meshes can be animated through scripts (*kinematics*) or PhysX simulation (*dynamics*).
 
 **Contents**

--- a/content/docs/user-guide/assets/fbx-settings/motion-export.md
+++ b/content/docs/user-guide/assets/fbx-settings/motion-export.md
@@ -3,8 +3,6 @@ description: ' Export motions from .fbx files with FBX Settings to Open 3D Engin
 title: FBX Settings motion export
 ---
 
-{{< preview-migrated >}}
-
 **Motions** contain keyframe animated sequences that can be sequenced and blended in **Animation Editor** and applied to actors to create behaviors. Motions must use identical skeleton hierarchies as their actor counterparts.
 
 ## Export a motion 

--- a/content/docs/user-guide/assets/fbx-settings/multiple-uv-sets.md
+++ b/content/docs/user-guide/assets/fbx-settings/multiple-uv-sets.md
@@ -3,8 +3,6 @@ description: ' Export multiple UV sets from .fbx files with FBX Settings to Open
 title: Multiple UV sets for meshes and actors
 ---
 
-{{< preview-migrated >}}
-
 You can use **FBX Settings** to import multiple UV sets. With multiple UV sets, you can apply a detail or blend layer map to your geometry using UV sets that are independent of the diffuse, normal, and spec UV sets. With multiple UV sets, you can also apply an animated glow that is independent of other texture maps on a mesh.
 
 ![\[Image NOT FOUND\]](/images/user-guide/fbx/anim-multi-uv-support.gif)

--- a/content/docs/user-guide/assets/fbx-settings/physx-export.md
+++ b/content/docs/user-guide/assets/fbx-settings/physx-export.md
@@ -3,8 +3,6 @@ description: ' Export PhysX colliders from .fbx files with FBX Settings to Open 
 title: FBX Settings PhysX export
 ---
 
-{{< preview-migrated >}}
-
 PhysX colliders are required by **Actors** and **Meshes** to perform collision detection, raycast hit detection, overlap testing, and PhysX simulation. It's possible to use simple parametric primitive shapes in the **PhysX collider** component to create PhysX colliders, but many situations require colliders that more closely resemble the render mesh than simple shapes.
 
 The **PhysX** tab in **FBX Settings** has many options to generate PhysX colliders that offer the best resolution and performance for any use scenario.

--- a/content/docs/user-guide/assets/fbx-settings/properties.md
+++ b/content/docs/user-guide/assets/fbx-settings/properties.md
@@ -4,8 +4,6 @@ description: ' Modify the export properties of your .fbx files with FBX Settings
 title: FBX Settings export properties
 ---
 
-{{< preview-migrated >}}
-
 **Topics**
 + [FBX Settings overview](#fbx-properties-overview)
 + [Modify FBX Settings](#fbx-properties-modify)

--- a/content/docs/user-guide/assets/fbx-settings/settings-actor-tab.md
+++ b/content/docs/user-guide/assets/fbx-settings/settings-actor-tab.md
@@ -3,8 +3,6 @@ description: null
 title: FBX Settings Actors tab
 ---
 
-{{< preview-migrated >}}
-
 Actors are assets with at least one bone and can contain one or more skinned meshes. By default, all actors in the `.fbx` file are processed. However, you can manually exclude individual actors within your `.fbx` file. You can also process multiple actors from a single `.fbx` file. Each **Actor group** produces its own `.actor` file. The processed runtime assets appear in **Asset Browser** as children of the `.fbx` file.
 
 **Contents**

--- a/content/docs/user-guide/assets/fbx-settings/settings-meshes-tab.md
+++ b/content/docs/user-guide/assets/fbx-settings/settings-meshes-tab.md
@@ -3,8 +3,6 @@ description: ' Open 3D Engine FBX Settings Meshes tab export properties and modi
 title: FBX Settings Meshes tab
 ---
 
-{{< preview-migrated >}}
-
 All meshes in the `.fbx` file are processed to a single runtime asset \(`.cgf`\) by default. In the **Meshes** tab, you can create mesh groups containing specific meshes from the `.fbx` file. Each **Mesh group** produces its own `.cgf` file. The processed runtime assets appear in **Asset Browser** as children of the `.fbx` file.
 
 **Contents**

--- a/content/docs/user-guide/assets/fbx-settings/settings-motions-tab.md
+++ b/content/docs/user-guide/assets/fbx-settings/settings-motions-tab.md
@@ -3,8 +3,6 @@ description: null
 title: FBX Settings Motions tab
 ---
 
-{{< preview-migrated >}}
-
 You can process animation sequences from a single `.fbx` file as **Motions**. Each **Motion** produces its own `.motion` file. The processed runtime assets appear in **Asset Browser** as children of the `.fbx` file.
 
 **Important**

--- a/content/docs/user-guide/assets/fbx-settings/settings-physx-tab.md
+++ b/content/docs/user-guide/assets/fbx-settings/settings-physx-tab.md
@@ -3,8 +3,6 @@ description: null
 title: FBX Settings PhysX tab
 ---
 
-{{< preview-migrated >}}
-
 In the **PhysX** tab, you can create **PhysX Mesh groups** to process collider assets for PhysX. Collider assets can be triangle meshes, or generated as primitives or convex meshes based on meshes contained in the `.fbx` file. Multiple **PhysX Mesh groups** can be processed from a single `.fbx` file. Each **PhysX Mesh group** produces its own `.pxmesh` file. The processed runtime assets appear in Asset Browser as children of the `.fbx` file.
 
 **Important**

--- a/content/docs/user-guide/assets/fbx-settings/settings-soft-naming.md
+++ b/content/docs/user-guide/assets/fbx-settings/settings-soft-naming.md
@@ -5,8 +5,6 @@ description: ' View and update the soft naming conventions for assets such as Lo
 title: FBX soft naming conventions
 ---
 
-{{< preview-migrated >}}
-
 You can use soft naming conventions when authoring assets in your content creation tools, such as Autodesk 3ds Max or Maya. Soft naming conventions are prefixes or suffixes that you add to either nodes in your scene or the `.fbx` file name. In O3DE, **Asset Processor** recognizes these soft naming conventions and then applies an action based on the specified soft naming convention.
 
 O3DE provides soft naming conventions as a convenience for content creators to automate steps that are typically done manually in **FBX Settings**. Depending on the soft naming conventions that you specify, **Asset Processor** automatically adds those modifiers to the scene settings.

--- a/content/docs/user-guide/assets/pipeline/_index.md
+++ b/content/docs/user-guide/assets/pipeline/_index.md
@@ -5,8 +5,6 @@ title: Working with the Asset Pipeline and asset files
 weight: 100
 ---
 
-{{< preview-migrated >}}
-
 The Asset Pipeline converts source art and other assets into OS-specific, game ready data. To prepare your game to ship, build all your game assets with the Asset Pipeline and package them with your game for your supported operating systems.
 
 The Asset Processor (AP) is a service that runs in the background and monitors a configurable set of input directories for changes in files. When it detects changes, it uses configurable rules to determine its next action. The objective is to end up with game-ready versions of all assets for each OS and each game directory in a location called the asset cache. The asset cache is kept separate from your input directory and can be automatically rebuilt entirely from your source assets by the Asset Processor.

--- a/content/docs/user-guide/assets/pipeline/asset-system-programming.md
+++ b/content/docs/user-guide/assets/pipeline/asset-system-programming.md
@@ -1,6 +1,5 @@
 ---
-description: ' Understand the workflow of Open 3D Engine's runtime asset system and learn
-  how to load prebuilt assets into a running instance of the engine. '
+description: Understand the workflow of Open 3D Engine's runtime asset system and learn how to load prebuilt assets into a running instance of the engine.
 title: Programming the O3DE AZCore Runtime Asset System
 ---
 

--- a/content/docs/user-guide/assets/pipeline/asset-system-programming.md
+++ b/content/docs/user-guide/assets/pipeline/asset-system-programming.md
@@ -1,10 +1,8 @@
 ---
-description: ' Understand the workflow of Open 3D Engine''s runtime asset system and learn
+description: ' Understand the workflow of Open 3D Engine's runtime asset system and learn
   how to load prebuilt assets into a running instance of the engine. '
 title: Programming the O3DE AZCore Runtime Asset System
 ---
-
-{{< preview-migrated >}}
 
 The O3DE Editor and O3DE runtime code use the AZCore runtime asset system to asynchronously stream and activate assets. This topic describes the workflow of the classes in the asset system and shows how to load already-built assets into a running instance of the engine.
 

--- a/content/docs/user-guide/assets/pipeline/asset-type-adding.md
+++ b/content/docs/user-guide/assets/pipeline/asset-type-adding.md
@@ -4,8 +4,6 @@ title: Adding an Asset Type to O3DE
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 When you develop a game, you might need to add a new kind of asset to O3DE. The new asset could be a configuration file, a game-specific data asset, or structured data for which you created an editor. This topic guides you through the process of adding a custom asset type to O3DE.
 
 For an overview of the O3DE asset system, see [Programming the O3DE AZCore Runtime Asset System](/docs/user-guide/assets/pipeline/asset-system-programming).

--- a/content/docs/user-guide/assets/pipeline/configuring-image-processing.md
+++ b/content/docs/user-guide/assets/pipeline/configuring-image-processing.md
@@ -5,8 +5,6 @@ title: Configuring Image Processing
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 Images or textures are automatically processed by Asset Processor, which makes them ready for O3DE game creation. When you place an image file anywhere within your O3DE directory, Asset Processor detects and converts the file to a game-ready asset. O3DE has several configuration files that specify settings for the conversion process, such as the colorspace to use, texture size, [whether to generate mip maps](/docs/userguide/assets/generating-mipmaps.md), and so on.
 
 You can [edit the configuration files](/docs/userguide/assets/creating-image-processing-presets#asset-pipeline-creating-presets-imagecompiler-rc) to create your own image processing presets. To use these presets, you append existing or customized suffixes to your image file names. Based on these file name suffixes, Asset Processor automatically uses the appropriate preset to convert the image.

--- a/content/docs/user-guide/assets/pipeline/configuring.md
+++ b/content/docs/user-guide/assets/pipeline/configuring.md
@@ -4,8 +4,6 @@ title: Configuring the Asset Pipeline
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 **Important**
 The Asset Builder SDK is now preferred over the legacy `rc.exe` program for adding asset types to the pipeline. Instead of using the `rc.exe` program, make a builder module that you derive from the `BuilderSDK`. These modules are self configuring. 
 

--- a/content/docs/user-guide/assets/pipeline/debugging.md
+++ b/content/docs/user-guide/assets/pipeline/debugging.md
@@ -3,8 +3,6 @@ description: ' Debug Asset Processor issues in Open 3D Engine '
 title: Debugging Asset Processor
 ---
 
-{{< preview-migrated >}}
-
 Use the following options to help debug Asset Processor issues.
 
 ## Viewing Asset Processor Log Files 

--- a/content/docs/user-guide/assets/pipeline/developers.md
+++ b/content/docs/user-guide/assets/pipeline/developers.md
@@ -4,8 +4,6 @@ description: ' Learn the asset identifiers and file paths that game engineers ne
 title: Asset IDs and File Paths
 ---
 
-{{< preview-migrated >}}
-
 Consult this section if you are a game engineer who needs to port older game code or develop new code or tools.
 
 ## File Path Aliases versus Asset IDs 

--- a/content/docs/user-guide/assets/pipeline/faster-scanning.md
+++ b/content/docs/user-guide/assets/pipeline/faster-scanning.md
@@ -4,8 +4,6 @@ description: ' Use Asset Processor''s Faster Scanning Mode to improve startup ti
 title: Enabling Asset Processor's Faster Scanning Mode
 ---
 
-{{< preview-migrated >}}
-
 Asset Processor's **Faster Scanning Mode** speeds up O3DE's startup scan by disabling checking for cache changes that occurred while Asset Processor was not running. This can save you time when processing many assets in your project.
 
 By default, **Faster Scanning Mode** is enabled. You can enable or disable this mode any time without restarting the Asset Processor, including during the scan. Asset Processor saves your preference between sessions.

--- a/content/docs/user-guide/assets/pipeline/game-sequence.md
+++ b/content/docs/user-guide/assets/pipeline/game-sequence.md
@@ -5,8 +5,6 @@ title: Game Startup Sequence
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 Compiled O3DE games start up in the following sequence:
 
 1. The game reads the `bootstrap.cfg` file, which must contain the following information at a minimum:

--- a/content/docs/user-guide/assets/pipeline/image-tool.md
+++ b/content/docs/user-guide/assets/pipeline/image-tool.md
@@ -5,8 +5,6 @@ title: Using the Resource Compiler Image Tool
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 Before you can use the Resource Compiler image tool, you must install RC Shell Commands.
 
 **Note**

--- a/content/docs/user-guide/assets/pipeline/job-dependency-reference.md
+++ b/content/docs/user-guide/assets/pipeline/job-dependency-reference.md
@@ -4,8 +4,6 @@ title: Job Dependency for Asset Pipeline
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 Manage dependencies for assets so that Asset Pipeline processes them in the correct order.
 
 In Asset Pipeline, you create asset builders using the Asset Builder SDK. The Asset Builder SDK processes your custom asset-type source files into game-ready files. The Asset Builder SDK is a separate executable from Asset Processor..

--- a/content/docs/user-guide/assets/pipeline/live-reloading.md
+++ b/content/docs/user-guide/assets/pipeline/live-reloading.md
@@ -5,8 +5,6 @@ title: Live Reloading and VFS
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 On the PC platform, live reloading does not require virtual file system (VFS), since the PC that is running the game is presumably also running the Asset Processor.
 
 On non-PC platforms, VFS is required for live reloading to work, because otherwise assets would need to be deployed onto the game device as part of live reloading, incurring platform-specific costs and different asset pipelines. VFS enables the same behavior across all platforms using the same workflow. For debugging purposes, you can also enable VFS on a PC and point it at a remote Asset Processor to serve assets.

--- a/content/docs/user-guide/assets/pipeline/mipmaps.md
+++ b/content/docs/user-guide/assets/pipeline/mipmaps.md
@@ -5,8 +5,6 @@ title: Generating Mip Maps
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 [Mip maps](/docs/user-guide/appendix/glossary#mip_map) are a sequence of optimized images made from one image. Each image is lower in resolution than the previous image by a power of two. Mip maps reduce the time and processing power it takes to render an image in a game. Lower resolution mip maps are used when the viewing distance is great enough that the loss of detail is not noticeable. Higher resolution mip maps are used when an object is close to the camera and needs to be displayed in detail.
 
 When you enable mip maps in O3DE, Resource Compiler automatically generates six mip maps for that image. The largest mip map is the original size of your image, and each progressive mip map is smaller by a power of two.

--- a/content/docs/user-guide/assets/pipeline/processor-remote-access.md
+++ b/content/docs/user-guide/assets/pipeline/processor-remote-access.md
@@ -4,8 +4,6 @@ description: ' How to add IP addresses for external devices (Android and iOS) to
 title: Adding IP Addresses to Allow Access to the Asset Processor and Remote Console
 ---
 
-{{< preview-migrated >}}
-
 The Asset Processor is a networked application that O3DE uses to build source assets into game engine ready assets. To ensure your external device can connect to the Asset Processor, you must add the IP address of the external device (Android or iOS) to the **allow\_list** in the `bootstrap.cfg` file.
 
 The Universal Remote Console is a networked application that O3DE uses to send commands and view output from the running game engine. To ensure remote console access to a running game instance on your external device, you must add the IP address of the computer that will run the remote console to the **log\_RemoteConsoleAllowedAddresses** list in the appropriate configuration file for your project:

--- a/content/docs/user-guide/assets/pipeline/processor-ui.md
+++ b/content/docs/user-guide/assets/pipeline/processor-ui.md
@@ -4,8 +4,6 @@ description: ' Learn the functions of each area of the Asset Processor interface
 title: 'Asset Processor Interface'
 ---
 
-{{< preview-migrated >}}
-
 The Asset Processor interface provides areas containing detailed information about the assets that it processes. These areas are shown in the following example.
 
 ![\[The main window of the O3DE Asset Processor. The window is annotated with markers that identify the visual components and features described below.\]](/images/user-guide/asset_processor/asset-processor-ui.png)

--- a/content/docs/user-guide/assets/pipeline/processor.md
+++ b/content/docs/user-guide/assets/pipeline/processor.md
@@ -4,8 +4,6 @@ description: ' Use Asset Processor in Open 3D Engine to detect and process new o
 title: Using Asset Processor
 ---
 
-{{< preview-migrated >}}
-
 Asset Processor is a utility that runs in the background to detect changes to your asset files. When Asset Processor detects new or updated asset files, it launches the Resource Compiler, processes the assets, and then places them in the cache. Asset Processor then notifies all running game or tool instances that the assets are updated. The game can then reload the updated assets.
 
 As part of Asset Processing, the Asset Processor generates and stores product and source dependencies . In this context, a dependency defines how a one product or source asset depends on another asset. A given asset may have 0 or more dependencies, and these dependencies are used by features such as the [Asset Bundler](/docs/user-guide/packaging/asset-bundler) in order to determine which assets must be included when you bundle your game for release.

--- a/content/docs/user-guide/assets/pipeline/using-image-naming-conventions.md
+++ b/content/docs/user-guide/assets/pipeline/using-image-naming-conventions.md
@@ -5,8 +5,6 @@ title: Using Image Naming Conventions
 draft: true
 ---
 
-{{< preview-migrated >}}
-
 You can use any existing or created image processing presets. To do this, append the suffix to the end of the file name before you add it to your O3DE directory.
 
 **Example**


### PR DESCRIPTION
…. Removed preview banners, set zero length topics to draft, commented out links to zero length topics in this PR, other minor fixes such as removing H2s that duplicate topic title.

Signed-off-by: Mike Cronin <mikecro@amazon.com>