### PR TITLE
Atom components | Update link to Atom Gem

### DIFF
--- a/content/docs/user-guide/components/reference/atom/_index.md
+++ b/content/docs/user-guide/components/reference/atom/_index.md
@@ -2,5 +2,4 @@
 title: Atom Components
 linktitle: Atom
 description: ' Using Atom lighting and rendering components in Open 3D Engine (O3DE). '
-toc: true
 ---

--- a/content/docs/user-guide/components/reference/atom/bloom.md
+++ b/content/docs/user-guide/components/reference/atom/bloom.md
@@ -5,8 +5,6 @@ description: "Open 3D Engine (O3DE) Bloom component reference."
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Bloom component** simulates real-world light bleeding, or glow.
 
 

--- a/content/docs/user-guide/components/reference/atom/bloom.md
+++ b/content/docs/user-guide/components/reference/atom/bloom.md
@@ -12,7 +12,7 @@ The **Bloom component** simulates real-world light bleeding, or glow.
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/decal.md
+++ b/content/docs/user-guide/components/reference/atom/decal.md
@@ -5,8 +5,6 @@ description: "Open 3D Engine (O3DE) Decal component reference."
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Decal** component enables an entity to project a material onto a mesh. A large number of overlapping decals can be applied to a single mesh.
 
 

--- a/content/docs/user-guide/components/reference/atom/deferred-fog.md
+++ b/content/docs/user-guide/components/reference/atom/deferred-fog.md
@@ -12,7 +12,7 @@ The **Deferred Fog** component creates a screen space fog effect that can be use
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/deferred-fog.md
+++ b/content/docs/user-guide/components/reference/atom/deferred-fog.md
@@ -5,8 +5,6 @@ description: "Open 3D Engine (O3DE) Deferred Fog component reference."
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Deferred Fog** component creates a screen space fog effect that can be used as scene fog or layered/ground fog. You can also add an optional cloud noise turbulence.
 
 

--- a/content/docs/user-guide/components/reference/atom/depth-of-field.md
+++ b/content/docs/user-guide/components/reference/atom/depth-of-field.md
@@ -12,7 +12,7 @@ The **Depth of Field component** simulates the lens effects of real world camera
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/depth-of-field.md
+++ b/content/docs/user-guide/components/reference/atom/depth-of-field.md
@@ -5,8 +5,6 @@ description: "Open 3D Engine (O3DE) Depth of Field component reference."
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Depth of Field component** simulates the lens effects of real world cameras that focus on a specific area.
 
 

--- a/content/docs/user-guide/components/reference/atom/diffuse-probe-grid.md
+++ b/content/docs/user-guide/components/reference/atom/diffuse-probe-grid.md
@@ -5,8 +5,6 @@ description: "Open 3D Engine (O3DE) Diffuse Probe Grid component reference."
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Diffuse Probe Grid component** creates a volume of light probes that provide diffuse global illumination within the specified area.
 
 

--- a/content/docs/user-guide/components/reference/atom/diffuse-probe-grid.md
+++ b/content/docs/user-guide/components/reference/atom/diffuse-probe-grid.md
@@ -12,7 +12,7 @@ The **Diffuse Probe Grid component** creates a volume of light probes that provi
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/directional-light.md
+++ b/content/docs/user-guide/components/reference/atom/directional-light.md
@@ -12,7 +12,7 @@ The **Directional Light** component casts light from an infinitely distant point
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/directional-light.md
+++ b/content/docs/user-guide/components/reference/atom/directional-light.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Directional Light component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Directional Light** component casts light from an infinitely distant point towards a single direction, similar to sunlight. This component also supports shadow casting. 
 
 

--- a/content/docs/user-guide/components/reference/atom/display-mapper.md
+++ b/content/docs/user-guide/components/reference/atom/display-mapper.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Display Mapper component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Display Mapper** component provides settings to configure tone mapping and color grading.
 
 

--- a/content/docs/user-guide/components/reference/atom/display-mapper.md
+++ b/content/docs/user-guide/components/reference/atom/display-mapper.md
@@ -12,7 +12,7 @@ The **Display Mapper** component provides settings to configure tone mapping and
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/entity-reference.md
+++ b/content/docs/user-guide/components/reference/atom/entity-reference.md
@@ -11,7 +11,7 @@ The **Entity Reference** component allows you to provide an entity with referenc
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/entity-reference.md
+++ b/content/docs/user-guide/components/reference/atom/entity-reference.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Entity Reference component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Entity Reference** component allows you to provide an entity with references to other entities
 
 ## Provider ##

--- a/content/docs/user-guide/components/reference/atom/exposure-control.md
+++ b/content/docs/user-guide/components/reference/atom/exposure-control.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Exposure Control component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Exposure Control** component adjusts the amount of light the camera exposes in the scene, which controls how bright the scene appears. You can set the exposure manually or automatically using **Eye Adaptation** mode.
 
 

--- a/content/docs/user-guide/components/reference/atom/exposure-control.md
+++ b/content/docs/user-guide/components/reference/atom/exposure-control.md
@@ -12,7 +12,7 @@ The **Exposure Control** component adjusts the amount of light the camera expose
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
+++ b/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Global Skylight (IBL) component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Global Skylight (IBL)** component creates an image-based global illumination effect that calculates light for a scene using an HDR skybox image. 
 
 

--- a/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
+++ b/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
@@ -12,7 +12,7 @@ The **Global Skylight (IBL)** component creates an image-based global illuminati
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/grid.md
+++ b/content/docs/user-guide/components/reference/atom/grid.md
@@ -12,7 +12,7 @@ The **Grid** component adds a grid to the scene. You can customize the appearanc
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/grid.md
+++ b/content/docs/user-guide/components/reference/atom/grid.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Grid component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Grid** component adds a grid to the scene. You can customize the appearance of the grid, such as its colors, spacing, and size.
 
 

--- a/content/docs/user-guide/components/reference/atom/hdri-skybox.md
+++ b/content/docs/user-guide/components/reference/atom/hdri-skybox.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) HDRi Skybox component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **HDRi Skybox** component creates a skybox with an HDR image in your scene. 
 
 

--- a/content/docs/user-guide/components/reference/atom/hdri-skybox.md
+++ b/content/docs/user-guide/components/reference/atom/hdri-skybox.md
@@ -12,7 +12,7 @@ The **HDRi Skybox** component creates a skybox with an HDR image in your scene.
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/light.md
+++ b/content/docs/user-guide/components/reference/atom/light.md
@@ -5,8 +5,6 @@ description: ' Open 3D Engine (O3DE) Light component reference. '
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Light** component simulates soft studio light with various types of punctual and area lights. The Light component supports the punctual lights Point (simple punctual) and Spot (simple punctual), which are infinitesimally small. These are slightly more performant than their area light counterparts, but they produce simpler light effects. The Light component also supports the area lights Point (sphere), Spot (disk), Capsule, Quad, and Polygon. These most accurately simulate real-world light sources.
 
 

--- a/content/docs/user-guide/components/reference/atom/light.md
+++ b/content/docs/user-guide/components/reference/atom/light.md
@@ -9,7 +9,9 @@ toc: true
 
 The **Light** component simulates soft studio light with various types of punctual and area lights. The Light component supports the punctual lights Point (simple punctual) and Spot (simple punctual), which are infinitesimally small. These are slightly more performant than their area light counterparts, but they produce simpler light effects. The Light component also supports the area lights Point (sphere), Spot (disk), Capsule, Quad, and Polygon. These most accurately simulate real-world light sources.
 
+
 ## Light types
+
 Point (sphere)
 : Emits light from the surface of a sphere in all directions, similar to a standard light bulb. The Point (sphere) light type supports shadow effects.
 
@@ -30,24 +32,25 @@ Polygon
 
 ## Provider
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Dependencies
 
-| Light Type | Dependency |
-| - | - |
-| Point (sphere) | [Sphere Shape](/docs/user-guide/components/reference/shape/sphere-shape/) | 
-| Point (simple punctual) | - | 
-| Spot (disk) | [Disk Shape](/docs/user-guide/components/reference/shape/disk-shape/) |
-| Spot (simple punctual) | - | 
-| Capsule | [Capsule Shape](/docs/user-guide/components/reference/shape/capsule-shape/) |
-| Quad | [Quad Shape](/docs/user-guide/components/reference/shape/quad-shape/) | 
-| Polygon | [Polygon Prism Shape](/docs/user-guide/components/reference/shape/polygon-prism-shape/) |
+Depending on the light type, the Light component has the following dependencies:
+
+- **Point (sphere)**: [Sphere Shape](/docs/user-guide/components/reference/shape/sphere-shape/)
+- **Point (simple punctual)**: None
+- **Spot (disk)**: [Disk Shape](/docs/user-guide/components/reference/shape/disk-shape/)
+- **Spot (simple punctual)**: None
+- **Capsule**: [Capsule Shape](/docs/user-guide/components/reference/shape/capsule-shape/)
+- **Quad**: [Quad Shape](/docs/user-guide/components/reference/shape/quad-shape/)
+- **Polygon**: [Polygon Prism Shape](/docs/user-guide/components/reference/shape/polygon-prism-shape/)
 
 
 
 ## Properties
+
 {{< tabs name="light-component-ui" >}}
 {{% tab name="Default" %}}
 

--- a/content/docs/user-guide/components/reference/atom/look-modification.md
+++ b/content/docs/user-guide/components/reference/atom/look-modification.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Look Modification component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Look Modification** component allows you to configure a color grading look-up table (LUT)
 
 

--- a/content/docs/user-guide/components/reference/atom/look-modification.md
+++ b/content/docs/user-guide/components/reference/atom/look-modification.md
@@ -12,7 +12,7 @@ The **Look Modification** component allows you to configure a color grading look
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/material.md
+++ b/content/docs/user-guide/components/reference/atom/material.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Material component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Material** component adds a material on the object's mesh. The material can be edited using the Material Editor.
 
 

--- a/content/docs/user-guide/components/reference/atom/material.md
+++ b/content/docs/user-guide/components/reference/atom/material.md
@@ -12,7 +12,7 @@ The **Material** component adds a material on the object's mesh. The material ca
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/mesh.md
+++ b/content/docs/user-guide/components/reference/atom/mesh.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Mesh component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Mesh** component specifies a model to render in the scene. Model assets are supported and processed using [AssImp](https://www.assimp.org/). 
 
 ## Provider ##

--- a/content/docs/user-guide/components/reference/atom/mesh.md
+++ b/content/docs/user-guide/components/reference/atom/mesh.md
@@ -11,7 +11,7 @@ The **Mesh** component specifies a model to render in the scene. Model assets ar
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
+++ b/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Occlusion Culling Plane component reference.
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Occlusion Culling Plane** component adds a plane, or an occluder, that when put between the camera and a mesh, can block the mesh from being rendered. Occlusion culling is a render culling technique that reduces the number of non-visible objects sent to the renderer. The occlusion culling technique determines whether to render an object or not by testing if the object is fully behind an occluder.
 
 

--- a/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
+++ b/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
@@ -12,7 +12,7 @@ The **Occlusion Culling Plane** component adds a plane, or an occluder, that whe
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/physical-sky.md
+++ b/content/docs/user-guide/components/reference/atom/physical-sky.md
@@ -12,7 +12,7 @@ The **Physical Sky** component adjusts the physical environment of the scene, su
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/physical-sky.md
+++ b/content/docs/user-guide/components/reference/atom/physical-sky.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Physical Sky component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Physical Sky** component adjusts the physical environment of the scene, such as the sky, sun, and fog.
 
 

--- a/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
@@ -5,14 +5,12 @@ description: 'Open 3D Engine (O3DE) PostFX Gradient Weight Modifier component re
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **PostFX Gradient Weight Modifier** component modifies post-processing effects' (PostFX) weight based on another entity's gradient signal.
 
 
 ## Provider ##
 
-[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
+[Atom Gem](/docs/atom-guide)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
@@ -12,7 +12,7 @@ The **PostFX Gradient Weight Modifier** component modifies post-processing effec
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/postfx-layer.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-layer.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) PostFX Layer component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **PostFx Layer** component controls how post-processing effects' (PostFX) are applied in a scene.
 
 ## Provider ##

--- a/content/docs/user-guide/components/reference/atom/postfx-layer.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-layer.md
@@ -11,7 +11,7 @@ The **PostFx Layer** component controls how post-processing effects' (PostFX) ar
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) PostFX Shape Weight Modifier component refer
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **PostFX Shape Weight Modifier** component limits post-processing effects (PostFX) to a volume of space that is defined by a shape component. The weight of the PostFX remains constant within the shape component's bounds, but it begins to fade outside of the bounds.
 
 

--- a/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
@@ -12,7 +12,7 @@ The **PostFX Shape Weight Modifier** component limits post-processing effects (P
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/radius-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/radius-weight-modifier.md
@@ -12,7 +12,7 @@ The **Radius Weight Modifier** component modifies post-processing effects' (Post
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/radius-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/radius-weight-modifier.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) Radius Weight Modifier component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **Radius Weight Modifier** component modifies post-processing effects' (PostFX) weight based on the camera's distance to the center.
 
 

--- a/content/docs/user-guide/components/reference/atom/reflection-probe.md
+++ b/content/docs/user-guide/components/reference/atom/reflection-probe.md
@@ -23,13 +23,13 @@ The **Reflection Probe** creates specular reflections in the environment around 
 ![Reflection Probe component properties](/images/user-guide/components/reference/atom/reflection-probe-component-ui.png)
  
 
-### Cubemap Bake
+### Cubemap Bake properties
 
 | Property | Description | Values | Default |
 |-|-|-|-|
 | **Bake Reflection Probe** | Bakes the surrounding environment to a cubemap. | - | - |
 
-### Inner Extents
+### Inner Extents properties
 
 | Property | Description | Values | Default |
 |-|-|-|-|
@@ -37,14 +37,14 @@ The **Reflection Probe** creates specular reflections in the environment around 
 | **Length** | The length of the reflection probe's inner volume. The length is dependent on the Box Shape component's dimension along the y-axis. | `0` to the Box Shape component's `Dimensions`-`Y` property| The value of the Box Shape component's `Dimensions`-`Y` property. |
 | **Width** | The width of the reflection probe's inner volume. The width is dependent on the Box Shape component's dimension along the x-axis. | `0` to the Box Shape component's `Dimensions`-`X` property| The value of the Box Shape component's `Dimensions`-`X` property. |
 
-### Settings
+### Settings properties
 
 | Property | Description | Values | Default |
 |-|-|-|-|
 | **Parallax Correction** | Corrects the reflection by adjusting an offset from the capture position. | Boolean | `Enabled` |
 | **Show Visualization** |  Shows a sphere to visualize the probe. |  Boolean | `Enabled` |
 
-### Cubemap
+### Cubemap properties
 
 | Property | Description | Values | Default |
 |-|-|-|-|

--- a/content/docs/user-guide/components/reference/atom/ssao.md
+++ b/content/docs/user-guide/components/reference/atom/ssao.md
@@ -12,7 +12,7 @@ The **SSAO** component approximates indirect lighting in a scene by using the *s
 
 ## Provider ##
 
-[Atom Gem](/docs/atom-guide)
+[Atom Gem](/docs/user-guide/gems/reference/rendering/atom/atom/)
 
 
 ## Properties

--- a/content/docs/user-guide/components/reference/atom/ssao.md
+++ b/content/docs/user-guide/components/reference/atom/ssao.md
@@ -5,8 +5,6 @@ description: 'Open 3D Engine (O3DE) SSAO component reference.'
 toc: true
 ---
 
-{{< preview-new >}}
-
 The **SSAO** component approximates indirect lighting in a scene by using the *screen space ambient occlusion* technique.
 
 


### PR DESCRIPTION
- Updated the link to the Atom Gem in the Atom component reference pages, if necessary. (Previously, the link pointed to the Atom Guide.)
- Minor reformatting. 