### PR TITLE
Improve website font style at H4 level

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -137,6 +137,24 @@ $o3de-green: #58BD61
     a
       opacity: 1
 
+  h4
+    font-weight: 600
+    font-size: 18px
+    margin: 26px 0 8px
+
+    @include media-breakpoint-down(sm)
+      font-size: 22px
+      line-height: 32px
+
+  h4
+    a
+      opacity: 0
+      transition: opacity .3s ease
+
+  h4:hover
+    a
+      opacity: 1
+
   p
     font-size: 16px
     line-height: 28px


### PR DESCRIPTION
Adds an H4 style. Copied over from closed PR #765.

Usage examples:

https://deploy-preview-840--o3deorg.netlify.app/docs/contributing/to-docs/hugo/#understanding-hugo-layout-structure

https://deploy-preview-840--o3deorg.netlify.app/docs/atom-guide/look-dev/get-started-materialtypes-and-shaders/#shader-resource-groups

https://deploy-preview-840--o3deorg.netlify.app/docs/atom-guide/look-dev/materials/material-editor/#camera-controls

https://deploy-preview-840--o3deorg.netlify.app/docs/user-guide/components/reference/physx/force-region/#linear-damping

Signed-off-by: William Hayward <wilhayw@amazon.com>