### PR TITLE
Clarifications to creating-projects-using-cli

### DIFF
--- a/content/docs/welcome-guide/create/creating-projects-using-cli.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli.md
@@ -113,9 +113,14 @@ If your project build directory is outside the project path, you must include th
         ```
 
         {{< important >}}
-If you built the engine from source using the `INSTALL` target, make sure that you launch the Editor and other tools from the install directory, _not_ the engine's build directory. The Windows install directory typically ends in `/bin/Windows/profile`.
+If you built the engine from source using the `INSTALL` target, make sure that you launch the Editor _and_ other tools from the installed engine's build directory, _not_ the engine's build directory. The Windows install directory typically ends in `/bin/Windows/profile`.
         {{< /important >}}
 
 You can also run Project Manager (`o3de.exe`) from the same directory to edit your project's settings, add or remove Gems from the project, rebuild your project, and launch the Editor.
+
+
+{{< caution >}}
+If you launch the Editor from the wrong directory, the **Asset Processor** processor from that directory will also launch.  You must close all **Asset Processor** tasks before you attempt to launch the Editor from a different directory.
+{{< /caution >}}
 
 For more information about project configuration and building, refer to the [Project Configuration](/docs/user-guide/project-config) and [Build](/docs/user-guide/build) sections of the User Guide.

--- a/content/docs/welcome-guide/create/creating-projects-using-cli.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli.md
@@ -120,7 +120,7 @@ You can also run Project Manager (`o3de.exe`) from the same directory to edit yo
 
 
 {{< caution >}}
-If you launch the Editor from the wrong directory, the **Asset Processor** processor from that directory will also launch.  You must close all **Asset Processor** tasks before you attempt to launch the Editor from a different directory.
+When you launch the Editor, the **Asset Processor** from the same directory will also launch.  You must close all **Asset Processor** tasks before you attempt to launch the Editor from a different directory.
 {{< /caution >}}
 
 For more information about project configuration and building, refer to the [Project Configuration](/docs/user-guide/project-config) and [Build](/docs/user-guide/build) sections of the User Guide.

--- a/content/docs/welcome-guide/create/creating-projects-using-cli.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli.md
@@ -120,7 +120,7 @@ You can also run Project Manager (`o3de.exe`) from the same directory to edit yo
 
 
 {{< caution >}}
-When you launch the Editor, the **Asset Processor** from the same directory will also launch.  You must close all **Asset Processor** tasks before you attempt to launch the Editor from a different directory.
+When you launch the Editor, the **Asset Processor** from the same directory will also launch.  To launch the Editor from a different directory, you must close any **Asset Processor** tasks that are running.
 {{< /caution >}}
 
 For more information about project configuration and building, refer to the [Project Configuration](/docs/user-guide/project-config) and [Build](/docs/user-guide/build) sections of the User Guide.


### PR DESCRIPTION
The instructions for SDK builds and the Important section that followed needed wording aligned for clarity.  The Important section was too similar to the preceding section, now it emphasizes an additional point.  I also added a Caution section to help users recover from launching the Editor from an incorrect directory.