### PR TITLE
Add TOC navigation to environment subfolder Issue#854

### DIFF
--- a/content/docs/user-guide/gems/reference/environment/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/_index.md
@@ -8,6 +8,6 @@ The dynamic vegetation system uses vegetation components to customize dynamic ve
 
 The [Landscape Canvas Gem](./landscape-canvas) provides the **Landscape Canvas** editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.
 
-The [Vegetation Assets Gem](./vegetation-gem-assets.md) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
+The [Vegetation Assets Gem](./vegetation-gem-assets) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
 
 The [Surface Data Gem](./surface-data.md) enables surfaces such as terrain or meshes to emit signals or tags, that communicate its surface type. These signals and tags have various uses, such as creating inclusion and exclusion areas for vegetation growth.

--- a/content/docs/user-guide/gems/reference/environment/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/_index.md
@@ -10,4 +10,4 @@ The [Landscape Canvas Gem](./landscape-canvas) provides the **Landscape Canvas**
 
 The [Vegetation Assets Gem](./vegetation-gem-assets) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
 
-The [Surface Data Gem](./surface-data.md) enables surfaces such as terrain or meshes to emit signals or tags, that communicate its surface type. These signals and tags have various uses, such as creating inclusion and exclusion areas for vegetation growth.
+The [Surface Data Gem](./surface-data) enables surfaces such as terrain or meshes to emit signals or tags, that communicate its surface type. These signals and tags have various uses, such as creating inclusion and exclusion areas for vegetation growth.

--- a/content/docs/user-guide/gems/reference/environment/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/_index.md
@@ -6,7 +6,7 @@ description: The Environment Gems provide the tools and framework to create natu
 
 The dynamic vegetation system uses vegetation components to customize dynamic vegetation coverage for levels of any size. To use the dynamic vegetation system, you must enable the [Vegetation Gem](./vegetation) for your project.
 
-The [Landscape Canvas Gem](./landscape-canvas.md) provides the **Landscape Canvas** editor; a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.
+The [Landscape Canvas Gem](./landscape-canvas) provides the **Landscape Canvas** editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.
 
 The [Vegetation Assets Gem](./vegetation-gem-assets.md) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
 

--- a/content/docs/user-guide/gems/reference/environment/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/_index.md
@@ -1,0 +1,13 @@
+---
+linkTitle: Environment
+title: Environment Gems
+description: The Environment Gems provide the tools and framework to create natural-looking vegetation in Open 3D Engine (O3DE) projects.
+---
+
+The dynamic vegetation system uses vegetation components to customize dynamic vegetation coverage for levels of any size. To use the dynamic vegetation system, you must enable the [Vegetation Gem](./vegetation) for your project.
+
+The [Landscape Canvas Gem](./landscape-canvas.md) provides the **Landscape Canvas** editor; a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.
+
+The [Vegetation Assets Gem](./vegetation-gem-assets.md) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
+
+The [Surface Data Gem](./surface-data.md) enables surfaces such as terrain or meshes to emit signals or tags, that communicate its surface type. These signals and tags have various uses, such as creating inclusion and exclusion areas for vegetation growth.

--- a/content/docs/user-guide/gems/reference/environment/landscape-canvas.md
+++ b/content/docs/user-guide/gems/reference/environment/landscape-canvas.md
@@ -2,6 +2,7 @@
 linkTitle: Landscape Canvas
 title: Landscape Canvas Gem
 description: The Landscape Canvas Gem provides the Landscape Canvas editor to author dynamic vegetation for Open 3D Engine (O3DE) projects.
+weight: 200
 toc: true
 ---
 

--- a/content/docs/user-guide/gems/reference/environment/surface-data.md
+++ b/content/docs/user-guide/gems/reference/environment/surface-data.md
@@ -2,6 +2,7 @@
 linkTitle: Surface Data
 title: Surface Data Gem
 description: The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain in Open 3D Engine (O3DE) projects.
+weight: 400
 toc: true
 ---
 

--- a/content/docs/user-guide/gems/reference/environment/vegetation-gem-assets.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation-gem-assets.md
@@ -2,6 +2,7 @@
 linkTitle: Vegetation Assets
 title: Vegetation Assets Gem
 description: The Vegetation Assets Gem provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and Landscape Canvas.
+weight: 300
 toc: true
 ---
 

--- a/content/docs/user-guide/gems/reference/environment/vegetation/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/_index.md
@@ -2,6 +2,7 @@
 linkTitle: Vegetation
 title: Vegetation Gem
 description: The Vegetation Gem provides tools to place natural-looking vegetation in Open 3D Engine.
+weight: 100
 toc: true
 ---
 

--- a/content/docs/user-guide/gems/reference/environment/vegetation/concepts.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/concepts.md
@@ -1,7 +1,7 @@
 ---
-description: ' Learn about dynamic vegetation concepts and ideas in Open 3D Engine. '
+linkTitle: Concepts
 title: Dynamic vegetation concepts
-weight: 100
+description: Learn about dynamic vegetation concepts and ideas in Open 3D Engine.
 ---
 
 The dynamic vegetation system operates around the following ideas:
@@ -24,7 +24,7 @@ You can customize your vegetation in the following ways:
 + Use customizable gradients such as the **Perlin Noise Gradient** to mimic the types of vegetation groupings often found in nature.
 + Save your customized vegetation areas as slices so that you can easily reuse them in other levels or share them with collaborators. Use slice overrides to make small or large changes to individual instances of the slice.
 
-## Dynamic Vegetation Components 
+## Dynamic Vegetation Components
 
 The common workflow for creating a new vegetation area starts with creating an entity and adding a **Vegetation Layer Spawner** component to it. Then you add to that entity the two required components, which define the area's shape and the assets to display. From there, you can add optional components such as vegetation filters and modifiers.
 

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/_index.md
@@ -1,8 +1,7 @@
 ---
-description: ' Learn the basic procedures to create realistic-looking dynamic vegetation
-  in Open 3D Engine. '
+linkTitle: Procedures
 title: Dynamic vegetation procedures
-weight: 200
+description: Learn the basic procedures to create realistic-looking dynamic vegetation in Open 3D Engine.
 ---
 
 Creating realistic dynamic vegetation in O3DE starts with a few basic procedures that you can follow up with endless customizations.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/adding-modifiers.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/adding-modifiers.md
@@ -1,7 +1,9 @@
 ---
-description: ' Add scale, rotation, and position modifiers to change the look of your
-  dynamic vegetation in Open 3D Engine. '
+linkTitle: Adding Modifiers
 title: Adding Scale, Rotation, and Position Modifiers
+description: Add scale, rotation, and position modifiers to change the look of your dynamic vegetation in Open 3D Engine.
+weight: 150
+toc: true
 ---
 
 Before you can complete this procedure, you must first [create a vegetation layer](/docs/user-guide/gems/vegetation/layer.md).
@@ -19,7 +21,7 @@ Applying modifiers to your vegetation gives it a realistic, natural look.
 
 ![\[Vegetation area after adding the scale, rotation, and position modifiers.\]](/images/user-guide/vegetation/dynamic/dynamic-vegetation-procedures-adding-modifiers-after.png)
 
-## Adding a Scale Modifier 
+## Adding a Scale Modifier
 
 A scale modifier varies the size of the vegetation.
 
@@ -44,7 +46,7 @@ A scale modifier varies the size of the vegetation.
 
    **Range Min** sets the scale size for the gradient signal's lowest values. **Range Max** sets the scale size for the gradient signal's highest values. Because the gradient signal varies in range from black to white, a scale value between the minimum and the maximum is applied to that vegetation instance.
 
-## Adding a Rotation Modifier 
+## Adding a Rotation Modifier
 
 A rotation modifier varies the rotation of the vegetation.
 
@@ -63,7 +65,7 @@ A rotation modifier varies the rotation of the vegetation.
 
    The **Gradient Entity Id** field populates with the entity name.
 
-## Adding a Position Modifier 
+## Adding a Position Modifier
 
 A position modifier shifts each instance of vegetation by an amount that the gradient determines, which removes the grid-like appearance of the vegetation.
 
@@ -102,4 +104,3 @@ You can also overcome this issue by using a gradient modifier on your existing g
 
 1. To produce a swizzling effect on the y-axis, use the following values or a variation on them.
 ****
-

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/blockers.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/blockers.md
@@ -1,6 +1,9 @@
 ---
-description: ' Create areas where you don''t want vegetation to appear in Open 3D Engine. '
+linkTitle: Blockers
 title: Blocking Vegetation in Select Areas
+description: Create areas where you don''t want vegetation to appear in Open 3D Engine.
+weight: 800
+toc: true
 ---
 
 You can create areas in your level to block vegetation from appearing. For example, you can use this feature to create areas around buildings or homes where vegetation shouldn't appear.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/coverage.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/coverage.md
@@ -1,6 +1,9 @@
 ---
-description: ' Expand your vegetation to cover your level in Open 3D Engine. '
+linkTitle: Expanding Coverage
 title: Expanding Vegetation Coverage
+description: Expand your vegetation to cover your level in Open 3D Engine.
+weight: 200
+toc: true
 ---
 
 After you create a vegetation patch, you can expand it so that your vegetation covers the entire level.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/gradient-random.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/gradient-random.md
@@ -1,7 +1,9 @@
 ---
-description: ' Link gradient entities to vegetation entities to create random distribution
-  in Open 3D Engine dynamic vegetation. '
+linkTitle: Using Gradients
 title: Using Gradients to Create Random Distribution
+description: Link gradient entities to vegetation entities to create random distribution in Open 3D Engine dynamic vegetation.
+weight: 600
+toc: true
 ---
 
 You can use gradients in different areas of O3DE, such as with audio and AI. Gradients are particularly helpful in dynamic vegetation, where they create a realistically random look in the distribution of your vegetation.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/layer.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/layer.md
@@ -1,6 +1,9 @@
 ---
-description: ' Create a basic vegetation layer in Open 3D Engine. '
+linkTitle: Layers
 title: Creating a Vegetation Layer
+description: Create a basic vegetation layer in Open 3D Engine.
+weight: 100
+toc: true
 ---
 
 Creating a vegetation layer is the first and most basic step in creating your dynamic vegetation. The following procedure uses a simple workflow and assets from the Starter Game project.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/place-random.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/place-random.md
@@ -1,7 +1,9 @@
 ---
-description: ' Create random distribution by using a noise gradient as a placement
-  mask for Open 3D Engine dynamic vegetation. '
+linkTitle: Noise-Based Random Selection
 title: Random Placement Using the Vegetation Distribution Filter
+description: Create random distribution by using a noise gradient as a placement mask for Open 3D Engine dynamic vegetation.
+weight: 650
+toc: true
 ---
 
 The **Vegetation Distribution Filter** component creates the look of random placement by limiting the amount of vegetation that the **Vegetation Layer Spawner** component produces.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/reuse.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/reuse.md
@@ -1,6 +1,9 @@
 ---
-description: ' Reference dynamic vegetation to another area in Open 3D Engine. '
+linkTitle: Reusing Vegetation
 title: Reusing Vegetation in Multiple Areas
+description: Reference dynamic vegetation to another area in Open 3D Engine.
+weight: 500
+toc: true
 ---
 
 After you create your vegetation entity, you can designate your customized vegetation to appear in another area. You do this by referencing another shape. For example, if you created a forest patch that includes the vegetation assets and arrangement for your level, you can create another entity with a different shape and reference this new shape for your vegetation. With this feature, you can reuse your vegetation in different areas of your level without creating a separate vegetation entity each time.

--- a/content/docs/user-guide/gems/reference/environment/vegetation/procedures/selection-random.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation/procedures/selection-random.md
@@ -1,12 +1,14 @@
 ---
-description: ' Create random distribution by using weight-based random selection in
-  Open 3D Engine dynamic vegetation. '
+linkTitle: Weight-Based Random Selection
 title: Creating Weight-Based Random Selection
+description: Create random distribution by using weight-based random selection in Open 3D Engine.
+weight: 700
+toc: true
 ---
 
 When you create distribution using random selection, the vegetation asset that is selected for a particular point on the grid varies. The assigned weight of each asset determines its chance of selection. In this procedure, you specify weights and link to the gradient using the **Vegetation Asset Weight Selector** component.
 
-## Preparing the Vegetation Entity 
+## Preparing the Vegetation Entity
 
 The vegetation entity, or the entity that contains the **Vegetation Layer Spawner** component, must contain a component that assigns values for selection of the listed assets. This procedure uses the **Vegetation Asset Weight Selector** component for that purpose. It's also helpful, though unnecessary, to add multiple assets if you haven't already. If you have only one asset listed, your one asset and bare ground are used when you link the gradient in [Creating a Gradient Entity](#create-gradient-entity).
 
@@ -35,7 +37,7 @@ When specifying your first asset, you don't need to click + because there is an 
 
    In the next step, [Creating a Gradient Entity](#create-gradient-entity), you link this component to the gradient, which supplies values between 0.0 to 1.0 at a given position. Assets are then mapped based on those values and each asset's weight and order values.
 
-## Creating a Gradient Entity 
+## Creating a Gradient Entity
 
 The gradient entity provides the noise signal to reference from the vegetation entity.
 
@@ -66,7 +68,7 @@ If you don't have the **Gradient** category in your list of components, you must
    The **Shape Entity Id** field populates with the entity name that you selected and uses the shape on that entity as its reference shape.
 ![\[In the Entity Outliner, select the TestBox entity.\]](/images/user-guide/vegetation/dynamic/dynamic-vegetation-procedures-gradient-random-selection-basic-coverage.png)
 
-## Linking the Gradient to the Vegetation Area 
+## Linking the Gradient to the Vegetation Area
 
 Before the gradient that you created can have any effect on the vegetation, you must reference the gradient from within the vegetation area. This means the component that you reference the gradient (in this example, the **Vegetation Asset Weight Selector**) in uses the gradient's information for its selection of values.
 


### PR DESCRIPTION
Fixes [ISSUE][DOCS] Table of contents not enabled for pages in Vegetation Gem https://github.com/o3de/o3de.org/issues/854

Created new __index.md for the Environment subfolder, assigned weights for TOC and cleaned up frontmatter of directory.