### PR TITLE
Remove the requirement that PR contributors assign reviewers - this (should be) done in SIG triage.

### DIFF
--- a/content/docs/contributing/to-docs/submit-a-pr.md
+++ b/content/docs/contributing/to-docs/submit-a-pr.md
@@ -29,10 +29,9 @@ Before submitting a PR, ensure your contributions meet the guidelines below:
 Despite only having five steps, the PR process can take some time depending on the availability of reviewers and the length and technical depth of the submitted changes. You can help keep PRs moving by quickly responding to feedback and review requests. The PR process is summarized below.
 
 1. Commit your changes to a branch on your fork.
-2. Create a PR against `o3de.org:main` from your branch.
-3. Request reviewers for your PR.
-4. Respond to feedback from reviewers.
-5. When the PR receives two approvals, plus a technical review approval for highly technical topics, it can be merged.
+1. Create a PR against `o3de.org:main` from your branch.
+1. Respond to feedback from reviewers.
+1. When the PR receives two approvals, plus any additional required approval such as copyedit or technical review, it can be merged.
 
 {{< important >}}
 **Never** merge your own PRs. PRs require two approvals, and may require an additional approval from a technical reviewer. The last reviewer to approve the PR should merge it into `o3de.org:main`.
@@ -69,16 +68,6 @@ PRs are created in the GitHub web interface from your branch. Go to your fork on
 If you go to the main o3de.org repo on GitHub and refer to [O3DE repository pull requests (PRs)](https://github.com/o3de/o3de.org/pulls), your new PR appears at the top of the list.
 
 For more information on creating a pull request, refer to [Creating a pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
-
-### Request reviewers
-
-PRs require two reviewer approvals to be merged into main. Highly technical topics require an additional review by an O3DE code contributor for technical accuracy. You should request at least two, but no more than five reviewers for your PRs. Keep in mind that this is a community project, and that interested contributors can add themselves as reviewers to any PR.
-
-"But who do I ask to review my PRs?" you are probably wondering. If you are new to the project, you might not know any other contributors. You can look through the PR list and try to find reviewers who seem responsive, but a better solution is to visit the O3DE Discord and ask for suggestions and volunteers for reviewers. It's a great way to meet new people and introduce yourself to other contributors.
-
-To add reviewers to your PR, find the section named **Reviewers** in the column to the right of your PR. Choose the **gear button** to open the list of potential reviewers, and search for the names of reviewers you'd like to add. Click the reviewer's name to select them and add them to your PR's reviewer list.
-
-For more information on requesting reviewers, refer to [Requesting a pull request review](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review).
 
 ### Respond to feedback
 


### PR DESCRIPTION
Signed-off-by: Stephen Tramer <stramer@amazon.com>
