### PR TITLE
Fix link to O3D Foundation

### DIFF
--- a/content/docs/release-notes/archive/2107-1-release-notes.md
+++ b/content/docs/release-notes/archive/2107-1-release-notes.md
@@ -12,7 +12,7 @@ The current version of Open 3D Engine is 2107.1 (Developer Preview). Check out t
 
 ## Highlights
 
-The [Open 3D Foundation](https://o3de.foundation) is very excited to bring you this initial Developer Preview release, kicking off what we hope is a long and illustrious community effort to develop a 3D rendering platform that can evolve as fast as modern gaming and simulation has. If it looks a bit familiar to AWS Lumberyard developers, well, they're right: O3DE builds off the effort Amazon Web Services poured into that engine.
+The [Open 3D Foundation](https://o3d.foundation) is very excited to bring you this initial Developer Preview release, kicking off what we hope is a long and illustrious community effort to develop a 3D rendering platform that can evolve as fast as modern gaming and simulation has. If it looks a bit familiar to AWS Lumberyard developers, well, they're right: O3DE builds off the effort Amazon Web Services poured into that engine.
 
 Note that this release is a Developer Preview and is incomplete for many major development workflows. Initially, this release primarily supports engine and tools developers, and as the O3DE community builds it out, more features will be added.
 


### PR DESCRIPTION
The release notes linked to the non-existent domain o3de.foundation, the
correct domain is o3d.foundation.

I've checked for other incorrect links; somewhat surprisingly, this is the only link to the O3DF in the whole repository.