### PR TITLE
Add search to navbar in /docs/

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -23,6 +23,10 @@
         <div id="main-nav" class="navbar-primary">
           {{ partial "docs-menu-loop.html" . }}
         </div>
+        
+        <div class="search">
+          {{ partial "search.html" . }}
+        </div>        
 
         <button class="navbar-toggler secondary-toggler" type="button" data-toggle="collapse" data-target="#secondary-nav" aria-controls="secondary-nav" aria-expanded="false" aria-label="Toggle secondary navigation">
           <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
This does add search to the navbar throughout /docs/.  On docs pages other than the landing page, you have search above the left-hand TOC as well.

Fix #893 