### PR TITLE
Add standard UI icons for browse and open-in-app

### DIFF
--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -355,6 +355,7 @@ You can add inline O3DE GUI icons with the `icon` shortcode. Icon `.svg` files a
 | animation-editor.svg | {{< icon "animation-editor.svg" >}} |
 | asset-editor.svg | {{< icon "asset-editor.svg" >}} |
 | audio-editor.svg | {{< icon "audio-editor.svg" >}} |
+| browse-edit-select-files.svg | {{< icon "browse-edit-select-files.svg" >}} |
 | camera.svg | {{< icon "camera.svg" >}} |
 | caret-closed.svg | {{< icon "caret-closed.svg" >}} |
 | caret-open.svg | {{< icon "caret-open.svg" >}} |
@@ -383,6 +384,7 @@ You can add inline O3DE GUI icons with the `icon` shortcode. Icon `.svg` files a
 | menu.svg | {{< icon "menu.svg" >}} |
 | more.svg | {{< icon "more.svg" >}} |
 | move.svg | {{< icon "move.svg" >}} |
+| open-in-internal-app.svg | {{< icon "open-in-internal-app.svg" >}}
 | parent.svg | {{< icon "parent.svg" >}} |
 | picker.svg | {{< icon "picker.svg" >}} |
 | pin-button.svg | {{< icon "pin-button.svg" >}} |

--- a/static/images/icons/browse-edit-select-files.svg
+++ b/static/images/icons/browse-edit-select-files.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
+    <title>Icons / System / Select Files</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons-/-System-/-Select-Files" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Icon-Background" x="0" y="0" width="24" height="24"></rect>
+        <path d="M6,7 L4,7 L4,2 L10,2 L10,7 L8,7 L8,10.5 L15,10.5 L15,9 L20,9 L20,14 L15,14 L15,12.5 L8,12.5 L8,18.5 L15,18.5 L15,17 L20,17 L20,22 L15,22 L15,20.5 L6,20.5 L6,7 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+    </g>
+</svg>

--- a/static/images/icons/open-in-internal-app.svg
+++ b/static/images/icons/open-in-internal-app.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
+    <title>Icons / System / Open / Open in Internal App</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Icons-/-System-/-Open-/-Open-in-Internal-App" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="Icon-Background" x="0" y="0" width="24" height="24"></rect>
+        <path d="M21,3 L21,19.5 L21.0070809,19.5 L21.0070809,20.9975284 L21,20.997 L21,21 L19.5,21 L19.5,20.997 L7.97261837,21 L9.45378213,19.5 L19.5,19.5 L19.5,7 L4.5,7 L4.5,14.7148938 L3,16.0495017 L3,3 L21,3 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+        <path d="M13.5,17 L12,17 L12,13.063 L4.06066017,21.0033009 L3,19.9426407 L10.942,12 L7,12 L7,10.5 L13.5,10.5 L13.5,17 Z" id="Combined-Shape" fill="#FFFFFF"></path>
+    </g>
+</svg>


### PR DESCRIPTION
These icons are used in Lua and Script Canvas components, and will be added to their respective documentation in a follow-on PR.

Signed-off-by: William Hayward <wilhayw@amazon.com>