### PR TITLE
Update setup requirements and binary directory for installed engines

### DIFF
--- a/content/docs/atom-guide/look-dev/get-started-materialtypes-and-shaders.md
+++ b/content/docs/atom-guide/look-dev/get-started-materialtypes-and-shaders.md
@@ -101,7 +101,7 @@ Vertex Shader
 
 The vertex shader inputs and outputs are defined inside the structs `VertexInput` and `VertexShaderOutput`. The type of input and output is indicated by HLSL semantics (see Microsoft DirectX HLSL - Semantics](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics) documentation). 
 
-In this vertex shader program, you need the geometry’s position. You can set up vertex input and output using the following code:
+In this vertex shader program, you need the geometry's position. You can set up vertex input and output using the following code:
 
 ```hlsl
 struct VertexInput
@@ -392,7 +392,7 @@ Here is the complete `MyUnlitColor.materialtype` file:
 ## 5. Compile and debug with the Asset Processor
 At this point, we've finished writing the files `MyUnlitColor.materialtype`, `MyUnlitColor.shader`, and `MyUnlitColor.azsl`. Now, we are going to make sure they compile successfully. 
 
-**Asset Processor** is responsible for compiling and debugging `.material`, `.materialtype,` `.shader`, and `.azsl` files (among many other assets). **Asset Processor** automatically launches when **Material Editor** is open and runs in the background in the system tray. You can also launch **Asset Processor** from the directory for your build config such as `<build>/bin/profile/`.  
+**Asset Processor** is responsible for compiling and debugging `.material`, `.materialtype,` `.shader`, and `.azsl` files (among many other assets). **Asset Processor** automatically launches when **Material Editor** is open and runs in the background in the system tray. You can also launch **Asset Processor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.  
 
 **Asset Processor** monitors your project's subdirectories and automatically compiles and debugs assets when it detects new or updated files.
 
@@ -404,7 +404,7 @@ If a job displays an error or warning, select the job in the **Asset Status** li
 At this point, all of our files should compile successfully. Now, you are going to create a material based on the MyUnlitColor material type. 
 
 To create a new material using **Material Editor**: 
-1. Launch **Material Editor** from the directory for your build config such as `<build>/bin/profile/`.  
+1. Launch **Material Editor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.  
 2. From the **File** menu in **Material Editor**, select **New**, or press **Control + N** to create a new material.
 3. In the **Create New Material** dialog, select **MyUnlitColor** in the **Material Type** list.
 4. Choose the folder icon below **Select Material Filename**. Ensure the file browser has your project's `Materials` directory selected and name the material `MyUnlitColor.material`. Choose **OK** to close both the file browser and the **Create New Material** dialog.

--- a/content/docs/atom-guide/look-dev/materials/create-standardpbr-material.md
+++ b/content/docs/atom-guide/look-dev/materials/create-standardpbr-material.md
@@ -42,8 +42,8 @@ We rename the following files to properly apply a filemask. (For the sake of cla
 
 ## Create material with Material Editor
 To create a material using the Material Editor:
-1. Open the Material Editor. If you are in the Open 3D Engine Editor, go to *Tools > Material Editor*, or press *M*. Otherwise, you can open the Material Editor as a standalone application from `<build_folder>/bin/profile/MaterialEditor.exe`.
-   
+1. Open the Material Editor. If you are in the Open 3D Engine Editor, go to *Tools > Material Editor*, or press *M*. Otherwise, you can open the Material Editor as a standalone application from `<build_folder>/bin/profile/MaterialEditor.exe` or `<install>/bin/<platform>/profile/Default/MaterialEditor.exe`.
+
 2. Create a new StandardPBR material by choosing **File** > **New** > **Standard PBR**. This opens the file browser and prompts you to save the new file. In the **Inspector** tab, you can verify that the material type is `StandardPBR` by checking the `Material Type` property in the `Details` property group. 
 
     {{< note >}} 

--- a/content/docs/tools-ui/uidev-control-gallery.md
+++ b/content/docs/tools-ui/uidev-control-gallery.md
@@ -14,7 +14,7 @@ Use the **O3DE Qt Control Gallery** tool to see the O3DE UI custom Qt widget lib
 
 Before you begin, make sure that you have built or installed O3DE on your computer.
 
-1. Open your computer's file explorer to the O3DE binaries directory. If you installed the O3DE engine, the path on your computer will be similar to `<engine>/bin/Windows/profile`. If you build O3DE from source, the tool will build to your engine build directory.
+1. Open your computer's file explorer to the O3DE binaries directory. If you installed the O3DE engine, the path on your computer will be similar to `<engine>/bin/Windows/profile/Default`. If you build O3DE from source, the tool will build to your engine build directory.
 
 1. Locate and then launch `O3DEQtControlGallery.exe`.
 

--- a/content/docs/user-guide/assets/pipeline/debugging.md
+++ b/content/docs/user-guide/assets/pipeline/debugging.md
@@ -61,11 +61,14 @@ You must start Asset Processor before you can enter a `-debug` command.
 
 **To debug Asset Processor using Asset Builder**
 
-1. Navigate to `<build>/bin/<config>/` in a termainal.
+1. Navigate to one of the following directories in a terminal:
+
+    * Installed engine: `<install>/bin/<platform>/profile/Default`
+    * Engine built from source: `<project>/<build>/bin/<config>`
 
 1. In a command line prompt, enter the following command to get a list of possible options.
 
-   ```
+   ```cmd
    AssetBuilder.exe -help
    ```
 
@@ -83,14 +86,14 @@ AssetBuilder.exe -debug Objects\Tutorials\Fbx\shapes.fbx
 **Example**
 To create a job without processing a specified file, run the following command.
 
-```
+```cmd
 AssetBuilder.exe -debug_create "Objects\Tutorials\Fbx\shapes.fbx" -module "C:\lumbeyard_version\dev\Bin64vc141.Debug\Builders\ExampleBuilder.dll" -output "C:\lumbeyard_version\dev\Logs\Shapes\"
 ```
 
 **Example**
 To process without creating a job for a specified file, run the following command.
 
-```
+```cmd
 AssetBuilder.exe -debug_process "Objects\Tutorials\Fbx\shapes.fbx"
 ```
 

--- a/content/docs/user-guide/build/_index.md
+++ b/content/docs/user-guide/build/_index.md
@@ -11,8 +11,8 @@ To support multiple native build toolchains, Open 3D Engine (O3DE) uses the [CMa
 {{< tabs >}}
 {{< tab name="Windows" codelang="cmd">}}cd <project-directory>
 mkdir build\windows
-cmake -B build/windows -S . -G "Visual Studio 16 2019" -DLY_3RDPARTY_PATH=<absolute-path-to-packages>
-cmake --build build/windows --config profile --target <ProjectName>.GameLauncher Editor -- /m
+cmake -B build/windows_vs2019 -S . -G "Visual Studio 16" -DLY_3RDPARTY_PATH=<absolute-path-to-packages>
+cmake --build build/windows_vs2019 --config profile --target <ProjectName>.GameLauncher Editor -- /m
 {{< /tab >}}
 {{< tab name="Linux" codelang="bash">}}cd <project-directory>
 mkdir -p build/linux
@@ -21,7 +21,7 @@ cmake --build build/linux --config profile --target <ProjectName>.ServerLauncher
 {{< /tab >}}
 {{< /tabs >}}
 
-Builds created with these commands are located in the `<project-directory>/<build-dir>/bin/<platform>/profile` directory.
+Builds created with these commands are located in the `<project-directory>/<build-dir>/bin/profile` directory.
 
 O3DE requires CMake {{< versions/cmake >}} or higher.
 

--- a/content/docs/user-guide/project-config/add-remove-gems.md
+++ b/content/docs/user-guide/project-config/add-remove-gems.md
@@ -28,7 +28,7 @@ The basic steps to configure Gems for your project are as follows:
 
 ### Opening the Configure Gems screen
 
-1. Launch **Project Manager**, which can be found on your desktop or in `bin/Windows/profile/o3de.exe` if you installed O3DE, or in your engine build directory if you built O3DE from source.
+1. Launch **Project Manager**, which can be found on your desktop or in `bin/Windows/profile/Default/o3de.exe` if you installed O3DE, or in your engine build directory if you built O3DE from source.
 
 1. Open the menu for a project and select the **Edit Project Settings...** button.
 

--- a/content/docs/user-guide/project-config/project-manager.md
+++ b/content/docs/user-guide/project-config/project-manager.md
@@ -49,12 +49,12 @@ To launch Project Manager, do the following:
 
 1. Open a file browser or command line window on your computer and navigate to your O3DE install directory.
 
-1. Locate and launch the Project Manager application, `o3de.exe`, from `<INSTALL_DIRECTORY>/bin/<PLATFORM>/<BUILD_CONFIGURATION>`.
+1. Locate and launch the Project Manager application, `o3de.exe`, from `<INSTALL_DIRECTORY>/bin/<PLATFORM>/<BUILD_CONFIGURATION>/Default`.
 
 Example:
 
 ```cmd
-bin\Windows\profile\o3de.exe
+bin\Windows\profile\Default\o3de.exe
 ```
 
 {{< important >}}
@@ -109,7 +109,7 @@ The project context menu contains the following actions:
 The **Engine** tab contains settings from the engine manifest and the O3DE manifest. The default folder locations are editable on this screen.
 
 {{< note >}}
-The `.o3de` directory in your user folder is the default location for all of the default folders. If you have limited drive space in your user folder, consider changing some of these default folder locations–particularly the "3rd Party Software Folder," which will contain several GB of downloaded packages after creating your first project.
+The `.o3de` directory in your user folder is the default location for all of the default folders. If you have limited drive space in your user folder, consider changing some of these default folder locations&mdash;particularly the "3rd Party Software Folder," which will contain several GB of downloaded packages after creating your first project.
 {{< /note >}}
 
 ![Engine tab with default values](/images/user-guide/project-config/project-manager/engine-tab.png)

--- a/content/docs/welcome-guide/create/creating-projects-using-cli.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli.md
@@ -113,11 +113,11 @@ If your project build directory is outside the project path, you must include th
     * If you installed O3DE or built your engine as an [SDK engine](/docs/welcome-guide/setup/setup-from-github/#build-the-engine) using the `INSTALL` target, run the Editor from the installed engine's build directory. (If you don't supply the project path, **Project Manager** launches instead.) The project path can be absolute or relative to the engine directory.
 
         ```cmd
-        C:\o3de-install\bin\Windows\profile\Editor.exe --project-path C:\o3de-projects\MyProject
+        C:\o3de-install\bin\Windows\profile\Default\Editor.exe --project-path C:\o3de-projects\MyProject
         ```
 
         {{< important >}}
-If you built the engine from source using the `INSTALL` target, make sure that you launch the Editor _and_ other tools from the installed engine's build directory, _not_ the engine's build directory. The Windows install directory typically ends in `/bin/Windows/profile`.
+If you built the engine from source using the `INSTALL` target, make sure that you launch the Editor _and_ other tools from the installed engine's build directory, _not_ the engine's build directory. The Windows install directory typically ends in `/bin/Windows/profile/Default`.
         {{< /important >}}
 
 You can also run Project Manager (`o3de.exe`) from the same directory to edit your project's settings, add or remove Gems from the project, rebuild your project, and launch the Editor.

--- a/content/docs/welcome-guide/create/creating-projects-using-project-manager.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-project-manager.md
@@ -35,12 +35,12 @@ This tutorial uses the following project name and directories in the examples:
 
 ## Launch Project Manager
 
-1. Open a file browser or command line window on your computer and navigate to your O3DE engine directory. Locate and launch the O3DE **Project Manager** application, `o3de.exe`, from `<INSTALL_DIRECTORY>/bin/Windows/profile`.
+1. Open a file browser or command line window on your computer and navigate to your O3DE engine directory. Locate and launch the O3DE **Project Manager** application, `o3de.exe`, from `<INSTALL_DIRECTORY>/bin/Windows/profile/Default`.
 
-    ![Launch o3de.exe from <INSTALL_DIRECTORY>/bin/profile](/images/welcome-guide/project-manager-location.png)
+    ![Launch o3de.exe from its build directory](/images/welcome-guide/project-manager-location.png)
 
     {{< important >}}
-If you built an SDK engine from source using the `INSTALL` target, make sure you launch the Project Manager and other tools from the **install** directory, _not_ the build directory in the engine root. For example, the Windows install directory will typically end in `/bin/Windows/profile`.
+If you built an SDK engine from source using the `INSTALL` target, make sure you launch the Project Manager and other tools from the **install** directory, _not_ the build directory in the engine root. For example, the Windows install directory will typically end in `/bin/Windows/profile/Default`.
     {{< /important >}}
 
 ## Configure the engine settings

--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -64,9 +64,6 @@ The default Visual Studio installation might not include all of the features tha
       + In the **Installation details** panel on the right, select at least one **Windows 10 SDK**.
    + Select **Desktop development with C++**.
 
-1. On the **Individual components** tab, in **Compilers, build tools, and runtime**:
-   + Select at least one version of the **MSVC v142 - VS 2019 C++ x64/x86 build tools**. If you don't know which to choose, just use **Latest**.
-
 1. Once you've completed your changes, choose the **Install** button in the lower right hand corner, selecting your preferred download option.
   {{< note >}}
   If you've made changes to an existing installation, you might see a **Modify** button in the lower right corner of the options window instead.

--- a/content/docs/welcome-guide/setup/setup-from-github.md
+++ b/content/docs/welcome-guide/setup/setup-from-github.md
@@ -243,7 +243,7 @@ Choose one of the following build types based on the primary focus of your devel
 
     * `LY_3RDPARTY_PATH` : The path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
     * `LY_VERSION_ENGINE_NAME` : The name you want to give the engine. Giving the install layout a different engine name ("o3de-install") than the source engine ("o3de") enables useful side-by-side options.
-    * `CMAKE_INSTALL_PREFIX`: The path to the installed build of the engine source. The directory you specify here is your engine install directory. You will find the Project Manager, Editor, and other tools in the subdirectory `bin/Windows/profile`. If you don't specify this option, the engine SDK binaries will be built to `<ENGINE_SOURCE>/install/bin/Windows/profile`.
+    * `CMAKE_INSTALL_PREFIX`: The path to the installed build of the engine source. The directory you specify here is your engine install directory. You will find the Project Manager, Editor, and other tools in the subdirectory `bin/Windows/profile/Default`. If you don't specify this option, the engine SDK binaries will be built to `<ENGINE_SOURCE>/install/bin/Windows/profile/Default`.
 
 1. Use CMake to build the engine as an SDK, the same as if you installed the engine from an installer tool. The following example shows the `profile` build configuration.
 
@@ -253,7 +253,7 @@ Choose one of the following build types based on the primary focus of your devel
 
     The `/m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
 
-    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de-install\bin\Windows\profile`.
+    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de-install\bin\Windows\profile\Default`.
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/docs/welcome-guide/tours/editor-tour.md
+++ b/content/docs/welcome-guide/tours/editor-tour.md
@@ -14,7 +14,7 @@ You can learn the basics of navigating and customizing O3DE Editor from the quic
 
 ## Launch O3DE Editor
 
-O3DE Editor can be launched by running `Editor.exe` from your O3DE installation's `/bin/<platform>/<config>` directory. You will be greeted by **Project Manager** which will allow you to choose or create a project. When you choose a project, O3DE Editor launches, and you're given the option to create a new level or load an existing level. Levels aren't just environments. Levels are complex assets with many files that represent a section of your project. In general, levels are stored in named subdirectories of the project's `Levels` directory.
+O3DE Editor can be launched by running `Editor.exe` from your O3DE installation's `/bin/<platform>/<config>/Default` directory. You will be greeted by **Project Manager** which will allow you to choose or create a project. When you choose a project, O3DE Editor launches, and you're given the option to create a new level or load an existing level. Levels aren't just environments. Levels are complex assets with many files that represent a section of your project. In general, levels are stored in named subdirectories of the project's `Levels` directory.
 
 ## The O3DE Editor default layout
 


### PR DESCRIPTION
1. Remove individual component - MSVC v142 step because that component is a core part of the game workload and cannot be deselected, i.e. it will always be included with the specified required workloads.
2. Add new "Default" subdirectory to the path of the binaries for installed engines.

Signed-off-by: William Hayward <wilhayw@amazon.com>