### PR TITLE
Removing the term Perspective in favor of the general term viewport

### DIFF
--- a/content/docs/contributing/to-docs/terminology.md
+++ b/content/docs/contributing/to-docs/terminology.md
@@ -15,7 +15,7 @@ Open 3D Engine (O3DE) has many unique and specialized terms. This topic explains
 * Use regular text for subsequent references to a tool, Gem, or component proper name.
 * Introduce acronyms in their expanded form followed by the acronym in parentheses. For example, "console variable (cvar)".
 * Use the acronym for subsequent on-page references.
-* Be consistent in the use of O3DE terms. For example, use "level" rather than "scene", and use "Perspective" rather than "viewport".
+* Be consistent in the use of O3DE terms. For example, use "level" rather than "scene".
 
 ## O3DE specific terms
 


### PR DESCRIPTION
 because the pane is no longer named Perspective in the interface.

Signed-off-by: Mike Cronin <mikecro@amazon.com>