### PR TITLE
Linux add note for open file limit

### DIFF
--- a/content/docs/user-guide/platforms/linux/_index.md
+++ b/content/docs/user-guide/platforms/linux/_index.md
@@ -100,5 +100,27 @@ To enable the generation of the compilation database file, include the following
 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DLY_UNITY_BUILD=OFF
 ```
 
+### Default Open File Limit
+
+On Linux systems like Ubuntu, the operating system limits how many open file handles any one process can have open at a time. The default number is typically 1024 files. 
+You can see the actual limit from the command line tool `ulimit` with the `-n` (open files) argument
+
+```shell
+ulimit -n
+1024
+```
+
+The O3DE Editor may use more than **1024** open file handles, so if this value is not updated, the Editor or one of its tools will crash or not work properly. To prevent this, you can set the value to a larger number (i.e. 65536) before launching the Editor or any of its tools.
+
+This can be done at the command line (temporary)
+
+```shell
+ulimit -n 65536
+```
+
+For a permanent change, you will need to update the system file (as a sudoer) [/etc/security/limits.conf](https://man7.org/linux/man-pages/man5/limits.conf.5.html) file and modify the `nofile` item.
+
+
+
 
 

--- a/content/docs/user-guide/platforms/linux/_index.md
+++ b/content/docs/user-guide/platforms/linux/_index.md
@@ -102,23 +102,31 @@ To enable the generation of the compilation database file, include the following
 
 ### Default Open File Limit
 
-On Linux systems like Ubuntu, the operating system limits how many open file handles any one process can have open at a time. The default number is typically 1024 files. 
-You can see the actual limit from the command line tool `ulimit` with the `-n` (open files) argument
+On Linux systems, the operating system limits how many open file handles any one process can have open at a time. The default number is typically 1024 files.
+You can see the actual limit from the command line tool `ulimit` with the `-n` (open files) argument:
 
 ```shell
 ulimit -n
 1024
 ```
 
-The O3DE Editor may use more than **1024** open file handles, so if this value is not updated, the Editor or one of its tools will crash or not work properly. To prevent this, you can set the value to a larger number (i.e. 65536) before launching the Editor or any of its tools.
+The O3DE Editor may use more than **1024** open file handles. Using the Editor will crash or not work properly when it surpasses this number of open files. The open file limit needs to be updated to accomodate a larger number of open file handles. There are two ways to do this:
 
-This can be done at the command line (temporary)
+1. Command line tool `ulimit` (Temporary)
 
 ```shell
 ulimit -n 65536
 ```
 
-For a permanent change, you will need to update the system file (as a sudoer) [/etc/security/limits.conf](https://man7.org/linux/man-pages/man5/limits.conf.5.html) file and modify the `nofile` item.
+2. Updating [/etc/security/limits.conf](https://man7.org/linux/man-pages/man5/limits.conf.5.html) (Permanent)
+
+To set the limit permanently, the file [/etc/security/limits.conf](https://man7.org/linux/man-pages/man5/limits.conf.5.html) needs to be updated:
+
+```
+ * soft    nofile          65536
+ * hard    nofile          65536
+```
+
 
 
 


### PR DESCRIPTION
Signed-off-by: Steve Pham <spham@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Linux by default sets a limit on how many open files a process can have at the same time: 1024. When the O3DE editor is launched, (at least with the AutomatedTest project), it already has just over 1000 open file handles (from lsof). There are 2 identified operations that will not work:

* Browsing Quickly through the Asset Browser ( https://github.com/o3de/o3de/issues/4659 )
* Opening the Material Editor from the Editor tools menu

This change will suggest that O3DE users update the default value to a larger, more reasonable value (65536) 

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?
