### PR TITLE
Hiding Blast documentation until Blast is fixed 

### DIFF
--- a/content/docs/user-guide/components/reference/_index.md
+++ b/content/docs/user-guide/components/reference/_index.md
@@ -91,11 +91,11 @@ The components below are grouped by type as they appear in the O3DE Editor.
 | [Camera](/docs/user-guide/components/reference/camera/camera/) | Allows an entity to be used as a camera. |
 | [Camera Rig](/docs/user-guide/components/reference/camera/camera-rig/) | Manages the behaviors that drive a camera entity. |
 
-### Destruction
+<!--### Destruction
 | Component | Description | 
 | - | - |
 | [Blast Family](/docs/user-guide/components/reference/destruction/blast-family/) | Enables destruction simulation using the [NVIDIA Blast library](https://developer.nvidia.com/blast). |
-| [Blast Family Mesh Data](/docs/user-guide/components/reference/destruction/blast-family-mesh-data/) | Sets the mesh and material assets for NVIDIA Blast entities. |
+| [Blast Family Mesh Data](/docs/user-guide/components/reference/destruction/blast-family-mesh-data/) | Sets the mesh and material assets for NVIDIA Blast entities. | Hiding until blast tools are fixed, and blast docs are updated.-->
 
 ### Editor
 | Component | Description | 

--- a/content/docs/user-guide/components/reference/destruction/_index.md
+++ b/content/docs/user-guide/components/reference/destruction/_index.md
@@ -2,4 +2,5 @@
 title: Destruction Components
 linktitle: Destruction
 description: ' Using Destruction components in Open 3D Engine (O3DE). '
+draft: true
 ---

--- a/content/docs/user-guide/components/reference/destruction/blast-family-mesh-data.md
+++ b/content/docs/user-guide/components/reference/destruction/blast-family-mesh-data.md
@@ -1,6 +1,7 @@
 ---
 description: ' Learn about the Open 3D Engine Blast Family Mesh Data component. '
 title: Blast Family Mesh Data component
+draft: true
 ---
 
 

--- a/content/docs/user-guide/components/reference/destruction/blast-family.md
+++ b/content/docs/user-guide/components/reference/destruction/blast-family.md
@@ -1,6 +1,7 @@
 ---
 title: Blast Family Component
 description: ' Learn about the Open 3D Engine Blast Family component. '
+draft: true
 ---
 
 

--- a/content/docs/user-guide/components/reference/destruction/simulate.md
+++ b/content/docs/user-guide/components/reference/destruction/simulate.md
@@ -2,6 +2,7 @@
 description: ' Create realistic destruction simulations in Open 3D Engine with NVIDIA Blast. '
 title: Simulate destruction with NVIDIA Blast
 weight: 400
+draft: true
 ---
 
 

--- a/content/docs/user-guide/gems/reference/_index.md
+++ b/content/docs/user-guide/gems/reference/_index.md
@@ -131,10 +131,10 @@ toc: true
 
 | Gem | Description |
 | - | - |
-| [NVIDIA Blast](./physics/nvidia/nvidia-blast) | The NVIDIA Blast Gem provides tools to author fractured mesh assets in Houdini, and functionality to create realistic destruction simulations in Open 3D Engine. |
 | [NVIDIA Cloth (NvCloth)](./physics/nvidia/nvidia-cloth) | The NVIDIA Cloth (NvCloth) Gem provides functionality to create realistic cloth and fabric simulation. |
 | [PhysX](./physics/nvidia/physx) | The PhysX Gem provides physics simulation with NVIDIA PhysX including static and dynamic rigid body simulation, force regions, ragdolls, and dynamic PhysX joints. |
 | [PhysX Debug](./physics/nvidia/physx-debug) | The PhysX Debug Gem provides debugging functionality and visualizations for PhysX in Open 3D Engine (O3DE) projects. |
+<!--| [NVIDIA Blast](./physics/nvidia/nvidia-blast) | The NVIDIA Blast Gem provides tools to author fractured mesh assets in Houdini, and functionality to create realistic destruction simulations in Open 3D Engine. | Hiding until blast tools are fixed and blast docs are updated.-->
 
 ## Rendering
 

--- a/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-blast.md
+++ b/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-blast.md
@@ -2,6 +2,7 @@
 description: ' Use the NVIDIA Blast Gem to simulate destruction in your Open 3D Engine
   project. '
 title: NVIDIA Blast Gem
+draft: true
 ---
 
 The NVIDIA Blast Gem uses the NVIDIA Blast library to provide fast, high-fidelity destruction simulation in Open 3D Engine.

--- a/content/docs/user-guide/interactivity/_index.md
+++ b/content/docs/user-guide/interactivity/_index.md
@@ -7,7 +7,7 @@ weight: 800
 | - | - | 
 | [Entities](entities) | Learn about how to interact with entities in the Editor. |
 | Navigation and pathfinding | - |
-| [Physics](physics) | Simulate physics interactions in O3DE using NVIDIA PhysX for collisions and rigid bodies, NVIDIA Blast to simulate destruction, and NVIDIA Cloth to simulate cloth. |
+| [Physics](physics) | Simulate physics interactions in O3DE using NVIDIA PhysX for collisions and rigid bodies, <!--NVIDIA Blast to simulate destruction, -->and NVIDIA Cloth to simulate cloth. |
 | [Prefabs](prefabs) | Learn about O3DE's prefab system. |
 | [Audio](audio) | Control audio and sound effects in your game. |
 | [Input](input) | Allow player input such as key presses and mouse clicks, to create an interactive experience in O3DE. |

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/_index.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/_index.md
@@ -3,6 +3,7 @@ description: ' Create realistic destruction simulations in Open 3D Engine with N
 linktitle: NVIDIA Blast
 title: Simulated destruction with NVIDIA Blast
 weight: 200
+draft: true
 ---
 
  With **NVIDIA Blast** in Open 3D Engine, you can simulate destruction by authoring blast assets in SideFX Houdini and creating entities with the **Blast Family** and **Blast Family Mesh Data** components.

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/create-blast-asset.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/create-blast-asset.md
@@ -2,6 +2,7 @@
 description: ' Create NVIDIA Blast assets in Houdini for Open 3D Engine. '
 title: Create assets for NVIDIA Blast
 weight: 200
+draft: true
 ---
 
 Assets for NVIDIA Blast are created in Houdini with the provided tools and plug-ins. Follow the steps below to create and export blast assets for O3DE.

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/debug.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/debug.md
@@ -3,6 +3,7 @@ description: ' Use visual debugging on destruction simulations in Open 3D Engine
   Blast. '
 title: NVIDIA Blast visual debugger
 weight: 700
+draft: true
 ---
 
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/install-houdini-plugin.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/install-houdini-plugin.md
@@ -3,6 +3,7 @@ description: ' Install Houdini plug-ins to create destruction assets for simulat
   in Open 3D Engine with NVIDIA Blast. '
 title: Install SideFX Houdini plug-ins for NVIDIA Blast
 weight: 100
+draft: true
 ---
 
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/materials.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/materials.md
@@ -3,6 +3,7 @@ description: ' Use Blast materials to set destruction properties in Open 3D Engi
   NVIDIA Blast. '
 title: Specify destruction properties with Blast materials
 weight: 600
+draft: true
 ---
 
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/process-blast-asset.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/process-blast-asset.md
@@ -2,6 +2,7 @@
 description: ' Process assets for NVIDIA Blast. '
 title: Processing assets for NVIDIA Blast
 weight: 300
+draft: true
 ---
 
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/script-canvas.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/script-canvas.md
@@ -2,6 +2,7 @@
 description: ' Create realistic destruction simulations in Open 3D Engine with NVIDIA Blast. '
 title: Script Canvas nodes for NVIDIA Blast
 weight: 800
+draft: true
 ---
 
 The NVIDIA Blast gem includes several **Script Canvas** nodes to script destructible assets. The nodes can be found in the **Blast** group in **Script Canvas**.

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/simulate.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/simulate.md
@@ -2,6 +2,7 @@
 description: ' Create realistic destruction simulations in Open 3D Engine with NVIDIA Blast. '
 title: Simulate destruction with NVIDIA Blast
 weight: 400
+draft: true
 ---
 
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-blast/static-chunks.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-blast/static-chunks.md
@@ -3,6 +3,7 @@ description: ' Create realistic partial destruction simulations in Open 3D Engin
   NVIDIA Blast. '
 title: Partial destruction with NVIDIA Blast
 weight: 500
+draft: true
 ---
 
 In some scenarios, you might want to partly destroy an entity. For example, you create a destructible wall, but want the bottom of the wall to remain in place as a static mesh with colliders after the top of the wall takes damage from a projectile and is destroyed. You can achieve this by adding **static** to the `name` primitive attribute of non-root mesh chunks in Houdini.


### PR DESCRIPTION
and the docs are updated. The Houdini tools have been removed and currently there is no reasonable path for content creators to make blast assets.

Signed-off-by: Mike Cronin <mikecro@amazon.com>

## Change summary

Commented out references to Blast Gem and Blast components on index pages. Set all component, Gem, and feature documentation related to Blast to draft.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

