### PR TITLE
Website - Remove 2021 Game Jam banners

### DIFF
--- a/layouts/community/section.html
+++ b/layouts/community/section.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-{{ partial "top-banner.html" . }}
 {{ partial "community/hero.html" . }}
 {{ partial "community/join.html" . }}
 <div class="community-blog d-flex align-items-center text-light">

--- a/layouts/download/section.html
+++ b/layouts/download/section.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-{{ partial "top-banner.html" . }}
 {{ partial "download/hero.html" . }}
 {{ with .Content }}
 <section class="container pt-lg-5">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-{{ partial "top-banner.html" . }}
 {{ partial "home/hero.html" . }}
 {{ partial "home/features.html" . }}
 {{ partial "home/partners.html" . }}


### PR DESCRIPTION
Removes the Game Jam banners from the home, download and community pages.
I'm leaving the top-banner.html partial in so that it can be easily re-used in the future.

Signed-off-by: ANT\daimini <daimini@amazon.com>