### PR TITLE
Website - Scroll to anchors with correct offset.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -160,3 +160,18 @@ $(function() {
     }
   });
 });
+
+// Detect anchor links, add correct offset and scroll behavior.
+$(function() {
+  var scrollOffset = $(".main-navbar").height() + 32;
+
+  $("a[href^=\\#]").click(function(e) {
+    e.preventDefault();
+    
+    var dest = $(this).attr('href');
+    if(dest != "" && $(dest).length > 0)
+    {
+      $('html,body').animate({ scrollTop: $(dest).offset().top - scrollOffset }, 'slow');
+    }
+  });
+});

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -166,8 +166,6 @@ $(function() {
   var scrollOffset = $(".main-navbar").height() + 32;
 
   $("a[href^=\\#]").click(function(e) {
-    e.preventDefault();
-    
     var dest = $(this).attr('href');
     if(dest != "" && $(dest).length > 0)
     {


### PR DESCRIPTION
Add some javascript to detect whenever an anchor link is clicked, and ensure the correct position is calculated (previously, the page would move to the right spot, but the top navbar was not taken into account).

The page will now scroll to the position instead of teleporting to it.

![website_scrollAnimateOffset](https://user-images.githubusercontent.com/82231674/141844539-5790af33-1b86-4553-938d-dea37816fc02.gif)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>