### PR TITLE
Website - Add YouTube icon to footer and community blocks

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -972,6 +972,8 @@ $width: '59vw';
     color: #2A4875
   .fa-twitter
     color: #2AA9E0
+  .fa-youtube
+    color: #ff0000
   a
     color: #1E70EB
 

--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,11 @@ name = "O3DE Twitter"
 url = "https://twitter.com/o3dengine"
 icon = "fab fa-twitter"
 
+[[params.social]]
+name = "O3DE YouTube"
+url = "https://www.youtube.com/channel/UCTC8GDw1XidOTUBEFRbN-sA"
+icon = "fab fa-youtube"
+
 [[params.fonts]]
 name = "Open Sans"
 sizes = [300, 400, 600, 700]

--- a/layouts/partials/community/join.html
+++ b/layouts/partials/community/join.html
@@ -7,7 +7,7 @@
     {{ $social := site.Params.social }}
     {{ range $social }}
     {{ $color := .color }}
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md-4">
       <a class="btn" title="{{ .name }}" href="{{ .url }}" target="_blank">
         {{ with .icon }}
         <span class="icon">


### PR DESCRIPTION
Added a link to the YouTube channel in the footer

![image](https://user-images.githubusercontent.com/82231674/141849745-fc4b28a1-7d55-455c-a700-44189c4fbb33.png)

The Community page uses the same list, so the YouTube icon also shows up there now. As such, I have changed the grid to 3 columns.

![image](https://user-images.githubusercontent.com/82231674/141849943-41cabd2a-156a-4755-bd1c-78c9f85ace97.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>