### PR TITLE
Fix links | Atom Guide > Passes

### DIFF
--- a/content/docs/atom-guide/dev-guide/passes/_index.md
+++ b/content/docs/atom-guide/dev-guide/passes/_index.md
@@ -23,6 +23,6 @@ Passes are a means to produce a desired visual effect. To demonstrate, consider 
 This section covers the following topics.
 | Topics                        | Description |
 |--------------------------------------|---------|
-| [Pass System](pass-system/) | An overview of the pass system in Atom. |
-| [Pass Template File Specification](pass-template-file-spec/) | JSON reference for pass template data (`*.pass` files). |
-| [Authoring Passes](authoring-passes/) | Learn how to author passes in the pass system.  |
+| [Pass System](pass-system.md) | An overview of the pass system in Atom. |
+| [Pass Template File Specification](pass-template-file-spec.md) | JSON reference for pass template data (`*.pass` files). |
+| [Authoring Passes](authoring-passes.md) | Learn how to author passes in the pass system.  |

--- a/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
+++ b/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
@@ -10,7 +10,7 @@ weight: 1200
 For authoring PassTemplates, read the [Authoring PassTemplates](#authoring-a-passtemplate) section below. 
 
 ## Root Pass and Pass Registry
-Before you begin authoring passes, it's important to understand the Pass System (read the [Pass System](pass-system/) section). The following key points are also important to understand when authoring passes: 
+Before you begin authoring passes, it's important to understand the Pass System (read the [Pass System](pass-system.md) section). The following key points are also important to understand when authoring passes: 
 - Passes are structured in a tree of nested passes, starting at the **root pass**. 
 - PassTemplates must be registered in the **Pass Registry** in order to use them. 
 
@@ -64,7 +64,7 @@ PassTemplates specifies inputs and outputs and defines its function through the 
 
 PassTemplates can also contain a `PassRequests` container, that lists child passes. When a PassTemplate gets instantiated as a Pass, each PassRequest creates a child pass. 
 
-A complete breakdown of the PassTemplate JSON file (`*.pass`) can be found in [PassTemplate File Spec](pass-template-file-spec/) section. 
+A complete breakdown of the PassTemplate JSON file (`*.pass`) can be found in [PassTemplate File Spec](pass-template-file-spec.md) section. 
 
 
 ### Registering a Pass Template

--- a/content/docs/atom-guide/dev-guide/passes/pass-system.md
+++ b/content/docs/atom-guide/dev-guide/passes/pass-system.md
@@ -117,7 +117,7 @@ To use a pass in the render pipeline, the associated pass template must first be
 
 ### Pass Template
 
-*Related to: [PassTemplate API](/docs/api/gems/atom/class_a_z_1_1_r_p_i_1_1_pass_template.html), [Pass Template File Specification](pass-template-file-spec/)*
+*Related to: [PassTemplate API](/docs/api/gems/atom/class_a_z_1_1_r_p_i_1_1_pass_template.html), [Pass Template File Specification](pass-template-file-spec.md)*
 
 **Pass templates** provide data that allows the pass system to create an instance of a pass. 
 Pass templates can be authored in C++ or through a JSON file. 

--- a/content/docs/atom-guide/dev-guide/render_pipelines.md
+++ b/content/docs/atom-guide/dev-guide/render_pipelines.md
@@ -88,7 +88,7 @@ To enable or disable a pass in the render pipeline:
 1. In the render pipeline's `.pass` file, find the pass that you want to enable or disable in the `PassRequests` list. 
 2. Set the `Enabled` property to true or false.
    
-When you enable or disable a pass, the pass system automatically updates the connections in the pass hierarchy. This requires that you've set up fallback connections. For more information, refer to [PassTemplate File Specification](content/docs/atom-guide/dev-guide/passes/pass-template-file-spec/)
+When you enable or disable a pass, the pass system automatically updates the connections in the pass hierarchy. This requires that you've set up fallback connections. For more information, refer to [PassTemplate File Specification](content/docs/atom-guide/dev-guide/passes/pass-template-file-spec.md)
 
 For example, in the `PassRequests` section of the `MainPipeline.pass`, disable `DeferredFogPass` in the render pipeline by setting `Enabled` to false.
 ```JSON


### PR DESCRIPTION
## Change summary

Fix links, by replacing / with .md to reference a page. NOTE: The link works with / in o3de.org, but not in github.com

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

