### PR TITLE
Fix broken links to using-player-input

### DIFF
--- a/content/docs/user-guide/components/reference/camera/camera-rig.md
+++ b/content/docs/user-guide/components/reference/camera/camera-rig.md
@@ -82,7 +82,7 @@ Use **Rotate Camera Target** to rotate the camera target separately from its sou
 | **Invert Axis** | If enabled, inverts the **Axis Of Rotation**. | Boolean | `Disabled` |
 | **Rotation Speed Scale** | Multiplier for Input Event values used to scale the speed of rotation. | 0.001 to Infinity | `1.0` |
 
-For more information about Input Events, refer to [Working with the Input component](/docs/user-guide/interactivity/input/working-with-the-input-component).
+For more information about Input Events, refer to [Working with the Input component](/docs/user-guide/interactivity/input/using-player-input).
 
 {{% /tab %}}
 {{% tab name="Slide Along Axis Based On Angle" %}}
@@ -132,7 +132,7 @@ Use **SlideAlongAxisBasedOnAngle** to modify the position of the look-at target 
 | **Zoom Out Event Name** | Input Event name that increases the current follow distance, in effect, zooming out. | String | None |
 | **Zoom Speed Scale** | Multiplier for Input Event values used to scale the speed of zooming. | -Infinity to Infinity | `1.0` |
 
-For more information about Input Events, refer to [Working with the Input component](/docs/user-guide/interactivity/input/working-with-the-input-component).
+For more information about Input Events, refer to [Working with the Input component](/docs/user-guide/interactivity/input/using-player-input).
 
 {{% /tab %}}
 {{% tab name="Rotate" %}}

--- a/content/docs/user-guide/scripting/lua/_index.md
+++ b/content/docs/user-guide/scripting/lua/_index.md
@@ -56,7 +56,7 @@ After you read through this tutorial on writing Lua scripts for the component en
 | Topic | Description |
 | --- | --- |
 | [Camera Component](/docs/user-guide/components/reference/camera/camera) | Use the Camera component to allow an entity to be used as a camera. |
-| [Using Player Input](/docs/user-guide/interactivity/input/working-with-the-input-component) |  Work with the Input component in O3DE. |
+| [Using Player Input](/docs/user-guide/interactivity/input/using-player-input) |  Work with the Input component in O3DE. |
 | [Input Component Event Bus Interface](/docs/user-guide/components/reference/gameplay/input-event-bus-interface) | Work with the Input component EBus (event bus). |
 | [Simple State Component](/docs/user-guide/components/reference/gameplay/simple-state) | Use the Simple State component to provide a simple state machine. |
 | [Tag Component](/docs/user-guide/components/reference/gameplay/tag) | Use the Tag component to apply labels to entities. |


### PR DESCRIPTION
Signed-off-by: Jonathan Capes <j.capes@gmail.com>

## Change summary

Fix a few links that pointed to a page that was renamed: using-player-input.md.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

