### PR TITLE
Documented the new LY_ARCHIVE_FILE_SEARCH_MODE Cache Variable

### DIFF
--- a/content/docs/user-guide/build/reference.md
+++ b/content/docs/user-guide/build/reference.md
@@ -43,9 +43,10 @@ These options control the types of assets that are built, and where projects loa
 
 * **`LY_ASSET_DEPLOY_TYPE`** - The *default* type of assets to be built by the [asset processor](/docs/user-guide/assets/pipeline/processor/). Valid platforms are:
   * `pc` - Windows PC
-  * `osx_gl` - MacOS
+  * `linux` - Linux
+  * `mac` - MacOS
   * `ios` - iOS and iPad OS
-  * `es3` - Android
+  * `android` - Android
   
   *Type*: `STRING`  
   *Default*: The asset type for the current host platform.
@@ -58,11 +59,14 @@ These options control the types of assets that are built, and where projects loa
   *Type*: `STRING`  
   *Default*: `LOOSE`
 
-* **`LY_OVERRIDE_PAK_FOLDER_ROOT`**  
-Controls where asset `.pak` files are loaded from. An empty string uses the predefined `paks` root.  
+* **`LY_ARCHIVE_FILE_SEARCH_MODE`**  
+Defines the default file search mode to locate non-Pak files within the Archive System
+  *  `0` = Search file system first, before searching within mounted `.pak` files.
+  *  `1` = Search mounted `.pak` files first, before searching file system.
+  *  `2` = Search only mounted `.pak` files.
 
   *Type*: `STRING`  
-  *Default*: Predefined `paks` root under your O3DE installation
+  *Default*: `0` = (debug/profile configurations), `2` = (release configuration)
 
 ### Package system settings
 


### PR DESCRIPTION
Removed `LY_OVERRIDE_PAK_FOLDER_ROOT` documentation.
It being referenced in the cmake/FileUtil.cmake doesn't change any
behavior.

closes #1215

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ x] **Help the user** - Does the documentation show the user something *meaningful*?

