### PR TITLE
Hide interactivity/entities and interactivity/navigation

### DIFF
--- a/content/docs/user-guide/interactivity/_index.md
+++ b/content/docs/user-guide/interactivity/_index.md
@@ -5,8 +5,8 @@ weight: 800
 
 | Topic | Description |
 | - | - | 
-| [Entities](entities) | Learn about how to interact with entities in the Editor. |
-| Navigation and pathfinding | - |
+<!-- | [Entities](entities) | Learn about how to interact with entities in the Editor. | -->
+<!-- | Navigation and pathfinding | - | -->
 | [Physics](physics) | Simulate physics interactions in O3DE using NVIDIA PhysX for collisions and rigid bodies, <!--NVIDIA Blast to simulate destruction, -->and NVIDIA Cloth to simulate cloth. |
 | [Prefabs](prefabs) | Learn about O3DE's prefab system. |
 | [Audio](audio) | Control audio and sound effects in your game. |

--- a/content/docs/user-guide/interactivity/_index.md
+++ b/content/docs/user-guide/interactivity/_index.md
@@ -5,10 +5,10 @@ weight: 800
 
 | Topic | Description |
 | - | - | 
-<!-- | [Entities](entities) | Learn about how to interact with entities in the Editor. | -->
-<!-- | Navigation and pathfinding | - | -->
 | [Physics](physics) | Simulate physics interactions in O3DE using NVIDIA PhysX for collisions and rigid bodies, <!--NVIDIA Blast to simulate destruction, -->and NVIDIA Cloth to simulate cloth. |
 | [Prefabs](prefabs) | Learn about O3DE's prefab system. |
 | [Audio](audio) | Control audio and sound effects in your game. |
 | [Input](input) | Allow player input such as key presses and mouse clicks, to create an interactive experience in O3DE. |
 | [User interface](user-interface) | Create a user interface in your game such as with images, text, buttons, menus, scroll boxes, and heads-up displays (HUDs). |
+<!-- | [Entities](entities) | Learn about how to interact with entities in the Editor. | -->
+<!-- | Navigation and pathfinding | - | -->


### PR DESCRIPTION
Hide section links to empty pages in the interactivity directory.

Fix #254

