### PR TITLE
Update component and gem reference page titles

### DIFF
--- a/content/docs/user-guide/components/reference/ai/nav-area.md
+++ b/content/docs/user-guide/components/reference/ai/nav-area.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Navigation Area
 description: ' Use the Navigation Area component with the Polygon Prism Shape component
   to create navigation meshes in Open 3D Engine. '
-title: Navigation Area
+title: Navigation Area Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/ai/nav-seed.md
+++ b/content/docs/user-guide/components/reference/ai/nav-seed.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Navigation Seed
 description: ' Use the Navigation Seed component to generate a color-coded markup
   that indicates where your AI can travel in Open 3D Engine. '
-title: Navigation Seed
+title: Navigation Seed Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/ai/navigation.md
+++ b/content/docs/user-guide/components/reference/ai/navigation.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Navigation
 description: ' Use the Navigation component to enable an entity to find and follow
   paths in Open 3D Engine. '
-title: Navigation
+title: Navigation Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/animation/animgraph.md
+++ b/content/docs/user-guide/components/reference/animation/animgraph.md
@@ -1,16 +1,17 @@
 ---
+linkTitle: Anim Graph
 description: ' Use the AnimGraph component to adds an animation graph and motion set
   to your character. '
-title: AnimGraph
+title: Anim Graph Component
 ---
 
 
 
-You can use the **AnimGraph** component to add an animation graph and motion set to your character. Add this component to the [Actor](/docs/user-guide/components/reference/animation/actor/) component to control character behavior from an animation graph. For single motions, see the [Simple Motion](/docs/user-guide/components/reference/animation/simple-motion/) component.
+You can use the **Anim Graph** component to add an animation graph and motion set to your character. Add this component to the [Actor](/docs/user-guide/components/reference/animation/actor/) component to control character behavior from an animation graph. For single motions, see the [Simple Motion](/docs/user-guide/components/reference/animation/simple-motion/) component.
 
-## AnimGraph Component Properties 
+## Anim Graph Component Properties 
 
-The **AnimGraph** component has the following properties:
+The **Anim Graph** component has the following properties:
 
 **Anim graph**
 Lets you select the animation graph that was created in the Animation Editor.

--- a/content/docs/user-guide/components/reference/animation/attachment.md
+++ b/content/docs/user-guide/components/reference/animation/attachment.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Attachment
 description: ' Use the Attachment component to attach an entity''s bone to a bone
   on the skeleton of another entity in Open 3D Engine. '
-title: Attachment
+title: Attachment Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/atom/decal.md
+++ b/content/docs/user-guide/components/reference/atom/decal.md
@@ -1,5 +1,5 @@
 ---
-title: Decal component
+title: Decal Component
 linktitle: Decal
 description: "Open 3D Engine (O3DE) Decal component reference."
 toc: true
@@ -38,4 +38,3 @@ Example of a decal with attenuation angle set to 1. More attenuation means less 
 The black scorch mark decal has a larger sort key than the orange dirt decal and thus is on top.
 
 ![Decal component sorting order example](/images/user-guide/components/reference/atom/decal-component-ui/decal-component-sorting-example.png)
-

--- a/content/docs/user-guide/components/reference/atom/diffuse-gi.md
+++ b/content/docs/user-guide/components/reference/atom/diffuse-gi.md
@@ -1,5 +1,5 @@
 ---
-title: Diffuse Global Illumination component
+title: Diffuse Global Illumination Component
 linktitle: Diffuse Global Illumination
 description: Open 3D Engine (O3DE) Diffuse Global Illumination component reference.
 toc: true

--- a/content/docs/user-guide/components/reference/atom/directional-light.md
+++ b/content/docs/user-guide/components/reference/atom/directional-light.md
@@ -1,5 +1,5 @@
 ---
-title: Directional Light component
+title: Directional Light Component
 linktitle: Directional Light
 description: 'Open 3D Engine (O3DE) Directional Light component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/display-mapper.md
+++ b/content/docs/user-guide/components/reference/atom/display-mapper.md
@@ -1,5 +1,5 @@
 ---
-title: Display Mapper component
+title: Display Mapper Component
 linktitle: Display Mapper
 description: 'Open 3D Engine (O3DE) Display Mapper component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/entity-reference.md
+++ b/content/docs/user-guide/components/reference/atom/entity-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Entity Reference component
+title: Entity Reference Component
 linktitle: Entity Reference
 description: 'Open 3D Engine (O3DE) Entity Reference component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/exposure-control.md
+++ b/content/docs/user-guide/components/reference/atom/exposure-control.md
@@ -1,5 +1,5 @@
 ---
-title: Exposure Control component
+title: Exposure Control Component
 linktitle: Exposure Control
 description: 'Open 3D Engine (O3DE) Exposure Control component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
+++ b/content/docs/user-guide/components/reference/atom/global-skylight-ibl.md
@@ -1,5 +1,5 @@
 ---
-title: Global Skylight (IBL) component
+title: Global Skylight (IBL) Component
 linktitle: Global Skylight (IBL)
 description: 'Open 3D Engine (O3DE) Global Skylight (IBL) component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/grid.md
+++ b/content/docs/user-guide/components/reference/atom/grid.md
@@ -1,5 +1,5 @@
 ---
-title: Grid component
+title: Grid Component
 linktitle: Grid
 description: 'Open 3D Engine (O3DE) Grid component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/hdri-skybox.md
+++ b/content/docs/user-guide/components/reference/atom/hdri-skybox.md
@@ -1,5 +1,5 @@
 ---
-title: HDRi Skybox component
+title: HDRi Skybox Component
 linktitle: HDRi Skybox
 description: 'Open 3D Engine (O3DE) HDRi Skybox component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/look-modification.md
+++ b/content/docs/user-guide/components/reference/atom/look-modification.md
@@ -1,5 +1,5 @@
 ---
-title: Look Modification component
+title: Look Modification Component
 linktitle: Look Modification
 description: 'Open 3D Engine (O3DE) Look Modification component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/material.md
+++ b/content/docs/user-guide/components/reference/atom/material.md
@@ -1,5 +1,5 @@
 ---
-title: Material component
+title: Material Component
 linktitle: Material
 description: 'Open 3D Engine (O3DE) Material component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/mesh.md
+++ b/content/docs/user-guide/components/reference/atom/mesh.md
@@ -1,5 +1,5 @@
 ---
-title: Mesh component
+title: Mesh Component
 linktitle: Mesh
 description: 'Open 3D Engine (O3DE) Mesh component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
+++ b/content/docs/user-guide/components/reference/atom/occlusion-culling-plane.md
@@ -1,5 +1,5 @@
 ---
-title: Occlusion Culling Plane component
+title: Occlusion Culling Plane Component
 linktitle: Occlusion Culling Plane
 description: 'Open 3D Engine (O3DE) Occlusion Culling Plane component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/physical-sky.md
+++ b/content/docs/user-guide/components/reference/atom/physical-sky.md
@@ -1,5 +1,5 @@
 ---
-title: Physical Sky component
+title: Physical Sky Component
 linktitle: Physical Sky
 description: 'Open 3D Engine (O3DE) Physical Sky component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-gradient-weight-modifier.md
@@ -1,5 +1,5 @@
 ---
-title: PostFX Gradient Weight Modifier component
+title: PostFX Gradient Weight Modifier Component
 linktitle: PostFX Gradient Weight Modifier
 description: 'Open 3D Engine (O3DE) PostFX Gradient Weight Modifier component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/postfx-layer.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-layer.md
@@ -1,5 +1,5 @@
 ---
-title: PostFX Layer component
+title: PostFX Layer Component
 linktitle: PostFX Layer
 description: 'Open 3D Engine (O3DE) PostFX Layer component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/postfx-radius-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-radius-weight-modifier.md
@@ -1,5 +1,5 @@
 ---
-title: PostFX Radius Weight Modifier component
+title: PostFX Radius Weight Modifier Component
 linktitle: PostFX Radius Weight Modifier
 description: 'Open 3D Engine (O3DE) PostFx Radius Weight Modifier component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-shape-weight-modifier.md
@@ -1,5 +1,5 @@
 ---
-title: PostFX Shape Weight Modifier component
+title: PostFX Shape Weight Modifier Component
 linktitle: PostFX Shape Weight Modifier
 description: 'Open 3D Engine (O3DE) PostFX Shape Weight Modifier component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/reflection-probe.md
+++ b/content/docs/user-guide/components/reference/atom/reflection-probe.md
@@ -1,5 +1,5 @@
 ---
-title: Reflection Probe component
+title: Reflection Probe Component
 linktitle: Reflection Probe
 description: 'Open 3D Engine (O3DE) Reflection Probe component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/atom/ssao.md
+++ b/content/docs/user-guide/components/reference/atom/ssao.md
@@ -1,5 +1,5 @@
 ---
-title: SSAO component
+title: SSAO Component
 linktitle: SSAO
 description: 'Open 3D Engine (O3DE) SSAO component reference.'
 toc: true

--- a/content/docs/user-guide/components/reference/audio/area-environment.md
+++ b/content/docs/user-guide/components/reference/audio/area-environment.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Area Environment
+linkTitle: Audio Area Environment
+title: Audio Area Environment Component
 description: Use the Audio Area Environment component in O3DE to apply an environment effect to sounds that an entity triggers.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/environment.md
+++ b/content/docs/user-guide/components/reference/audio/environment.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Environment
+linkTitle: Audio Environment
+title: Audio Environment Component
 description: Use the Audio Environment component to set up a default environment for an entity in Open 3D Engine.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/listener.md
+++ b/content/docs/user-guide/components/reference/audio/listener.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Listener
+linkTitle: Audio Listener
+title: Audio Listener Component
 description: Use the Audio Listener component to add a virtual microphone in the Open 3D Engine environment.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/multi-position.md
+++ b/content/docs/user-guide/components/reference/audio/multi-position.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Multi-Position
+linkTitle: Audio Multi-Position
+title: Audio Multi-Position Component
 description: Use the Audio Multi-Position component to play sounds at multiple locations in Open 3D Engine.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/preload.md
+++ b/content/docs/user-guide/components/reference/audio/preload.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Preload
+linkTitle: Audio Preload
+title: Audio Preload Component
 description: Use the Audio Area Environment component in Open 3D Engine to apply an environment effect to sounds that an entity triggers.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/proxy.md
+++ b/content/docs/user-guide/components/reference/audio/proxy.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Proxy
+linkTitle: Audio Proxy
+title: Audio Proxy Component
 description: Use the Audio Proxy component in O3DE to provide a method of communication between multiple audio components.
 ---
 

--- a/content/docs/user-guide/components/reference/audio/rtpc.md
+++ b/content/docs/user-guide/components/reference/audio/rtpc.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Rtpc
+linkTitle: Audio RTPC
+title: Audio RTPC Component
 description: Use the Audio RTPC component to set values at runtime that produce real-time tweaking of sounds in Open 3D Engine.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/switch.md
+++ b/content/docs/user-guide/components/reference/audio/switch.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Switch
+linkTitle: Audio Switch
+title: Audio Switch Component
 description: Use the Audio Switch component to set up a default switch and switch states for an entity in O3DE.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/audio/trigger.md
+++ b/content/docs/user-guide/components/reference/audio/trigger.md
@@ -1,5 +1,6 @@
 ---
-title: Audio Trigger
+linkTitle: Audio Trigger
+title: Audio Trigger Component
 description: Use the Audio Trigger component to set up play and stop triggers in your game in O3DE.
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/destruction/blast-family-mesh-data.md
+++ b/content/docs/user-guide/components/reference/destruction/blast-family-mesh-data.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: Blast Family Mesh Data
 description: ' Learn about the Open 3D Engine Blast Family Mesh Data component. '
-title: Blast Family Mesh Data component
+title: Blast Family Mesh Data Component
 draft: true
 ---
 

--- a/content/docs/user-guide/components/reference/destruction/blast-family.md
+++ b/content/docs/user-guide/components/reference/destruction/blast-family.md
@@ -1,4 +1,5 @@
 ---
+linkTitle: Blast Family
 title: Blast Family Component
 description: ' Learn about the Open 3D Engine Blast Family component. '
 draft: true

--- a/content/docs/user-guide/components/reference/non-uniform-scale/non-uniform-scale.md
+++ b/content/docs/user-guide/components/reference/non-uniform-scale/non-uniform-scale.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: Non-uniform Scale
 description: ' Use the Non-uniform Scale component to scale an entity by different amounts along each axis. '
-title: Non-uniform Scale
+title: Non-uniform Scale Component
 ---
 
 The **Non-uniform Scale** component allows entities to be scaled by different amounts along each local axis. It can be added by clicking the **Add non-uniform scale** button on the [Transform](/docs/user-guide/components/reference/transform/) component.

--- a/content/docs/user-guide/components/reference/physx/ball-joint.md
+++ b/content/docs/user-guide/components/reference/physx/ball-joint.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: PhysX Ball Joint
 description: ' The Open 3D Engine PhysX Ball Joint component. '
-title: PhysX Ball Joint component
+title: PhysX Ball Joint Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/character-controller.md
+++ b/content/docs/user-guide/components/reference/physx/character-controller.md
@@ -1,7 +1,7 @@
 ---
-description: ' Use the PhysX Character Controller component to implement basic character
-  interactions in Open 3D Engine. '
-title: PhysX Character Controller
+linkTitle: PhysX Character Controller
+description: Use the PhysX Character Controller component to implement basic character interactions in Open 3D Engine (O3DE).
+title: PhysX Character Controller Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/character-gameplay.md
+++ b/content/docs/user-guide/components/reference/physx/character-gameplay.md
@@ -1,10 +1,9 @@
 ---
+linkTitle: PhysX Character Gameplay
 description: ' The PhysX Character Gameplay component provides example implementations of gameplay features such as gravity. '
-title: PhysX Character Gameplay
+title: PhysX Character Gameplay Component
 ---
 
 
 
 The **PhysX Character Gameplay** component builds on top of the **[PhysX Character Controller](/docs/user-guide/components/reference/physx/character-controller/)** component. The components are separated so that the **PhysX Character Controller** component provides basic behavior which is expected to be more universal, while the **PhysX Character Gameplay** component provides example implementations of logic which is likely to be more game-specific, such as gravity.
-
-

--- a/content/docs/user-guide/components/reference/physx/cloth.md
+++ b/content/docs/user-guide/components/reference/physx/cloth.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: Cloth
 description: ' The Open 3D Engine Cloth component. '
-title: Cloth component
+title: Cloth Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/collider.md
+++ b/content/docs/user-guide/components/reference/physx/collider.md
@@ -1,7 +1,7 @@
 ---
-description: ' Use the PhysX Collider component to define where collision detection
-  and response occur in Open 3D Engine. '
-title: PhysX Collider
+linkTitle: PhysX Collider
+description: Use the PhysX Collider component to define where collision detection and response occur in Open 3D Engine (O3DE).
+title: PhysX Collider Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/fixed-joint.md
+++ b/content/docs/user-guide/components/reference/physx/fixed-joint.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: PhysX Fixed Joint
 description: ' The Open 3D Engine PhysX Fixed Joint component. '
-title: PhysX Fixed Joint component
+title: PhysX Fixed Joint Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/force-region.md
+++ b/content/docs/user-guide/components/reference/physx/force-region.md
@@ -1,7 +1,7 @@
 ---
-description: ' Use the PhysX Force Region component to specify a region that applies
-  physical force to entities. '
-title: PhysX Force Region
+linkTitle: PhysX Force Region
+description: ' Use the PhysX Force Region component to specify a region that applies physical force to entities. '
+title: PhysX Force Region Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/heightfield-collider.md
+++ b/content/docs/user-guide/components/reference/physx/heightfield-collider.md
@@ -1,6 +1,6 @@
 ---
 linkTitle: PhysX Heightfield Collider
-title: PhysX Heightfield Collider
+title: PhysX Heightfield Collider Component
 description: Use the PhysX Heightfield Collider component to create collision for heightfields such as terrain in Open 3D Engine (O3DE).
 toc: true
 ---

--- a/content/docs/user-guide/components/reference/physx/hinge-joint.md
+++ b/content/docs/user-guide/components/reference/physx/hinge-joint.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: PhysX Hinge Joint
 description: ' Lean to use the Open 3D Engine PhysX Hinge Joint component. '
-title: PhysX Hinge Joint component
+title: PhysX Hinge Joint Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/ragdoll.md
+++ b/content/docs/user-guide/components/reference/physx/ragdoll.md
@@ -1,7 +1,7 @@
 ---
-description: ' Use the PhysX Ragdoll component to create a physical representation
-  of a character in the Open 3D Engine Animation Editor . '
-title: PhysX Ragdoll
+linkTitle: PhysX Ragdoll
+description: Use the PhysX Ragdoll component to create a physical representation of a character in the Open 3D Engine (O3DE) Animation Editor.
+title: PhysX Ragdoll Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/rigid-body-physics.md
+++ b/content/docs/user-guide/components/reference/physx/rigid-body-physics.md
@@ -1,6 +1,7 @@
 ---
+linkTitle: PhysX Rigid Body
 description: ' Learn more about the PhysX Rigid Body component in Open 3D Engine. '
-title: PhysX Rigid Body
+title: PhysX Rigid Body Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/physx/shape-collider.md
+++ b/content/docs/user-guide/components/reference/physx/shape-collider.md
@@ -1,7 +1,7 @@
 ---
-description: ' Use the PhysX Shape Collider component to define where collision
-  detection and response occur in Open 3D Engine. '
-title: 'PhysX Shape Collider'
+linkTitle: PhysX Shape Collider
+description: Use the PhysX Shape Collider component to define where collision detection and response occur in Open 3D Engine (O3DE).
+title: PhysX Shape Collider Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/terrain/height_gradient_list.md
+++ b/content/docs/user-guide/components/reference/terrain/height_gradient_list.md
@@ -1,6 +1,6 @@
 ---
-title: Terrain Height Gradient List component
-linktitle: TerrainHeightGradientList
+title: Terrain Height Gradient List Component
+linktitle: Terrain Height Gradient List
 description: ' Open 3D Engine (O3DE) Terrain Height Gradient List reference. '
 weight: 100
 ---
@@ -28,5 +28,3 @@ TerrainExists \[out\] - Indicates whether gradient data exists for the given pos
 
 **Return**  
 None
-
-

--- a/content/docs/user-guide/components/reference/terrain/layer_spawner.md
+++ b/content/docs/user-guide/components/reference/terrain/layer_spawner.md
@@ -1,6 +1,6 @@
 ---
-title: Terrain Layer Spawner component
-linktitle: LayerSpawner
+title: Terrain Layer Spawner Component
+linktitle: Terrain Layer Spawner
 description: ' Open 3D Engine (O3DE) Terrain Layer Spawner reference. '
 weight: 100
 ---

--- a/content/docs/user-guide/components/reference/transform.md
+++ b/content/docs/user-guide/components/reference/transform.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Transform
 description: ' Use the Transform component to move, rotate, and scale an entity in
   Open 3D Engine. '
-title: Transform
+title: Transform Component
 ---
 
 The **Transform** component controls the translation, rotation, and scale information of an entity in the 3D world. When you create an entity in O3DE Editor, the **Transform** component is automatically added. The translation is the coordinate location (x, y, and z axes) of the entity. The rotation is the degree in which the entity is rotated around its center. The uniform scale is the dimension of the entity in comparison to its original size, applied uniformly in each direction.

--- a/content/docs/user-guide/components/reference/ui/canvas-asset-ref.md
+++ b/content/docs/user-guide/components/reference/ui/canvas-asset-ref.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: UI Canvas Asset Ref
 description: ' Use the UI Canvas Asset Ref component in Open 3D Engine to associate a UI
   canvas with a component entity in a level. '
-title: UI Canvas Asset Ref
+title: UI Canvas Asset Ref Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/ui/canvas-on-mesh.md
+++ b/content/docs/user-guide/components/reference/ui/canvas-on-mesh.md
@@ -1,8 +1,9 @@
 ---
+linkTitle: UI Canvas on Mesh
 description: ' Use the UI Canvas on Mesh component in Open 3D Engine to place a UI canvas
   on a component entity in the 3D world that a player can interact with using ray
   casts. '
-title: UI Canvas on Mesh
+title: UI Canvas on Mesh Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/ui/canvas-proxy-ref.md
+++ b/content/docs/user-guide/components/reference/ui/canvas-proxy-ref.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: UI Canvas Proxy Ref
 description: ' Use the UI Canvas Proxy Ref component in Open 3D Engine to place a UI canvas
   on a 3D mesh that a player can interact with. '
-title: UI Canvas Proxy Ref
+title: UI Canvas Proxy Ref Component
 ---
 
 

--- a/content/docs/user-guide/components/reference/vegetation/layer-spawner.md
+++ b/content/docs/user-guide/components/reference/vegetation/layer-spawner.md
@@ -1,7 +1,8 @@
 ---
+linkTitle: Vegetation Layer Spawner
 description: ' Use the Vegetation Layer Spawner component to define areas and rules
   for procedurally placing dynamic vegetation or other static meshes in Open 3D Engine. '
-title: Vegetation Layer Spawner
+title: Vegetation Layer Spawner Component
 ---
 
 

--- a/content/docs/user-guide/gems/reference/_index.md
+++ b/content/docs/user-guide/gems/reference/_index.md
@@ -12,8 +12,8 @@ toc: true
 
 | Gem | Description |
 | - | - |
-| [EMotionFX](./animation/emotionfx) | The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors and includes Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors. |
-| [Maestro](./animation/maestro) | The Maestro Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor. |
+| [EMotion FX Animation](./animation/emotionfx) | The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors and includes Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors. |
+| [Maestro Cinematics](./animation/maestro) | The Maestro Cinematics Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor. |
 
 ## Artificial Intelligence
 
@@ -29,7 +29,7 @@ toc: true
 | [Asset Validation](./assets/asset-validation) | The Asset Validation Gem provides seed-related commands to ensure assets have valid seeds for asset bundling. |
 | [Custom Asset Example](./assets/custom-asset-example) | The Custom Asset Example Gem provides example code for creating a custom asset for Open 3D Engine's asset pipeline. |
 | [Dev Textures](./assets/dev-textures) | The Dev Textures Gem provides a collection of general purpose texture assets useful for prototypes and preproduction. |
-| [Prefab](./assets/prefab) | The Prefab Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities. |
+| [Prefab Builder](./assets/prefab) | The Prefab Builder Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities. |
 | [Primitive Assets](./assets/primitive-assets) | The Primitive Assets Gem provides primitive shape mesh objects with physics enabled. |
 | [Scene Processing](./assets/scene-processing) | The Scene Processing Gem provides FBX Settings, a tool you can use to specify the default settings for processing .fbx files for actors, meshes, motions, and PhysX. |
 | [Test Asset Builder](./assets/test-asset-builder) | The Test Asset Builder Gem is used to feature test Asset Processor. |
@@ -62,10 +62,10 @@ toc: true
 | Gem | Description |
 | - | - |
 | [Asset Memory Analyzer](./debug/asset-memory-analyzer) | The Asset Memory Analyzer Gem provides tools to profile asset memory usage in Open 3D Engine through ImGUI (Immediate Mode Graphical User Interface). |
-| [Automated Launcher Testing](./debug/automated-launcher-testing) | The Automated Launcher Testing Gem manages automated Open 3D Engine (O3DE) launcher tests. |
 | [Crash Reporting](./debug/crash-reporting) | The Crash Reporting Gem provides support for external crash reporting for Open 3D Engine projects. |
 | [Debug Draw](./debug/debug-draw) | The Debug Draw Gem provides Editor and runtime debug visualization features for Open 3D Engine. |
-| [Immediate Mode GUI (ImGui)](./debug/imgui) | The Immediate Mode GUI Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine. |
+| [Immediate Mode GUI (IMGUI)](./debug/imgui) | The Immediate Mode GUI Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine. |
+<!-- | [Automated Launcher Testing](./debug/automated-launcher-testing) | The Automated Launcher Testing Gem manages automated Open 3D Engine (O3DE) launcher tests. | -->
 
 ## Design
 
@@ -80,8 +80,8 @@ toc: true
 | [Landscape Canvas](./environment/landscape-canvas) | The Landscape Canvas Gem provides the Landscape Canvas editor; a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation. |
 | [Surface Data](./environment/surface-data) | The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain. |
 | [Vegetation](./environment/vegetation) | The Vegetation Gem provides tools to place natural-looking vegetation in Open 3D Engine. |
-| [Vegetation Gem Assets](./environment/vegetation-gem-assets) | The Vegetation Assets Gem provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and Landscape Canvas. |
 | [Terrain](./environment/terrain) | The Terrain Gem provides a terrain system that maps height, color, and surface data to regions of the world. It also provides gradient-based and shape-based authoring tools and workflows, integrates with physics for physical simulation and efficiently renders terrain. |
+<!-- | [Vegetation Gem Assets](./environment/vegetation-gem-assets) | The Vegetation Assets Gem provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and Landscape Canvas. | -->
 
 ## Framework
 
@@ -139,13 +139,13 @@ toc: true
 
 | Gem | Description |
 | - | - |
-| [Atom](./rendering/atom/atom) | The Atom Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces. |
+| [Atom Common Features](./rendering/atom/atom) | The Atom Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces. |
 | [Atom Content](./rendering/atom/atom-content) | The Atom Content Gem provides assets including models, textures, and materials, that  can be used to test Atom Renderer in  Open 3D Engine. |
 | [Atom O3DE Integration](./rendering/atom/atom-o3de-integration) | The Atom O3DE Integration Gem provides components, libraries, and functionality to support and integrate Atom Renderer in Open 3D Engine. |
 | [Atom TressFX](./rendering/amd/atom-tressfx) | The Atom TressFX Gem provides realistic hair and fur simulation and rendering in Atom and Open 3D Engine. |
 | [Camera](./rendering/camera) | The Camera Gem provides a basic camera component that defines a frustum for runtime rendering. |
 | [Camera Framework](./rendering/camera-framework) | The Camera Framework Gem provides a base for implementing more complex camera systems. |
-| [PBS Reference Materials](./rendering/pbs-reference-materials) | The PBS Reference Materials Gem provides physically based reference materials for Open 3D Engine (O3DE) projects. |
+| [PBR Reference Materials](./rendering/pbr-reference-materials) | The PBR Reference Materials Gem provides physically based reference materials for Open 3D Engine (O3DE) projects. |
 | [Starting Point Camera](./rendering/starting-point-camera) | The Starting Point Camera Gem provides the behaviors used with the Camera Framework Gem to define a camera rig. |
 | [Video Playback Framework](./rendering/video-playback-framework) | The Video Playback Framework Gem provides the interface to play back video. |
 
@@ -168,7 +168,7 @@ toc: true
 
 | Gem | Description |
 | - | - |
-| [In App Purchases](./sdk/in-app-purchases) | The In App Purchases Gem provides functionality for in app purchases in Open 3D Engine projects. |
+| [In-App Purchases](./sdk/in-app-purchases) | The In-App Purchases Gem provides functionality for in app purchases in Open 3D Engine projects. |
 
 ## UI
 

--- a/content/docs/user-guide/gems/reference/animation/emotionfx.md
+++ b/content/docs/user-guide/gems/reference/animation/emotionfx.md
@@ -1,11 +1,11 @@
 ---
-linkTitle: EMotionFX
-title: EMotionFX Animation Gem
-description: The EMotionFX Animation Gem provides Open 3D Engine's animation system for rigged actors including Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors.
+linkTitle: EMotion FX Animation
+title: EMotion FX Animation Gem
+description: The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors including Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors.
 toc: true
 ---
 
-Add the EmotionFX Animation Gem to your **Open 3D Engine (O3DE)** project to enable **Animation Editor**. Animation Editor provides an intuitive node-based system for controlling actor behavior with animation graphs. You can visually build hierarchal state machines and blend trees driven by parameters and events to animate rigged actors.
+Add the Emotion FX Animation Gem to your **Open 3D Engine (O3DE)** project to enable **Animation Editor**. Animation Editor provides an intuitive node-based system for controlling actor behavior with animation graphs. You can visually build hierarchal state machines and blend trees driven by parameters and events to animate rigged actors.
 
 Animation Editor includes tools for building the following:
 

--- a/content/docs/user-guide/gems/reference/animation/maestro.md
+++ b/content/docs/user-guide/gems/reference/animation/maestro.md
@@ -1,13 +1,11 @@
 ---
-linkTitle: Maestro
-title: Maestro Gem
-description: The Maestro Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor.
+linkTitle: Maestro Cinematics
+title: Maestro Cinematics Gem
+description: The Maestro Cinematics Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor.
 toc: true
 ---
 
 
-The Maestro Gem provides Track View, Open 3D Engine's (O3DE) animated sequence and cinematics editor.
-
-The Maestro gem is required and enabled by default in new O3DE projects.
+The Maestro Cinematics Gem provides Track View, Open 3D Engine's (O3DE) animated sequence and cinematics editor.
 
 For more information, see [Create cinematic sequences](/docs/user-guide/visualization/cinematics).

--- a/content/docs/user-guide/gems/reference/assets/prefab.md
+++ b/content/docs/user-guide/gems/reference/assets/prefab.md
@@ -1,8 +1,10 @@
 ---
-linkTitle: Prefab
-title: Prefab Gem
-description: The Prefab Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities.
+linkTitle: Prefab Builder
+title: Prefab Builder Gem
+description: The Prefab Builder Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities.
 toc: true
 ---
 
-The Prefab Gem provides an **Asset Processor** module for prefabs, which are complex assets built by combining smaller entities.
+The Prefab Builder Gem provides an **Asset Processor** module for prefabs, which are complex assets built by combining smaller entities.
+
+The Prefab Builder Gem is required to use prefabs in your project.

--- a/content/docs/user-guide/gems/reference/debug/automated-launcher-testing.md
+++ b/content/docs/user-guide/gems/reference/debug/automated-launcher-testing.md
@@ -3,6 +3,7 @@ linkTitle: Automated Launcher Testing
 title: Automated Launcher Testing Gem
 description: The Automated Launcher Testing Gem manages automated Open 3D Engine (O3DE) launcher tests.
 toc: true
+draft: true
 ---
 
 The Automated Launcher Testing Gem manages automated **Open 3D Engine (O3DE)** launcher tests.

--- a/content/docs/user-guide/gems/reference/debug/imgui.md
+++ b/content/docs/user-guide/gems/reference/debug/imgui.md
@@ -1,8 +1,8 @@
 ---
-linkTitle: IMGUI
-title: IMGUI Gem
-description: The ImGUI Gem provides the 3rdParty library IMGUI which can be used to create runtime immediate mode overlays for debugging and profiling in Open 3D Engine (O3DE) projects.
+linkTitle: Immediate Mode GUI (IMGUI)
+title: Immediate Mode GUI (IMGUI) Gem
+description: The Immediate Mode GUI (IMGUI) Gem provides the 3rdParty library IMGUI which can be used to create runtime immediate mode overlays for debugging and profiling in Open 3D Engine (O3DE) projects.
 toc: true
 ---
 
-The Immediate Mode GUI (IMGUI) Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine. ImGUI is used by the Asset Memory Analyzer and PhysX debugging tools.
+The Immediate Mode GUI (IMGUI) Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine. Atom ImGUI is used by the Asset Memory Analyzer and PhysX debugging tools.

--- a/content/docs/user-guide/gems/reference/environment/_index.md
+++ b/content/docs/user-guide/gems/reference/environment/_index.md
@@ -8,6 +8,6 @@ The dynamic vegetation system uses vegetation components to customize dynamic ve
 
 The [Landscape Canvas Gem](./landscape-canvas) provides the **Landscape Canvas** editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.
 
-The [Vegetation Assets Gem](./vegetation-gem-assets) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.
+<!-- The [Vegetation Assets Gem](./vegetation-gem-assets) provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**. -->
 
 The [Surface Data Gem](./surface-data) enables surfaces such as terrain or meshes to emit signals or tags, that communicate its surface type. These signals and tags have various uses, such as creating inclusion and exclusion areas for vegetation growth.

--- a/content/docs/user-guide/gems/reference/environment/vegetation-gem-assets.md
+++ b/content/docs/user-guide/gems/reference/environment/vegetation-gem-assets.md
@@ -4,6 +4,7 @@ title: Vegetation Assets Gem
 description: The Vegetation Assets Gem provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and Landscape Canvas.
 weight: 300
 toc: true
+draft: true
 ---
 
 The Vegetation Assets Gem provides vegetation models, textures, and other assets and samples for use with the Vegetation Gem and **Landscape Canvas**.

--- a/content/docs/user-guide/gems/reference/gameplay/game-state-samples.md
+++ b/content/docs/user-guide/gems/reference/gameplay/game-state-samples.md
@@ -5,11 +5,11 @@ description: The Game State Samples Gem provides a set of sample game states (bu
 toc: true
 ---
 
-The GameState Samples gem uses the [GameState Gem](/docs/user-guide/gems/reference/gameplay/game-state) to provide a set of sample game states that control the high-level flow of a game.
+The Game State Samples gem uses the [GameState Gem](/docs/user-guide/gems/reference/gameplay/game-state) to provide a set of sample game states that control the high-level flow of a game.
 
 ## Game States Included
 
-The GameState Samples gem includes the following game states. These states commonly occur in the beginning, middle, and end of a game.
+The Game State Samples gem includes the following game states. These states commonly occur in the beginning, middle, and end of a game.
 
 * **Main menu state** - Enables any level in the project to be loaded from a button click.
 * **Level loading state** - Displays a placeholder loading screen.
@@ -21,7 +21,7 @@ The GameState Samples gem includes the following game states. These states commo
 
 The following diagram shows the flow of the default game states in the GameState Samples gem.
 
-![Flow of game states in the GameState Samples gem.](/images/user-guide/gems/gems-system-gem-game-state-samples-2.png)
+![Flow of game states in the Game State Samples gem.](/images/user-guide/gems/gems-system-gem-game-state-samples-2.png)
 
 ## Possible Uses
 

--- a/content/docs/user-guide/gems/reference/input/starting-point-movement.md
+++ b/content/docs/user-guide/gems/reference/input/starting-point-movement.md
@@ -4,4 +4,4 @@ title: Starting Point Movement Gem
 description: The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events in Open 3D Engine (O3DE).
 ---
 
-The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events and apply tranformations such as translate and rotate to entities.
+The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events and apply transformations such as translate and rotate to entities.

--- a/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-blast.md
+++ b/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-blast.md
@@ -1,4 +1,5 @@
 ---
+linkTitle: NVIDIA Blast
 description: ' Use the NVIDIA Blast Gem to simulate destruction in your Open 3D Engine
   project. '
 title: NVIDIA Blast Gem
@@ -57,4 +58,3 @@ The NVIDIA Blast Gem provides the following:
    ```
    cmake --build <CMake build dir> --config profile --target <Project name> -- /m
    ```
-

--- a/content/docs/user-guide/gems/reference/rendering/atom/atom.md
+++ b/content/docs/user-guide/gems/reference/rendering/atom/atom.md
@@ -1,10 +1,10 @@
 ---
-linkTitle: Atom
-title: Atom Gem
-description: The Atom Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces.
+linkTitle: Atom Common Features
+title: Atom Common Features Gem
+description: The Atom Common Features Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces.
 toc: true
 ---
 
-The Atom Gem adds **Atom Renderer** and associated tools and utilties such as **Material Editor** to Open 3D Engine projects. Atom is a modular, data-driven, and multi-threaded renderer that supports Forward+ rendering.
+The Atom Common Features Gem adds **Atom Renderer** and associated tools and utilties such as **Material Editor** to Open 3D Engine projects. Atom is a modular, data-driven, and multi-threaded renderer that supports Forward+ rendering.
 
 For more information refer to the [Atom Guide](/docs/atom-guide).

--- a/content/docs/user-guide/gems/reference/rendering/pbs-reference-materials.md
+++ b/content/docs/user-guide/gems/reference/rendering/pbs-reference-materials.md
@@ -1,8 +1,0 @@
----
-linkTitle: PBS Reference Materials
-title: PBS Reference Materials Gem
-description: The PBS Reference Materials Gem provides physically based reference materials for Open 3D Engine (O3DE) projects.
-toc: true
----
-
-The PBS Reference Materials Gem provides physically based reference materials for **Open 3D Engine (O3DE)** projects. Physically based materials simulate the real world light transmission properties of surfaces.

--- a/content/docs/user-guide/gems/reference/sdk/in-app-purchases.md
+++ b/content/docs/user-guide/gems/reference/sdk/in-app-purchases.md
@@ -1,7 +1,7 @@
 ---
-linkTitle: In App Purchases
-title: In App Purchases Gem
-description: The In App Purchases Gem provides functionality for in app purchases in Open 3D Engine (O3DE) projects.
+linkTitle: In-App Purchases
+title: In-App Purchases Gem
+description: The In-App Purchases Gem provides functionality for in app purchases in Open 3D Engine (O3DE) projects.
 toc: true
 ---
 

--- a/pbr-reference-materials.md
+++ b/pbr-reference-materials.md
@@ -1,0 +1,8 @@
+---
+linkTitle: PBR Reference Materials
+title: PBR Reference Materials Gem
+description: The PBR Reference Materials Gem provides physically based reference materials for Open 3D Engine (O3DE) projects.
+toc: true
+---
+
+The PBR Reference Materials Gem provides physically based reference materials for **Open 3D Engine (O3DE)** projects. Physically based materials simulate the real world light transmission properties of surfaces.


### PR DESCRIPTION
Fix #568 

## Change summary

Hide Vegetation Gem Assets and Automated Launcher Testing gem.
Remove note that Maestro gem is required and enabled by default.

Edited gemnames: 
Atom -> Atom Common Features
IMGUI -> Immediate Mode GUI (IMGUI)
Prefab -> Prefab Builder
Maestro -> Maestro Cinematics
EmotionFX -> Emotion FX Animation
