### PR TITLE
Size info warning and removal instructions

### DIFF
--- a/content/docs/welcome-guide/setup/installing-linux.md
+++ b/content/docs/welcome-guide/setup/installing-linux.md
@@ -23,12 +23,13 @@ The following instructions assume that you have met all hardware and software re
     * `<path_to_deb_package>`: The path where you downloaded the deb package. Example: `~/Downloads`.
     * `<debian_package_name>`: The name of the package. Example: `o3de_2111_1.deb`.
 
-    {{< known-issue >}}
+    {{< known-issue link="https://bugs.launchpad.net/ubuntu/+source/synaptic/+bug/1522675" >}}
 When installing the package, you may observe the following error:
 ```shell
-N: Download is performed unsandboxed as root as file '/home/<user>/Downloads/o3de_2111_1.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
+N: Download is performed unsandboxed as root as file '/home/<user>/Downloads/o3de_2111_1.deb' 
+   couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
 ```
-This is a [bug](https://bugs.launchpad.net/ubuntu/+source/synaptic/+bug/1522675) in apt that has already been fixed. The error should go away once your current Linux distribution takes the fix.
+This is a bug in apt that has already been fixed. The error should go away once your current Linux distribution takes the fix.
 Until your distribution takes the fix, you can workaround the issue by repairing folder permissions with the following commands:
 ```shell
 sudo chown -Rv _apt:root /var/cache/apt/archives/partial/
@@ -36,13 +37,12 @@ sudo chmod -Rv 700 /var/cache/apt/archives/partial/
 ```
     {{< /known-issue >}}
 
-    {{< known-issue >}}
+    {{< known-issue link="https://salsa.debian.org/apt-team/apt/-/merge_requests/177" >}}
 If removing and installing the package, you may observe a warning like the following:
 ```shell
 W: Repository is broken: o3de:amd64 (= 21.11.1) has no Size information
 ```
-This is a [bug](https://salsa.debian.org/apt-team/apt/-/merge_requests/177) in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix.
-The issue is a warning and does not affect installing or removing.
+This is a bug in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix. The issue is a warning and does not affect installing or removing.
     {{< /known-issue >}}
 
     O3DE will be installed in the default location: `/opt/O3DE/<version>`, where `<version>` is the version of the installer. Example: `2111_1`.

--- a/content/docs/welcome-guide/setup/installing-linux.md
+++ b/content/docs/welcome-guide/setup/installing-linux.md
@@ -21,15 +21,28 @@ The following instructions assume that you have met all hardware and software re
     ```
     Use the following path substitutions:
     * `<path_to_deb_package>`: The path where you downloaded the deb package. Example: `~/Downloads`.
-    * `<debian_package_name>`: The name of the package. Example: `O3DE_2111_1.deb`.
+    * `<debian_package_name>`: The name of the package. Example: `o3de_2111_1.deb`.
 
     {{< known-issue >}}
-    If removing and installing the package, you may observe a warning like the following:
-        ```shell
-        W: Repository is broken: o3de:amd64 (= 21.11.1) has no Size information
-        ```
-    This is a [bug](https://salsa.debian.org/apt-team/apt/-/merge_requests/177) in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix.
-    The issue is a warning and does not affect installing or removing.
+When installing the package, you may observe the following error:
+```shell
+N: Download is performed unsandboxed as root as file '/home/<user>/Downloads/o3de_2111_1.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
+```
+This is a [bug](https://bugs.launchpad.net/ubuntu/+source/synaptic/+bug/1522675) in apt that has already been fixed. The error should go away once your current Linux distribution takes the fix.
+Until your distribution takes the fix, you can workaround the issue by repairing folder permissions with the following commands:
+```shell
+sudo chown -Rv _apt:root /var/cache/apt/archives/partial/
+sudo chmod -Rv 700 /var/cache/apt/archives/partial/
+```
+    {{< /known-issue >}}
+
+    {{< known-issue >}}
+If removing and installing the package, you may observe a warning like the following:
+```shell
+W: Repository is broken: o3de:amd64 (= 21.11.1) has no Size information
+```
+This is a [bug](https://salsa.debian.org/apt-team/apt/-/merge_requests/177) in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix.
+The issue is a warning and does not affect installing or removing.
     {{< /known-issue >}}
 
     O3DE will be installed in the default location: `/opt/O3DE/<version>`, where `<version>` is the version of the installer. Example: `2111_1`.
@@ -77,13 +90,18 @@ Example of launching Project Manager from the shell:
     Reading package lists... Done
     Building dependency tree
     Reading state information... Done
-    Package 'o3de' is not installed, so not removed
     The following packages were automatically installed and are no longer required:
-    gir1.2-ibus-1.0 libasound2-dev libblkid-dev libdbus-1-dev libegl1-mesa-dev libgles2-mesa-dev libglib2.0-dev libglib2.0-dev-bin libibus-1.0-5 libibus-1.0-dev libice-dev libmount-dev libpcre16-3
-    libpcre2-16-0 libpcre2-32-0 libpcre2-dev libpcre2-posix2 libpcre3-dev libpcre32-3 libpcrecpp0v5 libpulse-dev libpulse-mainloop-glib0 libsdl2-2.0-0 libsdl2-dev libselinux1-dev libsepol1-dev libsm-dev
-    libsndio-dev libsndio7.0 libudev-dev libwayland-bin libwayland-cursor0 libwayland-dev libwayland-egl1 libxcb-render0 libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinput-dev
-    libxcb-xkb-dev libxcb-xkb1 libxcursor-dev libxcursor1 libxfixes-dev libxi-dev libxinerama-dev libxkbcommon-dev libxkbcommon-x11-0 libxkbcommon-x11-dev libxkbcommon0 libxrandr-dev libxrender-dev
-    libxt-dev x11proto-input-dev x11proto-randr-dev x11proto-xinerama-dev
+      gir1.2-ibus-1.0 libasound2-dev libblkid-dev libdbus-1-dev libegl1-mesa-dev libgles2-mesa-dev libglib2.0-dev libglib2.0-dev-bin libibus-1.0-5 libibus-1.0-dev libice-dev libmount-dev libpcre16-3
+      libpcre2-16-0 libpcre2-32-0 libpcre2-dev libpcre2-posix2 libpcre3-dev libpcre32-3 libpcrecpp0v5 libpulse-dev libpulse-mainloop-glib0 libsdl2-2.0-0 libsdl2-dev libselinux1-dev libsepol1-dev libsm-dev
+      libsndio-dev libsndio7.0 libudev-dev libwayland-bin libwayland-cursor0 libwayland-dev libwayland-egl1 libxcb-render0 libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinput-dev
+      libxcb-xkb-dev libxcb-xkb1 libxcursor-dev libxcursor1 libxfixes-dev libxi-dev libxinerama-dev libxkbcommon-dev libxkbcommon-x11-0 libxkbcommon-x11-dev libxkbcommon0 libxrandr-dev libxrender-dev
+      libxt-dev x11proto-input-dev x11proto-randr-dev x11proto-xinerama-dev
     Use 'sudo apt autoremove' to remove them.
-    0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+    The following packages will be REMOVED:
+      o3de
+    0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
+    After this operation, 18.5 GB disk space will be freed.
+    Do you want to continue? [Y/n] Y
+    (Reading database ... 66411 files and directories currently installed.)
+    Removing o3de (0.0.0.0) ...
     ```

--- a/content/docs/welcome-guide/setup/installing-linux.md
+++ b/content/docs/welcome-guide/setup/installing-linux.md
@@ -23,6 +23,15 @@ The following instructions assume that you have met all hardware and software re
     * `<path_to_deb_package>`: The path where you downloaded the deb package. Example: `~/Downloads`.
     * `<debian_package_name>`: The name of the package. Example: `O3DE_2111_1.deb`.
 
+    {{< known-issue >}}
+    If removing and installing the package, you may observe a warning like the following:
+        ```shell
+        W: Repository is broken: o3de:amd64 (= 21.11.1) has no Size information
+        ```
+    This is a [bug](https://salsa.debian.org/apt-team/apt/-/merge_requests/177) in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix.
+    The issue is a warning and does not affect installing or removing.
+    {{< /known-issue >}}
+
     O3DE will be installed in the default location: `/opt/O3DE/<version>`, where `<version>` is the version of the installer. Example: `2111_1`.
 
 1. During installation, the installer downloads additional packages as needed. The process can take some time, depending on your internet connection speed and what packages were already installed. An example output looks like the following (versions and paths may not match):
@@ -56,3 +65,25 @@ Example of launching Project Manager from the shell:
 ```shell
 /opt/O3DE/2111_1/bin/Linux/profile/Default/o3de
 ```
+
+## Removing O3DE
+
+1. Run apt to remove o3de:
+    ```shell
+    sudo apt remove o3de
+    ```
+    An output like the following will be displayed:
+    ```shell
+    Reading package lists... Done
+    Building dependency tree
+    Reading state information... Done
+    Package 'o3de' is not installed, so not removed
+    The following packages were automatically installed and are no longer required:
+    gir1.2-ibus-1.0 libasound2-dev libblkid-dev libdbus-1-dev libegl1-mesa-dev libgles2-mesa-dev libglib2.0-dev libglib2.0-dev-bin libibus-1.0-5 libibus-1.0-dev libice-dev libmount-dev libpcre16-3
+    libpcre2-16-0 libpcre2-32-0 libpcre2-dev libpcre2-posix2 libpcre3-dev libpcre32-3 libpcrecpp0v5 libpulse-dev libpulse-mainloop-glib0 libsdl2-2.0-0 libsdl2-dev libselinux1-dev libsepol1-dev libsm-dev
+    libsndio-dev libsndio7.0 libudev-dev libwayland-bin libwayland-cursor0 libwayland-dev libwayland-egl1 libxcb-render0 libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinput-dev
+    libxcb-xkb-dev libxcb-xkb1 libxcursor-dev libxcursor1 libxfixes-dev libxi-dev libxinerama-dev libxkbcommon-dev libxkbcommon-x11-0 libxkbcommon-x11-dev libxkbcommon0 libxrandr-dev libxrender-dev
+    libxt-dev x11proto-input-dev x11proto-randr-dev x11proto-xinerama-dev
+    Use 'sudo apt autoremove' to remove them.
+    0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+    ```

--- a/content/docs/welcome-guide/setup/installing-linux.md
+++ b/content/docs/welcome-guide/setup/installing-linux.md
@@ -25,13 +25,13 @@ The following instructions assume that you have met all hardware and software re
 
     {{< known-issue link="https://bugs.launchpad.net/ubuntu/+source/synaptic/+bug/1522675" >}}
 When installing the package, you may observe the following error:
-```shell
+```
 N: Download is performed unsandboxed as root as file '/home/<user>/Downloads/o3de_2111_1.deb' 
    couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
 ```
 This is a bug in apt that has already been fixed. The error should go away once your current Linux distribution takes the fix.
 Until your distribution takes the fix, you can workaround the issue by repairing folder permissions with the following commands:
-```shell
+```
 sudo chown -Rv _apt:root /var/cache/apt/archives/partial/
 sudo chmod -Rv 700 /var/cache/apt/archives/partial/
 ```
@@ -39,7 +39,7 @@ sudo chmod -Rv 700 /var/cache/apt/archives/partial/
 
     {{< known-issue link="https://salsa.debian.org/apt-team/apt/-/merge_requests/177" >}}
 If removing and installing the package, you may observe a warning like the following:
-```shell
+```
 W: Repository is broken: o3de:amd64 (= 21.11.1) has no Size information
 ```
 This is a bug in apt that has already been fixed. The warning should go away once your current Linux distribution takes the fix. The issue is a warning and does not affect installing or removing.


### PR DESCRIPTION
## Change summary

Adds a known-issue for a warning that may be observed during the Linux installation procedure (for reference: https://github.com/o3de/o3de/issues/6009)
Adds instructions to remove O3DE

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

