### PR TITLE
Removes some padding that is causing the first line of code sections to be a couple of pixels off

### DIFF
--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -247,7 +247,6 @@ pre
     background-color: #2f1e2e
 
 code 
-  padding: 0.1rem
   border-radius: 5px
   background-color: #ebebeb
 


### PR DESCRIPTION
## Change summary

Removes some padding that is causing the first line of code sections to be a couple of pixels off

Before:
![image (12)](https://user-images.githubusercontent.com/81431996/144132443-5fdf57c3-83f2-45c5-991f-30af09010976.png)
After:
![image (13)](https://user-images.githubusercontent.com/81431996/144132459-1c172dff-63cd-4e3c-b006-9fb345c3c2e1.png)

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

