### PR TITLE
Fixes MSBuild compile option (/m should be -m)

### DIFF
--- a/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
@@ -56,10 +56,10 @@ To prepare to build the engine and projects, choose one of the following build t
     The following example shows the `profile` build configuration.
 
     ```cmd
-    cmake --build build/windows_vs2019 --target Editor --config profile -- /m
+    cmake --build build/windows_vs2019 --target Editor --config profile -- -m
     ```
 
-    The `/m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
+    The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de\build\windows_vs2019\bin\profile`.
 
@@ -97,10 +97,10 @@ To prepare to build the engine and projects, choose one of the following build t
 1. Use CMake to build the engine as an SDK, the same as if you installed the engine from an installer tool. The following example shows the `profile` build configuration.
 
     ```cmd
-    cmake --build build/windows_vs2019 --target INSTALL --config profile -- /m
+    cmake --build build/windows_vs2019 --target INSTALL --config profile -- -m
     ```
 
-    The `/m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
+    The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de-install\bin\Windows\profile\Default`.
 


### PR DESCRIPTION
Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>

## Change summary
Fixes bug #1253 - The compile parameter for msbuild is actually -m, not /m, and /m is interpreted as a folder name, resulting in an error.
See https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2019

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

## Impacted page(s)

https://github.com/o3de/o3de.org/blob/main/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
which turns into
https://o3de.org/docs/welcome-guide/setup/setup-from-github/building-windows/