### PR TITLE
Fixed links to custom tool gem tutorials

### DIFF
--- a/content/docs/learning-guide/tutorials/extend-the-editor/_index.md
+++ b/content/docs/learning-guide/tutorials/extend-the-editor/_index.md
@@ -8,5 +8,5 @@ Extend the **Open 3D Engine (O3DE) Editor** by creating a custom tool Gem. A too
 
 | Tutorial | Description |
 | - | - |
-| [Create a Custom Tool Gem in C++](extend-the-editor/shape-example-cpp.md) | Extend the Editor by creating a custom tool Gem that's written in C++. Learn how to use the **CppToolGem** template, and practice C++ development with [Qt](https://wiki.qt.io/Main), the O3DE Tools UI API, and other O3DE APIs. |
-| [Create a Custom Tool Gem in Python](extend-the-editor/shape-example-py.md) | Extend the Editor by creating a custom tool Gem that's written in Python. Learn how to use the **PythonToolGem** template, and practice Python development with [Qt](https://wiki.qt.io/Main), the O3DE Tools UI API, and other O3DE APIs.|
+| [Create a Custom Tool Gem in C++](./shape-example-cpp.md) | Extend the Editor by creating a custom tool Gem that's written in C++. Learn how to use the **CppToolGem** template, and practice C++ development with [Qt](https://wiki.qt.io/Main), the O3DE Tools UI API, and other O3DE APIs. |
+| [Create a Custom Tool Gem in Python](./shape-example-py.md) | Extend the Editor by creating a custom tool Gem that's written in Python. Learn how to use the **PythonToolGem** template, and practice Python development with [Qt](https://wiki.qt.io/Main), the O3DE Tools UI API, and other O3DE APIs.|


### PR DESCRIPTION
Signed-off-by: Matias Lavik <mlavik1@users.noreply.github.com>

## Change summary

I changed the links to the two custom tool gem tutorials ("Create a Custom Tool Gem in C++" and "Create a Custom Tool Gem in Python") to use relative path (./) instead.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Resolves #1273 