### PR TITLE
Temporary Google Search Console verification

### DIFF
--- a/static/docs/googlec2c22bf460a5707d.html
+++ b/static/docs/googlec2c22bf460a5707d.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec2c22bf460a5707d.html


### PR DESCRIPTION
## Change summary

Adds a Google site verification doc that will allow me to use the Google search console to investigate why a large portion of our docs are not returned in Google search results #1292 

This webpage will be removed after investigation is complete.

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>