### PR TITLE
Shortcode to reduce size of embedded YT videos

### DIFF
--- a/content/docs/atom-guide/_index.md
+++ b/content/docs/atom-guide/_index.md
@@ -11,7 +11,7 @@ primary: false
 
 Welcome to the Atom Documentation! Atom Renderer is the graphics engine powering **Open 3D Engine (O3DE)**. Check out the video below for a quick overview of some of Atom's features. Then, read on learn more about creating beautiful, high performance graphics with Atom!
 
-{{< youtube id="GTJ_ie7yHdI" title="Atom Renderer" >}}
+{{< youtube-width id="GTJ_ie7yHdI" title="Atom Renderer" >}}
 
 | Section                        | Description |
 |--------------------------------------|---------|

--- a/content/docs/contributing/to-docs/get-started.md
+++ b/content/docs/contributing/to-docs/get-started.md
@@ -29,7 +29,7 @@ Participation as a contributor requires a [GitHub account](https://github.com/si
 
 Don't want to read tiresome words, and prefer a snappy video to help you get started? Watch this video, instead!
 
-{{< youtube id="DGz9Clo6EKw" title="Contributing to O3DE Documentation" >}}
+{{< youtube-width id="DGz9Clo6EKw" title="Contributing to O3DE Documentation" >}}
 
 ## Technical information
 

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -141,7 +141,7 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 2. title
 3. width (using the default value (50%) is recommended)
 
-### Examples 
+**Examples** 
 
 1. `youtube-width` example without the `width` parameter uses the default value `width: 50%`:
 

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -151,7 +151,7 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 
     Output:
 
-    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" >}}
 
     <br>
 

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -135,11 +135,11 @@ Animated images are not currently accepted for contribution due to limitations o
 
 Embed Youtube videos in your page by using the `youtube-width` shortcode. The `youtube-width` shortcode is an extended version of Hugo's built-in [`youtube` shortcode](https://gohugo.io/content-management/shortcodes/#youtube) that allows you to control the size of the embedded video. 
 
-`youtube-width` takes three double-quoted parameters in order:
+`youtube-width` supports the following double-quoted parameters:
 
 1. id
 2. title
-3. width
+3. width (using the default value (50%) is recommended)
 
 `youtube-width` example:
 

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -141,12 +141,26 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 2. title
 3. width (using the default value (50%) is recommended)
 
-`youtube-width` example:
+### Examples 
 
-```markdown
-{{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" */>}}
-```
+1. `youtube-width` example without the `width` parameter:
 
-`youtube-width` example output:
+    ```markdown
+    {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" */>}}
+    ```
 
-{{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}
+    Output:
+
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}
+
+    <br>
+
+2. `youtube-width` example with the `width` parameter:
+
+    ```markdown
+    {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="100%" */>}}
+    ```
+
+    Output:
+
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="100%" >}}

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -143,7 +143,7 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 
 ### Examples 
 
-1. `youtube-width` example without the `width` parameter:
+1. `youtube-width` example without the `width` parameter uses the default value `width: 50%`:
 
     ```markdown
     {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" */>}}

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -129,3 +129,24 @@ Animated images are not currently accepted for contribution due to limitations o
 
 1. **Left-click** on the entity in **Perspective** to select it.
 1. **LMB+Drag** on the transform gizmo's **Z** axis to move the entity on the world **Z** axis.
+
+
+## Embedding Youtube videos with the `youtube-width` shortcode
+
+Embed Youtube videos in your page by using the `youtube-width` shortcode. The `youtube-width` shortcode is an extended version of Hugo's built-in [`youtube` shortcode](https://gohugo.io/content-management/shortcodes/#youtube) that allows you to control the size of the embedded video. 
+
+`youtube-width` takes three double-quoted parameters in order:
+
+1. id
+2. title
+3. width
+
+`youtube-width` example:
+
+```markdown
+{{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" */>}}
+```
+
+`youtube-width` example output:
+
+{{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}

--- a/content/docs/learning-guide/_index.md
+++ b/content/docs/learning-guide/_index.md
@@ -22,40 +22,40 @@ This guide contains video tutorials, written step-by-step tutorials, and sample 
 
 ### What is O3DE?
 
-{{< youtube id="CQmjAxr7LZs" title="What is O3DE?" >}}
+{{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" >}}
 
 ### Setting up O3DE from GitHub
 
-{{< youtube id="CIw9UoMMeX8" title="Setting up O3DE from GitHub" >}}
+{{< youtube-width id="CIw9UoMMeX8" title="Setting up O3DE from GitHub" >}}
 
 ### Creating Projects Using the Command Line
 
-{{< youtube id="SZC13S0YZZs" title="Creating Projects Using the Command Line" >}}
+{{< youtube-width id="SZC13S0YZZs" title="Creating Projects Using the Command Line" >}}
 
 ### O3DE Developer Overview
 
-{{< youtube id="lWhPwDYeuhc" title="O3DE Developer Overview" >}}
+{{< youtube-width id="lWhPwDYeuhc" title="O3DE Developer Overview" >}}
 
 ### Atom Renderer
 
-{{< youtube id="GTJ_ie7yHdI" title="Atom Renderer" >}}
+{{< youtube-width id="GTJ_ie7yHdI" title="Atom Renderer" >}}
 
 ### O3DE Networking Overview
 
-{{< youtube id="FfrkHJJt_X0" title="O3DE Networking Overview" >}}
+{{< youtube-width id="FfrkHJJt_X0" title="O3DE Networking Overview" >}}
 
 ### AWS Gems in O3DE
 
-{{< youtube id="EG0C9enezzo" title="AWS Gems in O3DE" >}}
+{{< youtube-width id="EG0C9enezzo" title="AWS Gems in O3DE" >}}
 
 ### O3DE Editor Tour
 
-{{< youtube id="tFfiXhckd7g" title="O3DE Editor Tour" >}}
+{{< youtube-width id="tFfiXhckd7g" title="O3DE Editor Tour" >}}
 
 ### O3DE Script Canvas Overview
 
-{{< youtube id="fTNcUV4zAgE" title="O3DE Script Canvas Overview" >}}
+{{< youtube-width id="fTNcUV4zAgE" title="O3DE Script Canvas Overview" >}}
 
 ## Contributing to O3DE Documentation
 
-{{< youtube id="DGz9Clo6EKw" title="Contributing to O3DE Documentation" >}}
+{{< youtube-width id="DGz9Clo6EKw" title="Contributing to O3DE Documentation" >}}

--- a/content/docs/learning-guide/tutorials/first-project/_index.md
+++ b/content/docs/learning-guide/tutorials/first-project/_index.md
@@ -15,32 +15,32 @@ Games, as conventional wisdom goes, started with Pong. Your experience with O3DE
 
 ### Pong Project and Level Creation
 
-{{< youtube id="kK0XnYFKw38" title="O3DE - 001: Pong Project and Level Creation" >}}
+{{< youtube-width id="kK0XnYFKw38" title="O3DE - 001: Pong Project and Level Creation" >}}
 
 ### Creating the Game Start Menu
 
-{{< youtube id="ULsTwK-GEt8" title="O3DE - 002: Pong Creating a Start Menu" >}}
+{{< youtube-width id="ULsTwK-GEt8" title="O3DE - 002: Pong Creating a Start Menu" >}}
 
 ### Scripting the Game Start Menu
 
-{{< youtube id="6-353OtcTkM" title="O3DE - 003: Pong Scripting the Start Menu" >}}
+{{< youtube-width id="6-353OtcTkM" title="O3DE - 003: Pong Scripting the Start Menu" >}}
 
 ### Creating the Pong Level Assets
 
-{{< youtube id="1z5SOi-McPI" title="O3DE - 004: Pong Creating The Level Assets" >}}
+{{< youtube-width id="1z5SOi-McPI" title="O3DE - 004: Pong Creating The Level Assets" >}}
 
 ### Scripting Player (Paddle) Movement and Controls
 
-{{< youtube id="4zwZcVQskGg" title="O3DE - 005: Pong Scripting Paddle Movement" >}}
+{{< youtube-width id="4zwZcVQskGg" title="O3DE - 005: Pong Scripting Paddle Movement" >}}
 
 ### Implementing a Simple Game State Machine
 
-{{< youtube id="Z7hqAJnj4-g" title="O3DE - 006 Pong Simple State Machine" >}}
+{{< youtube-width id="Z7hqAJnj4-g" title="O3DE - 006 Pong Simple State Machine" >}}
 
 ### Scripting Ball Movement and Behaviors
 
-{{< youtube id="Z84zOz0DCMg" title="O3DE - 007: Pong Scripting Our Ball Movement" >}}
+{{< youtube-width id="Z84zOz0DCMg" title="O3DE - 007: Pong Scripting Our Ball Movement" >}}
 
 ### Creating the "Game Over" User Interface
 
-{{< youtube id="cqQNHGkyo94" title="O3DE - 008 Pong Creating The Game Over UI" >}}
+{{< youtube-width id="cqQNHGkyo94" title="O3DE - 008 Pong Creating The Game Over UI" >}}

--- a/content/docs/user-guide/gems/reference/aws/_index.md
+++ b/content/docs/user-guide/gems/reference/aws/_index.md
@@ -8,7 +8,7 @@ Amazon Web Services (AWS) is a cloud platform that offers an extensive and power
 
 For an overview of AWS Gems in **Open 3D Engine (O3DE)**, check out the video below. Then, read on to learn more about using AWS in your O3DE projects!
 
-{{< youtube id="EG0C9enezzo" title="AWS Gems in O3DE" >}}
+{{< youtube-width id="EG0C9enezzo" title="AWS Gems in O3DE" >}}
 
 ## Cloud-based resources
 

--- a/content/docs/user-guide/gems/reference/multiplayer/_index.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/_index.md
@@ -8,7 +8,7 @@ Open 3D Engine ships with a Multiplayer Gem that uses the [O3DE networking stack
 
 For a quick introduction of the O3DE Multiplayer Gem and networking, watch the video below.
 
-{{< youtube id="FfrkHJJt_X0" title="O3DE - Networking Overview" >}}
+{{< youtube-width id="FfrkHJJt_X0" title="O3DE - Networking Overview" >}}
 
 ## Section topics
 

--- a/content/docs/user-guide/networking/_index.md
+++ b/content/docs/user-guide/networking/_index.md
@@ -8,7 +8,7 @@ Open 3D Engine uses an abstracted interface layer, the `AzNetworking` framework,
 
 For a quick introduction to the O3DE network layer and Multiplayer Gem, watch the video below.
 
-{{< youtube id="FfrkHJJt_X0" title="O3DE - Networking Overview" >}}
+{{< youtube-width id="FfrkHJJt_X0" title="O3DE - Networking Overview" >}}
 
 ## Section topics
 

--- a/content/docs/welcome-guide/_index.md
+++ b/content/docs/welcome-guide/_index.md
@@ -13,7 +13,7 @@ primary: true
 
 O3DE is an open-source, cross-platform, real time 3D engine that you can use to create high performance interactive experiences, including games and simulations. Check out the video below for a quick overview of some of O3DE's biggest features. Then, read on to get set up and start creating with O3DE!
 
-{{< youtube id="CQmjAxr7LZs" title="What is O3DE?" >}}
+{{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" >}}
 
 ## Get Started Guide Contents
 

--- a/content/docs/welcome-guide/create/creating-projects-using-cli/_index.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli/_index.md
@@ -16,4 +16,4 @@ The instructions guide you through the following steps:
 
 At the end of the tutorial, you'll have a new O3DE project based on the default "standard" project template.
 
-{{< youtube id="SZC13S0YZZs" title="Creating O3DE Projects Using Command Line" >}}
+{{< youtube-width id="SZC13S0YZZs" title="Creating O3DE Projects Using Command Line" >}}

--- a/content/docs/welcome-guide/create/creating-projects-using-project-manager.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-project-manager.md
@@ -14,7 +14,7 @@ This tutorial provides an introduction to project configuration and building in 
 
 At the end of the tutorial, you'll have a new O3DE project based on the default "standard" project template, ready to open in **O3DE Editor**.
 
-{{< youtube id="5VtWprJJBaw" title="O3DE Project Creation Using Project Manager" >}}
+{{< youtube-width id="5VtWprJJBaw" title="O3DE Project Creation Using Project Manager" >}}
 
 ## Prerequisites
 

--- a/content/docs/welcome-guide/setup/setup-from-github/_index.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/_index.md
@@ -14,7 +14,7 @@ The video and written instructions in this section guide you through the followi
 * Build the O3DE engine.
 * Register the engine.
 
-{{< youtube id="CIw9UoMMeX8" title="Setting up O3DE from GitHub" >}}
+{{< youtube-width id="CIw9UoMMeX8" title="Setting up O3DE from GitHub" >}}
 
 ## Prerequisites
 

--- a/content/docs/welcome-guide/tours/editor-tour.md
+++ b/content/docs/welcome-guide/tours/editor-tour.md
@@ -10,7 +10,7 @@ toc: true
 
 You can learn the basics of navigating and customizing O3DE Editor from the quick video tutorial below, and a few additional tips by reading this topic.
 
-{{< youtube id="tFfiXhckd7g" title="O3DE Editor Tour" >}}
+{{< youtube-width id="tFfiXhckd7g" title="O3DE Editor Tour" >}}
 
 ## Launch O3DE Editor
 

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -485,7 +485,7 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 
     Output:
 
-    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" >}}
 
     <br>
 

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -463,3 +463,38 @@ The `image-width` shortcode adds an image with alternate text and restricts the 
 `image-width` example output:
 
 {{< image-width "/images/welcome-guide/ui-editor-labeled.png" "700" "An annotated image of O3DE editor's user interface." >}}
+
+
+## Embedding Youtube videos with the `youtube-width` shortcode
+
+Embed Youtube videos in your page by using the `youtube-width` shortcode. The `youtube-width` shortcode is an extended version of Hugo's built-in [`youtube` shortcode](https://gohugo.io/content-management/shortcodes/#youtube) that allows you to control the size of the embedded video. 
+
+`youtube-width` supports the following double-quoted parameters:
+
+1. id
+2. title
+3. width (using the default value (50%) is recommended)
+
+### Examples 
+
+1. `youtube-width` example without the `width` parameter:
+
+    ```markdown
+    {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" */>}}
+    ```
+
+    Output:
+
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="50%" >}}
+
+    <br>
+
+2. `youtube-width` example with the `width` parameter:
+
+    ```markdown
+    {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="100%" */>}}
+    ```
+
+    Output:
+
+    {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="100%" >}}

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -475,9 +475,9 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
 2. title
 3. width (using the default value (50%) is recommended)
 
-### Examples 
+**Examples** 
 
-1. `youtube-width` example without the `width` parameter:
+1. `youtube-width` example without the `width` parameter uses the default value `width: 50%`:
 
     ```markdown
     {{</* youtube-width id="CQmjAxr7LZs" title="What is O3DE?" */>}}

--- a/layouts/shortcodes/youtube-width.html
+++ b/layouts/shortcodes/youtube-width.html
@@ -1,0 +1,11 @@
+{{- $pc := .Page.Site.Config.Privacy.YouTube -}}
+{{- if not $pc.Disable -}}
+{{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
+{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $title := .Get "title" | default "YouTube Video" }}
+{{- $width := .Get "width" | default "50%" }}
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: calc({{ $width }} * .5625); width: {{ $width }}; height: 0; overflow: hidden;"{{ end }}>
+  <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}"></iframe>
+</div>
+{{ end -}}


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

This PR resolves this issue: [[ISSUE][DOCS] Reduce the thumbnails size of the video tutorials and images](https://github.com/o3de/o3de.org/issues/1208).

- Created shortcode to reduce size of embedded YT videos
- Across the docs, replaced `youtube` shortcode with the new `youtube-width` shortcode

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

