### PR TITLE
Correct o3de-source shortcode in doc links

### DIFF
--- a/content/docs/contributing/to-code/git-workflow.md
+++ b/content/docs/contributing/to-code/git-workflow.md
@@ -10,7 +10,7 @@ Looking to submit new or changed code to **Open 3D Engine (O3DE)**? Exciting! Fo
 
 ### GitHub Code Contribution Workflow
 
-The O3DE base repository is on GitHub at [{{< links/o3de-source >}}]({{< links/o3de-source >}}).
+The O3DE base repository is on GitHub at [https://{{< links/o3de-source >}}](https://{{< links/o3de-source >}}).
 
 ![GitHub code contribution workflow diagram](/images/contributing/to-code/code-git-workflow.png)
 
@@ -26,14 +26,14 @@ At a high level, the workflow is:
 
 ### Initial Git contribution workflow steps
 
-1. Create a fork of `{{< links/o3de-source >}}.git` into your own GitHub account. To do this, go to the O3DE public GitHub repo at [{{< links/o3de-source >}}]({{< links/o3de-source >}}) and create a fork by selecting the "Fork" button in the upper-right. This will clone the O3DE public repo into your repo, and may take a few minutes. The URL for your fork will be something like `https://github.com/<YOUR GITHUB NAME HERE>/o3de.git`.
+1. Create a fork of `https://{{< links/o3de-source >}}.git` into your own GitHub account. To do this, go to the O3DE public GitHub repo at [https://{{< links/o3de-source >}}](https://{{< links/o3de-source >}}) and create a fork by selecting the "Fork" button in the upper-right. This will clone the O3DE public repo into your repo, and may take a few minutes. The URL for your fork will be something like `https://github.com/<YOUR GITHUB NAME HERE>/o3de.git`.
 
 1. Now, clone your fork locally by opening GitBash (or a Git-enabled shell or utility). Change directories to the folder you want to clone the repo in and run: `git clone https://github.com/<YOUR GITHUB NAME HERE>/o3de.git`. You will now have the clone of your fork on your local desktop and can work with the files directly.
 
 1. However, to simplify this workflow, you must make some changes to your local Git configuration. In this case, you will be setting your fork's URL as the `origin` repo, and the O3DE public repo as your `upstream` repo, and updating the LFS URL. Run the following Git commands from **your locally cloned fork's path**:
 
     ```bash
-    git remote add upstream {{< links/o3de-source >}}.git
+    git remote add upstream https://{{< links/o3de-source >}}.git
     ```
 
     Confirm that `upstream` points to the O3DE public repo and that `origin` points to your fork:
@@ -47,8 +47,8 @@ At a high level, the workflow is:
     ```bash
     origin  https://github.com/<FORK>/o3de.git (fetch)
     origin  https://github.com/<FORK>/o3de.git (push)
-    upstream  {{< links/o3de-source >}}.git (fetch)
-    upstream  {{< links/o3de-source >}}.git (push)
+    upstream  https://{{< links/o3de-source >}}.git (fetch)
+    upstream  https://{{< links/o3de-source >}}.git (push)
     ```
 
     You can also configure upstream to target specific branches, as well.

--- a/content/docs/welcome-guide/features-intro.md
+++ b/content/docs/welcome-guide/features-intro.md
@@ -12,7 +12,7 @@ toc: true
 
 O3DE is open source. You can use the provided binaries and tools to build your own projects, or get the source code and extend it!
 
-Visit [O3DE on GitHub]({{< links/o3de-source >}}) to get the source code, then follow the [GitHub setup instructions](/docs/welcome-guide/setup/setup-from-github) to get started.
+Visit [O3DE on GitHub](https://{{< links/o3de-source >}}) to get the source code, then follow the [GitHub setup instructions](/docs/welcome-guide/setup/setup-from-github) to get started.
 
 ## Modular engine and components
 

--- a/content/docs/welcome-guide/setup/setup-from-github/_index.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/_index.md
@@ -66,7 +66,7 @@ All contributions to the O3DE repo are expected to be staged in a fork before su
 
 **To fork and clone O3DE on your PC from GitHub**
 
-1. Create a fork of the O3DE GitHub repo from [{{< links/o3de-source >}}]({{< links/o3de-source >}}). Alternatively, if you are working as a member of a team that has already created a fork, you can skip this step and use your team's existing fork.
+1. Create a fork of the O3DE GitHub repo from [https://{{< links/o3de-source >}}](https://{{< links/o3de-source >}}). Alternatively, if you are working as a member of a team that has already created a fork, you can skip this step and use your team's existing fork.
 
     ![Create a fork using the Fork button on the O3DE GitHub repo](/images/welcome-guide/setup-create-fork.png)
 
@@ -107,7 +107,7 @@ All contributions to the O3DE repo are expected to be staged in a fork before su
 1. Add a remote to track the upstream repo. This will enable you to pull updates from the O3DE repo directly into your local clone.
 
     ```cmd
-    git remote add upstream {{< links/o3de-source >}}.git
+    git remote add upstream https://{{< links/o3de-source >}}.git
     ```
 
     Verify the upstream repository. You should see the URL for the fork as `origin`, and the URL for the original repository as `upstream`.
@@ -121,8 +121,8 @@ All contributions to the O3DE repo are expected to be staged in a fork before su
     ```cmd
     origin  https://github.com/<FORK>/o3de.git (fetch)
     origin  https://github.com/<FORK>/o3de.git (push)
-    upstream        {{< links/o3de-source >}}.git (fetch)
-    upstream        {{< links/o3de-source >}}.git (push)
+    upstream        https://{{< links/o3de-source >}}.git (fetch)
+    upstream        https://{{< links/o3de-source >}}.git (push)
     ```
 
 1. (Optional) If you don't expect to make changes to these files, ignore this step. Otherwise, update the LFS URL to include your fork. This lets you push changes to files in the LFS. For complete instructions and the **DISTRIBUTION** to use, open the `.lfsconfig` file at the root of the repository.

--- a/layouts/partials/home/hero-slideshow.html
+++ b/layouts/partials/home/hero-slideshow.html
@@ -1,6 +1,5 @@
 {{ $title := site.Title }}
 {{ $desc  := site.Params.description | markdownify }}
-{{ $source := site.Params.sourceRepo }}
 <div class="hero-block scalable d-flex flex-column align-items-center justify-content-around">
   <div class="hero-slideshow-background">
     <div id="hero-slideshow" class="hero-slideshow">

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -1,6 +1,5 @@
 {{ $title := site.Title }}
 {{ $desc  := site.Params.description | markdownify }}
-{{ $source := site.Params.sourceRepo }}
 <div class="scalable home-hero d-flex flex-column align-items-center justify-content-around">
   <div class="container hero-inner">
     <div class="row">

--- a/layouts/shortcodes/links/o3de-discord.html
+++ b/layouts/shortcodes/links/o3de-discord.html
@@ -1,2 +1,1 @@
-<!-- The https URL link prefix ("https://") is intentionally left off here. This forces links in Markdown docs to use the prefix before this shortcode, which then enables render-link code to correctly recognize the link as a "remote link", which results in a link that will open in a separate tab and render with the "external link" icon next to it. -->
-discord.com/invite/o3de
+<!-- The https URL link prefix ("https://") is intentionally left off here. This forces links in Markdown docs to use the prefix before this shortcode, which then enables render-link code to correctly recognize the link as a "remote link", which results in a link that will open in a separate tab and render with the "external link" icon next to it. -->discord.com/invite/o3de

--- a/layouts/shortcodes/links/o3de-source.html
+++ b/layouts/shortcodes/links/o3de-source.html
@@ -1,1 +1,1 @@
-{{ site.Params.sourceRepo }}
+<!-- The https URL link prefix ("https://") is intentionally left off here. This forces links in Markdown docs to use the prefix before this shortcode, which then enables render-link code to correctly recognize the link as a "remote link", which results in a link that will open in a separate tab and render with the "external link" icon next to it. -->github.com/o3de/o3de


### PR DESCRIPTION
Signed-off-by: William Hayward <wilhayw@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

The current format of the o3de-source shortcode results in a failure to display and work properly as an external link. The (quick) solution is to update the shortcode and its references to manually supply the https prefix.

- Modify o3de-source shortcode so that it doesn't use the https prefix.
- Update references.
- Remove unused references to the o3de source site param.
- Fix spacing issue in similar o3de-discord shortcode.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

