### PR TITLE
Fix broken links to /asset-processor/

### DIFF
--- a/content/docs/user-guide/build/reference.md
+++ b/content/docs/user-guide/build/reference.md
@@ -41,7 +41,7 @@ These options are the user-supplied settings that are required to configure O3DE
 
 These options control the types of assets that are built, and where projects load assets from at runtime.
 
-* **`LY_ASSET_DEPLOY_TYPE`** - The *default* type of assets to be built by the [asset processor](/docs/user-guide/assets/asset-processor/). Valid platforms are:
+* **`LY_ASSET_DEPLOY_TYPE`** - The *default* type of assets to be built by [Asset Processor](/docs/user-guide/assets/asset-processor/). Valid platforms are:
   * `pc` - Windows PC
   * `linux` - Linux
   * `mac` - MacOS

--- a/content/docs/user-guide/build/reference.md
+++ b/content/docs/user-guide/build/reference.md
@@ -41,7 +41,7 @@ These options are the user-supplied settings that are required to configure O3DE
 
 These options control the types of assets that are built, and where projects load assets from at runtime.
 
-* **`LY_ASSET_DEPLOY_TYPE`** - The *default* type of assets to be built by the [asset processor](/docs/user-guide/assets/pipeline/processor/). Valid platforms are:
+* **`LY_ASSET_DEPLOY_TYPE`** - The *default* type of assets to be built by the [asset processor](/docs/user-guide/assets/asset-processor/). Valid platforms are:
   * `pc` - Windows PC
   * `linux` - Linux
   * `mac` - MacOS

--- a/content/docs/user-guide/packaging/asset-bundler/list-operations.md
+++ b/content/docs/user-guide/packaging/asset-bundler/list-operations.md
@@ -151,7 +151,7 @@ Create the files that you will use in this tutorial.
    + `FileF.cfg`
    + `do-not-add-me.txt`
 
-1. Process the assets on your project by running the [Asset Processor](/docs/user-guide/assets/pipeline/processor).
+1. Process the assets on your project by running the [Asset Processor](/docs/user-guide/assets/asset-processor/).
 
 ### Create asset list files for the comparison operation 
 

--- a/content/docs/user-guide/packaging/asset-bundler/list-operations.md
+++ b/content/docs/user-guide/packaging/asset-bundler/list-operations.md
@@ -151,7 +151,7 @@ Create the files that you will use in this tutorial.
    + `FileF.cfg`
    + `do-not-add-me.txt`
 
-1. Process the assets on your project by running the [Asset Processor](/docs/user-guide/assets/asset-processor/).
+1. Process the assets on your project by running [Asset Processor](/docs/user-guide/assets/asset-processor/).
 
 ### Create asset list files for the comparison operation 
 

--- a/content/docs/user-guide/packaging/asset-bundler/overview.md
+++ b/content/docs/user-guide/packaging/asset-bundler/overview.md
@@ -12,7 +12,7 @@ The Asset Bundler is a command-line tool, `AssetBundlerBatch.exe`, and a set of 
 ## Prerequisites to use the Asset Bundler 
 
 To use the Asset Bundler, your game project must meet the following criteria:
-+ The assets that you are bundling have been processed by the [Asset Processor](/docs/user-guide/assets/asset-processor/).
++ The assets that you are bundling have been processed by [Asset Processor](/docs/user-guide/assets/asset-processor/).
 + You have Visual Studio 2019 (any edition) installed and configured for C++ development.
 
 ## Why use the Asset Bundler? 

--- a/content/docs/user-guide/packaging/asset-bundler/overview.md
+++ b/content/docs/user-guide/packaging/asset-bundler/overview.md
@@ -12,7 +12,7 @@ The Asset Bundler is a command-line tool, `AssetBundlerBatch.exe`, and a set of 
 ## Prerequisites to use the Asset Bundler 
 
 To use the Asset Bundler, your game project must meet the following criteria:
-+ The assets that you are bundling have been processed by the [Asset Processor](/docs/user-guide/assets/pipeline/processor/).
++ The assets that you are bundling have been processed by the [Asset Processor](/docs/user-guide/assets/asset-processor/).
 + You have Visual Studio 2019 (any edition) installed and configured for C++ development.
 
 ## Why use the Asset Bundler? 


### PR DESCRIPTION
- Fixes a few dead links to /user-guide/assets/asset-processor/.

Fix #1224

