### PR TITLE
Quick fix making more clear what --config means.

### DIFF
--- a/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
@@ -60,6 +60,7 @@ To prepare to build the engine and projects, choose one of the following build t
     ```
 
     The `-j` is a recommended build tool optimization. It tells the Ninja build tool the number of parallel build tasks that will be executed simultaneously. The 'number of parallel build tasks' is recommended to match the number of cores available on the Linux host machine.
+    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
 
     Example:
 
@@ -107,6 +108,7 @@ To prepare to build the engine and projects, choose one of the following build t
     ```
 
     The `-j` is a recommended build tool optimization. It tells the Ninja build tool the number of parallel build tasks that will be executed simultaneously. We recommend that the 'number of parallel build tasks' matches the number of cores available on the Linux host machine.
+    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
 
     Example:
 

--- a/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
@@ -60,6 +60,7 @@ To prepare to build the engine and projects, choose one of the following build t
     ```
 
     The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
+    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de\build\windows_vs2019\bin\profile`.
 
@@ -101,6 +102,7 @@ To prepare to build the engine and projects, choose one of the following build t
     ```
 
     The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
+    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de-install\bin\Windows\profile\Default`.
 


### PR DESCRIPTION
I had an unpleasant compilation experience.

--config profile being the default was one of the causes as it turns on -Werror which then finds unused variable.
I won't say this is the best fix as
1) building-windows may have a similar issue
2) better explanation of what different configurations types do beyond the names would be better

My other problems are probably caused by myself. It was a weird thing where I had to run first cmake let it complain that it didn't find clang then run again with CMAKE_CXX_COMPILE. If CMAKE_CXX_COMPILE was in the first run cmake would complain about pthread.h missing. I think I fixed that with LY_UNITY_BUILD=OFF.

