### PR TITLE
Prepend page title in HTML title

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,11 @@
   <head>
     <title>
       {{ block "title" . }}
-        {{ site.Title }}
+        {{if .IsHome -}}
+          {{ site.Title }}
+        {{- else -}}
+          {{ .Title }} - {{ site.Title }}
+        {{- end }}
       {{ end }}
     </title>
     {{ partial "css.html" . }}


### PR DESCRIPTION
## Change summary

Prepends the page title to the site title when not on the home page.  For example:

"Release Notes - Open 3D Engine"

This change is to attempt to fix some of our Google search engine erroneous duplicates.   This change will likely have the largest impact.


Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>