### PR TITLE
Move search results to dedicated page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,39 +57,12 @@ $(function() {
 
 $(() => {
   $("#search").submit(function(event){
-    event.preventDefault();
-    $(".search-input-view").show();
-
-    let data =  $('#search-input').val()
-    if (data.length > 0) {
-      const idx = lunr(function () {
-        this.ref('id')
-        this.field('title', {
-          boost: 15
-        })
-        this.field('tags')
-        this.field('content', {
-          boost: 10
-        })
-    
-        for (const key in window.store) {
-          this.add({
-            id: key,
-            title: window.store[key].title,
-            tags: window.store[key].category,
-            content: window.store[key].content
-          })
-        }
-      })
-    
-      // Perform the search
-      const results = idx.search(data)
-      // Update the search title
-      $('#search-title').text('Search Results for ' + '"' + data + '"')
-      // Update the list with results
-      displayResults(results, window.store)
+    if($(".search-input-view").is(":hidden"))
+    {
+      event.preventDefault();
+      $(".search-input-view").show();
     }
-  })
+  });
 });
 
 // --- Downloads page
@@ -121,30 +94,6 @@ $(function() {
   // If it doesn't exist, this will just do nothing.
   $("#os-" + hash).trigger("click");
 });
-
-// Search 
-
-function displayResults (results, store) {
-  const resultsContainer = document.getElementById('search-results')
-  const mainContainer = document.getElementById('primary')
-  const searchResults = document.getElementById('results')
-  
-  if (results.length) {
-    let resultList = ''
-    // Iterate and build result list elements
-    for (const n in results) {
-      const item = store[results[n].ref]
-      resultList += '<li><p><a href="' + item.url + '">' + item.title + '</a></p>'
-      resultList += '<p>' + item.content.substring(0, 400) + '...</p></li>'
-    }
-    searchResults.innerHTML = resultList
-  } else {
-    searchResults.innerHTML = 'No results found.'
-  }
-
-  resultsContainer.style.display = "block"
-  mainContainer.style.display = "none"
-}
 
 // Docs navigation
 

--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,0 +1,3 @@
+---
+title: Search Results
+---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,12 +14,13 @@
   {{ partial "javascript.html" }}
     <body>
       {{ partial "navbar.html" . }}
-    <div id="search-results" style="display: none;" aria-hidden="true">
-      {{ partial "search-results.html" . }}
-    </div>
     <main id="primary">
-      {{ block "main" . }}
-      {{ end }}
+      {{ if eq  .Type "search" }}
+        {{ partial "search-results.html" . }}
+      {{ else }}
+        {{ block "main" . }}
+        {{ end }}
+      {{ end}}
     </main>
   </body>
 </html>

--- a/layouts/partials/search-results.html
+++ b/layouts/partials/search-results.html
@@ -1,5 +1,23 @@
+<div class="container">
+  <h1 id="search-title">Search</h1>
+  <ul id="results"></ul>
+</div>
 <script>
-  window.store = {
+  const params = new URLSearchParams(window.location.search);
+  const queryParam = params.get('query');
+  console.log("Query param is " + params.get('query'));
+  if(queryParam !== null && queryParam.length > 0)
+  {
+    $(".search-input-view").show();
+    $('#search-title').text('Searching for ' + '"' + queryParam + '" ...');
+    $("#search-input").val(queryParam);
+  }
+  // close off this script block so it gets evaluated before the heavy lifting
+</script>
+<script>
+  if(queryParam !== null && queryParam.length > 0)
+  {
+    window.store = {
       // You can specify your blog section only:
       {{ range .Site.Pages }}
       // For all pages in your site, use "range .Site.Pages"
@@ -11,15 +29,51 @@
           "url": "{{ .Permalink }}"
       },
       {{ end }}
+    }
+
+    const idx = lunr(function () {
+      this.ref('id')
+      this.field('title', {
+        boost: 15
+      })
+      this.field('tags')
+      this.field('content', {
+        boost: 10
+      });
+  
+      for (const key in window.store) {
+        this.add({
+          id: key,
+          title: window.store[key].title,
+          tags: window.store[key].category,
+          content: window.store[key].content
+        });
+      }
+    })
+
+    // Perform the search
+    const results = idx.search(queryParam);
+
+    // Update the search title
+    $('#search-title').text('Search results for ' + '"' + queryParam + '"');
+
+    // Update the list with results
+    const searchResults = document.getElementById('results');
+    if (results.length) {
+      let resultList = '';
+      // Iterate and build result list elements
+      for (const n in results) {
+        const item = store[results[n].ref];
+        resultList += '<li><p><a href="' + item.url + '">' + item.title + '</a></p>';
+        resultList += '<p>' + item.content.substring(0, 400) + '...</p></li>';
+      }
+      searchResults.innerHTML = resultList;
+    } else {
+      searchResults.innerHTML = 'No results found.';
+    }
   }
-
-
-  const params = new URLSearchParams(window.location.search);
-  const queryParam = params.get('query');
-  console.log("Query param is " + params.get('query'));
-  </script>
-
-<div class="container">
-  <h1 id="search-title"> Search Results for </h1>
-  <ul id="results"></ul>
-</div>
+  else
+  {
+    $('#search-title').text('No search term provided');
+  }
+</script>


### PR DESCRIPTION
## Change summary

- moves search results to a dedicated page at `/search` 
- allows for hyperlinks that go directly to a search page e.g. `o3de.org/search?query_param=search+term`
- removes hidden giant search term blob from every page except the search page
- allows the back button to work and send the user to the previous page before the search was initiated

## Testing
I've tested this locally, but not on mobile.
One major change with this is the page header will look different when they go to the `/search` page because they're "leaving" whatever section of the site they're in e.g. "docs", "download" etc.  Those sub-sections have a blue header, but the search page will have the default black header you see on the main page.

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>