### PR TITLE
Remove unused hidden duplicated nav menu content

### DIFF
--- a/layouts/docs/docs_landing.html
+++ b/layouts/docs/docs_landing.html
@@ -3,6 +3,11 @@
 {{ $allSections  := site.Sections }} <!-- "blog" and "docs" -->
 {{ $docsSections := where $allSections "Section" "docs" }}
 
+{{/* Include the top level navigation for mobile */}}
+<section class="hide-content docs-sidebar">
+  {{ partial "section-nav.html" . }}
+</section>
+
 <div class="container pt-3 px-5 pb-3">
   <div class="row flex">
     <div class="col-12 docs-content">

--- a/layouts/docs/docs_landing.html
+++ b/layouts/docs/docs_landing.html
@@ -3,10 +3,6 @@
 {{ $allSections  := site.Sections }} <!-- "blog" and "docs" -->
 {{ $docsSections := where $allSections "Section" "docs" }}
 
-<section class="hide-content docs-sidebar">
-  {{ partial "section-nav.html" . }}
-</section>
-
 <div class="container pt-3 px-5 pb-3">
   <div class="row flex">
     <div class="col-12 docs-content">

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -10,8 +10,13 @@
 <nav class="docs-nav" id="docs-nav">
   <ul>
     {{ range .FirstSection.Pages }}
-      {{/* Only display pages inside the current /section/subsection/ e.g. /docs/welcome-guide/ or /docs/release-notes/ */}}
-      {{- if $.IsDescendant . -}}
+      {{- if eq $ .FirstSection -}}
+      {{/* Display the main subsections on the docs page (for mobile) */}}
+      <li>
+          <a href="{{ .RelPermalink }}" class="docs-link">{{ .LinkTitle }}</a>
+      </li>
+      {{- else if $.IsDescendant . -}}
+      {{/* Only display pages inside the current subsection */}}
       <li>
           <a href="{{ .RelPermalink }}"
           class="docs-link{{ if .Pages }} has-children{{ end }}">

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -1,6 +1,3 @@
-{{ $allSections  := site.Sections }} <!-- "blog" and "docs" -->
-{{ $docsSections := where $allSections "Section" "docs" }}
-
 <form id="search"
     action='{{ with .GetPage "/search" }}{{.Permalink}}{{end}}' method="get" class="align-items-center justify-content-center">
     <div class="search-input-view">
@@ -12,8 +9,27 @@
 
 <nav class="docs-nav" id="docs-nav">
   <ul>
-    {{ range $docsSections }}
-      {{ partial "section-nav-walk.html" . }}
+    {{ range .FirstSection.Pages }}
+      {{/* Only display pages inside the current /section/subsection/ e.g. /docs/welcome-guide/ or /docs/release-notes/ */}}
+      {{- if $.IsDescendant . -}}
+      <li>
+          <a href="{{ .RelPermalink }}"
+          class="docs-link{{ if .Pages }} has-children{{ end }}">
+          {{ .LinkTitle }}</a>
+          {{ if .Pages }}
+              <ul>
+                  {{ if and ( .IsSection ) (ge (len .Content) 1) }}
+                  <li>
+                      <a href="{{ .RelPermalink }}"
+                      class="docs-link">
+                      {{ .LinkTitle }}</a>
+                  </li>
+                  {{ end }}
+                  {{ partial "section-nav-walk.html" . }}
+              </ul>
+          {{ end }}
+      </li>
+      {{- end -}}
     {{ end }}
   </ul>
 </nav>


### PR DESCRIPTION
## Change summary
Every docs page contained the full nav menu for every docs subsection, and the docs landing page also included the entire nav menu in hidden HTML for mobile.  This change removes that unused duplicated HTML and should help with our SEO issues, making each page look less like the landing page to crawlers and help with bandwidth by removing a large chunk of unused HTML.

- no changes in UX or functionality
- remove all but the top level nav sub sections from the docs landing page for mobile.
- remove the hidden navigation menu subsections.  For example, in the /docs/welcome-guide, don't include the nav menu items for /docs/release-notes or /docs/user-guide
