### PR TITLE
Rename 'card component' to 'card widget'.

### DIFF
--- a/content/docs/tools-ui/component-library/uidev-card-component.md
+++ b/content/docs/tools-ui/component-library/uidev-card-component.md
@@ -1,7 +1,7 @@
 ---
 linktitle: Card
-title: O3DE UI Card Component
-description: Use the O3DE UI card component as a container to organize component property settings and actions together.
+title: O3DE UI Card Widget
+description: Use the O3DE UI card widget as a container to organize component property settings and actions together.
 toc: true
 ---
 
@@ -30,7 +30,7 @@ Cards allow for a certain amount of customization. The basic layout of a card in
     (Optional) Cards can have their own unique icon related to their purpose. For the full list of icons, see [O3DE component icons](/docs/tools-ui/icon-assets/uidev-component-icons/).
    
     {{< note >}}
-Two icons are required for new components:
+Two icons are required for new widgets:
 
 + A 16 x 16 SVG with a background box for the perspective window.
 + An SVG for everywhere else in the editor, without a background box.

--- a/content/docs/tools-ui/component-library/uidev-reflected-property-editor-component.md
+++ b/content/docs/tools-ui/component-library/uidev-reflected-property-editor-component.md
@@ -23,7 +23,7 @@ The following code shows how to add a simple **reflected property editor** to a 
 #include <AzCore/Serialization/EditContext.h>
 #include <AzQtComponents/Components/Widgets/Card.h>
 
-// Create a card component and set its title and header icon.
+// Create a card widget and set its title and header icon.
 AzQtComponents::Card* card = new AzQtComponents::Card(parent);
 card->setTitle(QStringLiteral("Card"));
 card->header()->setIcon(QIcon(QStringLiteral(":/Gallery/Grid-small.svg")));
@@ -45,4 +45,4 @@ For details on the **card** API, see the following topics in the [O3DE UI Extens
 ## Related links
 
 For additional information related to the **reflected property editor** component, see the following topics:
-+  [Card Component](./uidev-card-component)
++  [Card Widget](./uidev-card-component)


### PR DESCRIPTION
## Change summary

Changed references to "card component" to "card widget" in the Tools UI Guide, except in the `tools-ui/ux-patterns/component-card` section because the Component Card page will be done in a separate PR. 

The reason for this change is to distinguish "component card" from any similar terminology. 

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

