### PR TITLE
The image now opens full size in the same tab on click.

### DIFF
--- a/layouts/shortcodes/image-width.html
+++ b/layouts/shortcodes/image-width.html
@@ -1,6 +1,5 @@
-<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely.
+<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely. When clicked, the full size image opens in the same tab.
 -->
-
-<img src={{ .Get 0 }} width={{ .Get 1 }} alt={{ .Get 2 }}>
+<a href={{ .Get 0 }}><img src={{ .Get 0 }} width={{ .Get 1 }} alt={{ .Get 2 }}></a>
 <br>
 <br>


### PR DESCRIPTION
Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

