### PR TITLE
Add AWS GameLift gem to table on AWS index page

### DIFF
--- a/content/docs/user-guide/gems/reference/aws/_index.md
+++ b/content/docs/user-guide/gems/reference/aws/_index.md
@@ -37,3 +37,4 @@ The following AWS Gems are available:
 | [AWS Core](aws-core/) | Provides the common mechanisms and essential configuration for all AWS feature Gems, including credential management, resource sharing, and handling of calls to AWS services. This Gem also includes platform extensions for the AWS SDK for C++. |
 | [AWS Client Auth](aws-client-auth/) | Provides OAuth sign-in authentication flows and fetches temporary AWS credentials using OpenID tokens. |
 | [AWS Metrics](aws-metrics/) | Reports and aggregates metrics data for real-time or batch analytics in AWS. |
+| [AWS GameLift](aws-gamelift/) | Provides a framework to extend the O3DE networking layer and Multiplayer Gem to work with Amazon GameLift.|


### PR DESCRIPTION
## Change summary

Adds AWS GameLift gem to table on AWS index page. 

### Testing / screenshot

![image](https://user-images.githubusercontent.com/34254888/152062591-49da0327-8338-428f-94c5-a4dd8e064885.png)


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

