### PR TITLE
Fixed incorrect target name when running the install step using ninja

### DIFF
--- a/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
@@ -103,7 +103,7 @@ To prepare to build the engine and projects, choose one of the following build t
 1. Use CMake to build the engine as an SDK, the same as if you installed the engine from an installer tool. The following example shows the `profile` build configuration.
 
     ```shell
-    cmake --build build/linux --target INSTALL --config profile -j <number of parallel build tasks>
+    cmake --build build/linux --target install --config profile -j <number of parallel build tasks>
     ```
 
     The `-j` is a recommended build tool optimization. It tells the Ninja build tool the number of parallel build tasks that will be executed simultaneously. We recommend that the 'number of parallel build tasks' matches the number of cores available on the Linux host machine.
@@ -111,7 +111,7 @@ To prepare to build the engine and projects, choose one of the following build t
     Example:
 
     ```shell
-    cmake --build build/linux --target INSTALL --config profile -j 8
+    cmake --build build/linux --target install --config profile -j 8
     ```
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `$HOME/o3de-install/bin/Linux/profile/Default`.


### PR DESCRIPTION
The ninja generator through CMake exposes the install target as lowercase "install", not uppercase "INSTALL".
It is the Visual Studio Generator that adds the uppercase "INSTALL" target

fixes #1372

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>


## Change summary

This correct an issue with the Pre-Built SDK steps on the https://www.o3de.org/docs/welcome-guide/setup/setup-from-github/building-linux/ page which indicates to build an SDK layout on Linux the target to use is "INSTALL".
The correct target name is "install"

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

