### PR TITLE
Fixes to Multiplayer Gem Configuration Doc

### DIFF
--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
@@ -31,7 +31,7 @@ Make the following edits to the `<ProjectName>.Static` target:
                 ...
                 <projectname>_autogen_files.cmake
     ```
-    {{< note >}}The `<projectname>_autogen_files.cmake` file might not exist at this time. We will create this file later in the [Adding AutoGen CMake file](#adding_autogen_file) section. For now we just want to create a reference to it in the `CMakeList.txt`{{< /note >}}
+    {{< note >}}The `<projectname>_autogen_files.cmake` file is created later in the [Adding AutoGen CMake file](#adding_autogen_file) section. For now, create a reference to it in the `CMakeList.txt`{{< /note >}}
 
 1. In the `BUILD_DEPENDENCIES PUBLIC` section, add `AZ::AzNetworking`, `Gem::Multiplayer`, and `AZ::AzFramework`.
    ```cmake
@@ -45,7 +45,7 @@ Make the following edits to the `<ProjectName>.Static` target:
                 Gem::Multiplayer
    ```
 
-    {{< note >}}If `BUILD_DEPENDENCIES` does not contain a `PUBLIC` section, add it as seen above.{{< /note >}}
+    {{< note >}}If `BUILD_DEPENDENCIES` does not contain a `PUBLIC` section, add it as shown in the previous code example.{{< /note >}}
 1. In the `BUILD_DEPENDENCIES PRIVATE` section, add `Gem::Multiplayer.Static`.
    ```cmake
     ly_add_target(
@@ -115,12 +115,12 @@ set(FILES
 
 ### Adding a temporary auto-component
 {{< note >}}
-There's currently an [issue](https://github.com/o3de/o3de/issues/4058) causing a build failure if multiplayer auto-components are enabled, but no auto-components are created. As a work-around, create a temporary auto-component.
+You might experience a build failure if multiplayer auto-components are enabled, but no auto-components are created. As a work-around, create a temporary auto-component. Refer to this [issue](https://github.com/o3de/o3de/issues/4058) for more information.
 {{< /note >}}
 1. Create a new folder under your project's `Code\Source\` directory called `AutoGen`. 
     {{< note >}}This AutoGen directory doesn't have to be temporary. All future multiplayer auto-components can live here.{{< /note >}}
 1. Create a new, temporary auto-component file under `Code\Source\AutoGen` called `MyFirstNetworkComponent.AutoComponent.xml`.
-    {{< note >}}The name of this multiplayer auto-component can be anything, it's just important to ensure the name is used consistently. For this guide we will use "MyFirstNetworkComponent".{{< /note >}}
+    {{< note >}}This guide uses "MyFirstNetworkComponent" as the name for this multiplayer auto-component. You can specify any name for your component, but ensure that the name is used consistently.{{< /note >}}
 
 1. Modify `Code\Source\AutoGen\MyFirstNetworkComponent.AutoComponent.xml` to have the following content:
     ```xml  
@@ -135,7 +135,7 @@ There's currently an [issue](https://github.com/o3de/o3de/issues/4058) causing a
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     </Component>
     ```
-    {{< important >}}Make sure the "Namespace" property is wrapped in quotes and matches the name of your project.
+    {{< important >}}Make sure that the "Namespace" property is wrapped in quotes and matches the name of your project.
     {{< /important >}}
 1. Register the temporary auto-component with CMake by updating `<projectname_files.cmake>`
     ```cmake
@@ -144,7 +144,9 @@ There's currently an [issue](https://github.com/o3de/o3de/issues/4058) causing a
         Source/AutoGen/MyFirstNetworkComponent.AutoComponent.xml
     )
     ```
-{{< note >}}After completing the setup steps in this guide, you can delete the temporary auto-component and create a new auto-component, or use it as a starting point. There always needs to be at least 1 auto-component. Find out more in general about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
+{{< note >}}After completing the setup steps in this guide, you can delete the temporary auto-component and create a new auto-component, or use it as a starting point. There must always be at least one auto-component.
+
+You can learn more about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
 
 ## Module and System component setup
 
@@ -158,7 +160,7 @@ Make the following changes to your project's `Code/Source/<ProjectName>Module.cp
     #include <Source/AutoGen/AutoComponentTypes.h>
     ```
 
-1. Edit the `<ProjectName>Module` constructor to create the component descriptors, allowing Multiplayer components to be registered.
+1. Edit the `<ProjectName>Module` constructor to create the component descriptors, which allows Multiplayer components to be registered.
     ```cpp
     MultiplayerSampleModule()
         : AZ::Module()
@@ -189,4 +191,4 @@ Make the following changes to your project's `Code/Source/<ProjectName>SystemCom
     ```
 
 ## Rebuild the project
-Configuring and building is always required after editing CMake and C++ files. Use the [Project Manager](/docs/user-guide/project-config/project-manager/) to rebuild; otherwise instructions for configuring and building via commandline-interface (CLI) can be found [here](/docs/user-guide/build/configure-and-build/).
+Configuring and building is always required after editing CMake and C++ files. You can use the [Project Manager](/docs/user-guide/project-config/project-manager/) to rebuild, or configure and build via the [command-line interface (CLI)](/docs/user-guide/build/configure-and-build/).

--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
@@ -101,7 +101,7 @@ ly_add_target(
 ```
 <a id="adding_autogen_file"></a>
 ### Adding AutoGen CMake file
-Next, create a new file called `<projectname>_autogen_files.cmake` and make it a sibling of `CMakeList.txt`. Example: `<ProjectName>/Code/<projectname>_autogen_files.cmake`. The contents of this file add the source templates for [autocomponents](./autocomponents) to the project build.
+Next, create a new file called `<projectname>_autogen_files.cmake` and place it in the project's code folder. For example: `<ProjectName>/Code/<projectname>_autogen_files.cmake`. The contents of this file add the source templates for [autocomponents](./autocomponents) to the project build.
 
 ```cmake
 set(FILES
@@ -115,7 +115,7 @@ set(FILES
 
 ### Adding a temporary auto-component
 {{< note >}}
-There's currently a [bug](https://github.com/o3de/o3de/issues/4058) causing a build failure if multiplayer auto-components are enabled, but no auto-components are created. As a work-around, create a temporary auto-component.
+There's currently an [issue](https://github.com/o3de/o3de/issues/4058) causing a build failure if multiplayer auto-components are enabled, but no auto-components are created. As a work-around, create a temporary auto-component.
 {{< /note >}}
 1. Create a new folder under your project's `Code\Source\` directory called `AutoGen`. 
     {{< note >}}This AutoGen directory doesn't have to be temporary. All future multiplayer auto-components can live here.{{< /note >}}
@@ -144,7 +144,7 @@ There's currently a [bug](https://github.com/o3de/o3de/issues/4058) causing a bu
         Source/AutoGen/MyFirstNetworkComponent.AutoComponent.xml
     )
     ```
-{{< note >}}Feel free to delete this temporary auto-component, or use it as a starting point, once you're ready to build further multiplayer components. Find out more in general about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
+{{< note >}}After completing the setup steps in this guide, you can delete the temporary auto-component and create a new auto-component, or use it as a starting point. There always needs to be at least 1 auto-component. Find out more in general about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
 
 ## Module and System component setup
 

--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
@@ -16,7 +16,7 @@ Since both O3DE Gems and projects use the same CMake build functions, these inst
 
 ## Build setup
 
-As usual, the first step of enabling the Multiplayer Gem is to make sure the gem is [added to the project](/docs/user-guide/project-config/add-remove-gems/).
+Start by ensuring the Multiplayer Gem is [added to the project](/docs/user-guide/project-config/add-remove-gems/).
 After adding the Multiplayer Gem to the project there are more steps that require editing some of the project's CMake and C++ files by hand. 
 ### CMakeList.txt changes
 Make sure the `<ProjectName>.Static` target includes the correct dependencies. 
@@ -31,7 +31,7 @@ Make the following edits to the `<ProjectName>.Static` target:
                 ...
                 <projectname>_autogen_files.cmake
     ```
-    {{< note >}}Creating the new `<projectname>_autogen_files.cmake` file is covered below in the [Adding AutoGen CMake file](#adding_autogen_file) section.{{< /note >}}
+    {{< note >}}The `<projectname>_autogen_files.cmake` file might not exist at this time. We will create this file later in the [Adding AutoGen CMake file](#adding_autogen_file) section. For now we just want to create a reference to it in the `CMakeList.txt`{{< /note >}}
 
 1. In the `BUILD_DEPENDENCIES PUBLIC` section, add `AZ::AzNetworking` and `Gem::Multiplayer`.
    ```cmake
@@ -44,7 +44,7 @@ Make the following edits to the `<ProjectName>.Static` target:
                 Gem::Multiplayer
    ```
 
-    {{< note >}}`BUILD_DEPENDENCIES` might not contain a `PUBLIC` section, add it if necessary.{{< /note >}}
+    {{< note >}}If `BUILD_DEPENDENCIES` does not contain a `PUBLIC` section, add it as seen above.{{< /note >}}
 1. In the `BUILD_DEPENDENCIES PRIVATE` section, add `Gem::Multiplayer.Static`.
    ```cmake
     ly_add_target(
@@ -112,10 +112,14 @@ set(FILES
 ```
 
 ### Adding a temporary auto-component
+{{< note >}}
 There's currently a [bug](https://github.com/o3de/o3de/issues/4058) causing a build failure if multiplayer auto-components are enabled, but no auto-components are created. As a work-around, create a temporary auto-component.
+{{< /note >}}
 1. Create a new folder under your project's `Code\Source\` directory called `AutoGen`. 
-    {{< note >}}This AutoGen directory doesn't have to be temporary; all multiplayer auto-components can live here.{{< /note >}}
+    {{< note >}}This AutoGen directory doesn't have to be temporary. All future multiplayer auto-components can live here.{{< /note >}}
 1. Create a new, temporary auto-component file under `Code\Source\AutoGen` called `MyFirstNetworkComponent.AutoComponent.xml`.
+    {{< note >}}The name of this multiplayer auto-component can be anything, it's just important to ensure the name is used consistently. For this guide we will use "MyFirstNetworkComponent".{{< /note >}}
+
 1. Modify `Code\Source\AutoGen\MyFirstNetworkComponent.AutoComponent.xml` to have the following content:
     ```xml  
     <?xml version="1.0"?>
@@ -138,7 +142,7 @@ There's currently a [bug](https://github.com/o3de/o3de/issues/4058) causing a bu
         Source/AutoGen/MyFirstNetworkComponent.AutoComponent.xml
     )
     ```
-{{< note >}}Feel free to delete this temporary auto-component, or use it as a starting point, once you're ready to build a real multiplayer component. Find out more in general about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
+{{< note >}}Feel free to delete this temporary auto-component, or use it as a starting point, once you're ready to build further multiplayer components. Find out more in general about multiplayer auto-components [here](/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/autocomponents/), or follow [this tutorial](/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/).{{< /note >}}
 
 ## Module and System component setup
 

--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
@@ -33,7 +33,7 @@ Make the following edits to the `<ProjectName>.Static` target:
     ```
     {{< note >}}The `<projectname>_autogen_files.cmake` file might not exist at this time. We will create this file later in the [Adding AutoGen CMake file](#adding_autogen_file) section. For now we just want to create a reference to it in the `CMakeList.txt`{{< /note >}}
 
-1. In the `BUILD_DEPENDENCIES PUBLIC` section, add `AZ::AzNetworking` and `Gem::Multiplayer`.
+1. In the `BUILD_DEPENDENCIES PUBLIC` section, add `AZ::AzNetworking`, `Gem::Multiplayer`, and `AZ::AzFramework`.
    ```cmake
     ly_add_target(
         NAME <ProjectName>.Static STATIC
@@ -42,6 +42,7 @@ Make the following edits to the `<ProjectName>.Static` target:
             PUBLIC
                 AZ::AzNetworking
                 Gem::Multiplayer
+                AZ::AzFramework
    ```
 
     {{< note >}}If `BUILD_DEPENDENCIES` does not contain a `PUBLIC` section, add it as seen above.{{< /note >}}
@@ -87,6 +88,7 @@ ly_add_target(
         PUBLIC
             AZ::AzNetworking
             Gem::Multiplayer
+            AZ::AzFramework
         PRIVATE
             ...
             Gem::Multiplayer.Static

--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/configuration.md
@@ -40,9 +40,9 @@ Make the following edits to the `<ProjectName>.Static` target:
         ...
         BUILD_DEPENDENCIES
             PUBLIC
+                AZ::AzFramework
                 AZ::AzNetworking
                 Gem::Multiplayer
-                AZ::AzFramework
    ```
 
     {{< note >}}If `BUILD_DEPENDENCIES` does not contain a `PUBLIC` section, add it as seen above.{{< /note >}}
@@ -86,9 +86,9 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PUBLIC
+            AZ::AzFramework
             AZ::AzNetworking
             Gem::Multiplayer
-            AZ::AzFramework
         PRIVATE
             ...
             Gem::Multiplayer.Static


### PR DESCRIPTION
Updating the Multiplayer Gem Configuration doc based on watching users attempt to enable the gem for the first time. Some updates are error corrections, missing information, or just general help explaining.

Signed-off-by: Gene Walters <genewalt@amazon.com>


## Change summary

Updating the Multiplayer Gem Configuration doc based on watching users attempt to enable the gem for the first time. Some updates are error corrections, missing information, or just general help explaining.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

