### PR TITLE
"O3DE Learn" now links to o3de.org/docs and "O3DE" logo appears in footer of docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,7 @@ description = "Open 3D Engine (O3DE) is a modular, open source, cross-platform 3
 favicon = "favicon.ico"
 repositoryUrl = "https://github.com/o3de/o3de.org"
 contentDir = "/content/"
+docsDir = "/docs/"
 sourceRepo = "https://github.com/o3de/o3de"
 
 [params.logos]

--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,7 @@ sourceRepo = "https://github.com/o3de/o3de"
 [params.logos]
 navbar = "O3DE-Logo-REV-Mono.svg"
 og_image = "O3DE-Circle-Icon.png"
+docs_footer = "O3DE-Logo-Black-Mono.svg"
 
 [[params.social]]
 name = "O3DE GitHub Forums"

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -19,7 +19,7 @@
             <h1 class="title">{{ .Page.Title | markdownify }}</h1>
             {{ partial "docs/content.html" . }}  
             <hr class="mt-5" />   
-            {{ partial "footer-content.html" . }}
+            {{ partial "docs-footer.html" . }}
           </div>
         </div>
       </section>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -19,7 +19,7 @@
             <h1 class="title">{{ .Page.Title | markdownify }}</h1>
             {{ partial "docs/content.html" . }}  
             <hr class="mt-5" />   
-            {{ partial "footer-content.html" . }}
+            {{ partial "docs-footer.html" . }}
           </div>
         </div>
       </section>

--- a/layouts/partials/docs-footer.html
+++ b/layouts/partials/docs-footer.html
@@ -4,25 +4,19 @@
 {{ $logo   := site.Params.logos.docs_footer }}
 
 <footer class="">
-  <div class="container pt-5 pb-5">
-    <div class="row">
-      <div class="col col-12 col-lg-8">
-        <div class="navbar-brand">
-          <a class="navbar-item" href="{{ $home }}">
-            {{ if $logo }}
-            {{ $url := printf "img/logos/%s" $logo | relURL }}
-              <img src="{{ $url }}" class="navbar-logo">
-            {{ else }}
-            {{ $title }}
-            {{ end }}
-          </a>
-        </div>
-      </div>
+  <div>
+    <div class="navbar-brand">
+      <a class="navbar-item" href="{{ $home }}">
+        {{ if $logo }}
+        {{ $url := printf "img/logos/%s" $logo | relURL }}
+          <img src="{{ $url }}" class="navbar-logo">
+        {{ else }}
+        {{ $title }}
+        {{ end }}
+      </a>
     </div>
-    <div class="row">
-      <div class="col col-12 col-xl-8">
-        {{ partial "footer-content.html" . }}
-      </div>
-    </div>
+  </div>
+  <div>
+    {{ partial "footer-content.html" . }}
   </div>
 </footer>

--- a/layouts/partials/docs-footer.html
+++ b/layouts/partials/docs-footer.html
@@ -1,0 +1,28 @@
+{{ $social := site.Params.social }}
+{{ $home   := site.BaseURL }}
+{{ $title  := site.Title }}
+{{ $logo   := site.Params.logos.docs_footer }}
+
+<footer class="">
+  <div class="container pt-5 pb-5">
+    <div class="row">
+      <div class="col col-12 col-lg-8">
+        <div class="navbar-brand">
+          <a class="navbar-item" href="{{ $home }}">
+            {{ if $logo }}
+            {{ $url := printf "img/logos/%s" $logo | relURL }}
+              <img src="{{ $url }}" class="navbar-logo">
+            {{ else }}
+            {{ $title }}
+            {{ end }}
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col col-12 col-xl-8">
+        {{ partial "footer-content.html" . }}
+      </div>
+    </div>
+  </div>
+</footer>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,4 +1,5 @@
 {{ $home   := site.BaseURL }}
+{{ $docs   := site.Params.docsDir }}
 {{ $title  := site.Title }}
 {{ $logo   := site.Params.logos.navbar }}
 {{ $menu   := site.Menus.main }}
@@ -8,7 +9,7 @@
 <div class="main-navbar navbar navbar-dark navbar-docs sticky-top" role="navigation" aria-label="main navigation">
   <div class="container-fluid d-flex flex-row justify-content-between">
       <div class="navbar-brand">
-        <a class="navbar-item" href="{{ $home }}">
+        <a class="navbar-item" href="{{ $docs }}">
           {{ if $logo }}
           {{ $url := printf "img/logos/%s" $logo | relURL }}
             <img src="{{ $url }}" class="navbar-logo">


### PR DESCRIPTION
**To test "O3DE Learn" logo:**
1. Open website preview: https://app.netlify.com/sites/o3deorg/deploys/6202fc6d71186000074260fc
2. Go to any page in the O3DE documentation. 
3. Click on the "O3DE Learn" logo at the top left corner. (See 1 in the image below.)

Expected result: You are redirected to the o3de.org/docs page. 

**To test the "O3DE" logo in the docs:**
1. Open website preview: https://app.netlify.com/sites/o3deorg/deploys/6202fc6d71186000074260fc
2. Go to any page in the O3DE documentation. 
3. Scroll to the bottom of the page.
3. Click on the "O3DE" logo in the page footer. (See 2 in the image below.)

Expected result: You are redirected to the o3de.org page. 


![image](https://user-images.githubusercontent.com/75444793/153095657-3f2ba359-dca1-44a4-8a84-a06e06a7e9ed.png)


<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

