### PR TITLE
Fixed broken link based on #1406

### DIFF
--- a/content/docs/user-guide/programming/gems/_index.md
+++ b/content/docs/user-guide/programming/gems/_index.md
@@ -17,4 +17,4 @@ weight: 120
 
 | Topic | Description |
 |---|---|
-| [Gems in Open 3D Engine](/docs/user-guide/gems/) | Learn about the Gems that extend O3DE. |
+| [Gems in Open 3D Engine](/docs/user-guide/gems/overview) | Learn about the Gems that extend O3DE. |


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

This is a simple fix to a link that was redirecting to an empty webpage. The link with a title "Gems in Open 3D Engine" from "/docs/user-guide/programming/gems/_index.md" was redirecting to "/docs/user-guide/gems/". I changed it to link to "/docs/user-guide/gems/overview" which seems to be where it should be redirecting, as its h1 title is "Gems in Open 3D Engine".

Signed-off-by: Matt Szalay <68120960+Szalay-Prog@users.noreply.github.com>

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

