### PR TITLE
Resolved broken links to Gem's page

### DIFF
--- a/content/docs/welcome-guide/tours/create-intro.md
+++ b/content/docs/welcome-guide/tours/create-intro.md
@@ -97,7 +97,7 @@ We suggest that you begin your learning path by browsing the following set of O3
 *  [Component Reference](/docs/user-guide/components/reference/)
 *  [Animation Editor](/docs/user-guide/visualization/animation/animation-editor/)
 *  [Scene Settings Tool](/docs/user-guide/assets/scene-settings/)
-*  [Gem Library](/docs/user-guide/gems/)
+*  [Gem Library](/docs/user-guide/gems/overview)
 *  [Cinematics and the Track View Editor](/docs/user-guide/visualization/cinematics/)
 *  [Shaders and Materials](/docs/atom-guide/look-dev/)
 
@@ -130,7 +130,7 @@ We suggest that you begin your learning path by browsing the following set of O3
 *  [Asset Pipeline](/docs/user-guide/assets/pipeline/)
 *  [Component Entity System](/docs/user-guide/components/)
 *  [Component Reference](/docs/user-guide/components/reference/)
-*  [Gem Library](/docs/user-guide/gems/)
+*  [Gem Library](/docs/user-guide/gems/overview)
 *  [Script Canvas](/docs/user-guide/scripting/script-canvas/)
 *  [Lua Editor](/docs/user-guide/scripting/lua/)
 <!-- *  [AI Navigation](/docs/user-guide/interactivity/navigation-and-pathfinding/) -->
@@ -154,7 +154,7 @@ We suggest that your learning path looks like this:
 Here is a basic set of O3DE tools and technologies to focus on:
 *  [O3DE Editor](/docs/user-guide/editor/)
 *  [Programming Concepts](/docs/user-guide/programming/intro/)
-*  [Gems](/docs/user-guide/gems/)
+*  [Gems](/docs/user-guide/gems/overview)
 *  [Component Entity System](/docs/user-guide/components/)
 *  [Component Reference](/docs/user-guide/components/reference/)
 *  [Programmer's Guide to Entities and Components](/docs/user-guide/programming/components/)


### PR DESCRIPTION
Similar to this [PR](https://github.com/o3de/o3de.org/pull/1414), found a few more instances where the link should redirect to user-`guide/gems/overview`.

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

