### PR TITLE
[project/pg] Reorganized some contents in 'Key Concepts > Scripting' to 'Scripting' section

### DIFF
--- a/content/docs/user-guide/_index.md
+++ b/content/docs/user-guide/_index.md
@@ -26,7 +26,7 @@ Read about [the features provided by Open 3D Engine](/docs/welcome-guide/feature
 | [Packaging](packaging/) | Learn how to package your O3DE-based product for release. |
 | [Programming](programming/) |  Learn about core engine programming concepts in O3DE. |
 | [Project Configuration](project-config/) | Learn how to configure and customize your O3DE project. |
-| [Scripting](scripting/) | Learn about Script Canvas, O3DE's visual scripting solution, as well as other scripting models. |
+| [Scripting Gameplay](scripting/) | Learn about Script Canvas, O3DE's visual scripting solution, and Lua to create logic and behaviors in your project. |
 | [Testing](testing/) | Learn how to test your O3DE components and project. |
 | [Visualization](visualization/) | Learn about Atom-based visualization components in O3DE. |
 

--- a/content/docs/user-guide/scripting/_index.md
+++ b/content/docs/user-guide/scripting/_index.md
@@ -1,17 +1,25 @@
 ---
 linktitle: Scripting
-title: Scripting in Open 3D Engine
-description: Learn about the scripting languages supported in Open 3D Engine (O3DE).
+title: Scripting Gameplay in O3DE
+description: Learn about the scripting languages supported in Open 3D Engine (O3DE) to add gameplay logic and behaviors in your project.
 weight: 900
 ---
 
-**Open 3D Engine (O3DE)** includes two scripting languages for creating logic and behaviors: Script Canvas and Lua.
+**Open 3D Engine (O3DE)** provides two scripting technologies so you can add gameplay logic and behaviors in your project: **Script Canvas** and **Lua**.
 
-**Script Canvas** is a general purpose, visual scripting environment. In the **Script Canvas Editor**, you lay out and connect graphical nodes that provide a visual representation of the logic flow. Script Canvas offers an approachable environment to author behaviors using the same framework as Lua and C++. You can use Script Canvas to create scripts without coding experience.
+*Script Canvas* is a general purpose, visual scripting environment. In the **Script Canvas Editor**, you lay out and connect graphical nodes that provide a visual representation of the logic flow. Script Canvas offers an approachable environment to author behaviors using the same framework as Lua and C++. You can use Script Canvas to create scripts without coding experience.
 
-**Lua** is a powerful, fast, lightweight, embeddable scripting language. Lua facilitates quick iteration in your project because you can run your changes immediately without needing to recompile your source code.
+*Lua* is a powerful, fast, lightweight, embeddable scripting language. Lua facilitates quick iteration in your project because you can run your changes immediately without needing to recompile your source code.
 
-O3DE functionality is exposed to Script Canvas and Lua through the _behavior context_. The behavior context reflects runtime code, making it accessible to scripts through bindings to C++ classes.
+
+### How scripts communicate in O3DE
+
+O3DE functionality is exposed to Script Canvas and Lua through the _behavior context_. The behavior context reflects runtime code, making it accessible to scripts through bindings to C++ classes, methods, properties, constants, and enums. The behavior context also provides bindings for O3DE's EBus so you can dispatch and handle events through Script Canvas and Lua.
+
+Functionality for both Script Canvas and Lua is added to entities through components. You can have multiple script components and mix and match between Lua and Script Canvas within your entities. This approach enables you to create small, manageable modules of logic and behavior that can be reused throughout your projects.
+
+
+## Section topics
 
 | Topic | Description |
 | --- | --- |

--- a/content/docs/welcome-guide/key-concepts.md
+++ b/content/docs/welcome-guide/key-concepts.md
@@ -174,19 +174,16 @@ When you're preparing to ship, you'll need to package the assets that your proje
 
 Asset Bundler makes shipping the specific assets that are used for the release of your game more reliable and repeatable. Reliability is based on an underlying dependency system. If you make changes to your project and add, remove, or update assets, Asset Bundler uses the dependencies to automatically determine which assets to include. Repeatability is based on underlying configuration files that provide consistency each time you run Asset Bundler.
 
-## Scripting for O3DE
+## Scripting gameplay
 
 O3DE includes two scripting technologies for creating logic and behaviors: *Script Canvas* and *Lua*.
 
-**Script Canvas** is a general purpose, visual scripting environment. In the **Script Canvas Editor**, you lay out and connect graphical nodes that provide a visual representation of the logic flow. Script Canvas offers an approachable and easy-to-read environment to author behaviors using the same framework as Lua and C++. You can use Script Canvas to create scripts without needing to know how to code.
+- **Script Canvas** is a general purpose, visual scripting environment. In the **Script Canvas Editor**, you lay out and connect graphical nodes that provide a visual representation of the logic flow. Script Canvas offers an approachable and easy-to-read environment to author behaviors using the same framework as Lua and C++. You can use Script Canvas to create scripts without needing to know how to code.
 
-To enable Script Canvas for O3DE, you must enable the **Script Canvas Gem**.
+- **Lua** is a powerful, fast, lightweight, embeddable scripting language. Lua facilitates quick iteration in your project because you can run your changes immediately without needing to recompile your source code.
 
-Lua is a powerful, fast, lightweight, embeddable scripting language. Lua facilitates quick iteration in your project because you can run your changes immediately without needing to recompile your source code.
+Learn more about Script Canvas and Lua in [Scripting Gameplay in O3DE](/docs/user-guide/scripting/) . 
 
-O3DE's functionality is exposed to Script Canvas and Lua by the behavior context. The behavior context reflects runtime code and makes it accessible to scripts by providing bindings to C++ classes, methods, properties, constants, and enums. The behavior context also provides bindings for O3DE's EBus so you can dispatch and handle events through Script Canvas and Lua.
-
-Functionality for both Script Canvas and Lua is added to entities through components. You can have multiple script components and mix and match between Lua and Script Canvas within your entities. This approach enables you to create small, manageable modules of logic and behavior that can be reused throughout your projects.
 
 ## Available Release Runtimes
 


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

This PR is part of the project to [restructure the Programming Guide](https://github.com/o3de/sig-docs-community/discussions/16) (or in this case, the Scripting section) to improve discoverability of related information. 

- Moved some information from **Scripting gameplay** in the **Welcome Guide > Key Concepts** page to the **User Guide > Scripting** section. The reason is because users who are looking for more information on Scripting expects to find it in the Scripting section. The Key Concepts page should remain very high level. 

- Also this PR clarified the titles as "Scripting gameplay", to differentiate from scripting tools to extend the O3DE. 
### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

