### PR TITLE
Add a tip shortcode

### DIFF
--- a/content/docs/contributing/to-docs/style-guide/shortcodes.md
+++ b/content/docs/contributing/to-docs/style-guide/shortcodes.md
@@ -14,7 +14,7 @@ O3DE documentation supports four different call-out shortcodes: **Note** `{{</* 
 
 ### Note
 
-Use `{{</* note */>}}` to highlight a tip or a piece of information that is helpful to know.
+Use `{{</* note */>}}` to draw attention to a clarification or information that's of special interest to the reader. For shortcuts and best practices, consider using a `{{</* tip */>}}` instead.
 
 For example:
 
@@ -68,7 +68,7 @@ The call-out style only applies to the line directly above the tag.
 
 ### Important
 
-Use `{{</* important */>}}` to indicate information that is crucial to follow.
+Use `{{</* important */>}}` to indicate information that is critical to follow.
 
 For example:
 
@@ -86,14 +86,16 @@ Avoid multiple paragraphs in call-outs.
 
 ### Call-out boxes in lists
 
-You can use a call-out in a list:
+You can use a call-out in a list. Make sure to indent the first call-out shortcode, as explained in the following note:
 
 ```markdown
 1. Use the note shortcode in a list.
 1. A second item with an embedded note.
 
     {{</* note */>}}
-Warning, Caution, and Note shortcodes, embedded in lists, need to be indented to the level of the list item; four spaces for the first level, eight spaces for the second level, and so on. Lists that contain shortcodes should have newlines between each list item and before and after the shortcode. See [Common Shortcode Issues](#common-shortcode-issues).
+Warning, Caution, Tip, and Note shortcodes, when embedded in lists, need to be indented to the level of the list item; four spaces for the first level, eight spaces for the second level, and so on.
+
+Lists that contain shortcodes should have newlines between each list item and before and after the shortcode.
 {{</* /note */>}}
 
 1. A third item in a list
@@ -106,7 +108,9 @@ The output is:
 1. A second item with an embedded note
 
     {{< note >}}
-Warning, Caution, and Note shortcodes, embedded in lists, need to be indented to the level of the list item; four spaces for the first level, eight spaces for the second level, and so on. Lists that contain shortcodes should have newlines between each list item and before and after the shortcode. See [Common Shortcode Issues](#common-shortcode-issues).
+Warning, Caution, Tip, and Note shortcodes, when embedded in lists, need to be indented to the level of the list item; four spaces for the first level, eight spaces for the second level, and so on.
+
+Lists that contain shortcodes should have newlines between each list item and before and after the shortcode.
 {{< /note >}}
 
 1. A third item in a list

--- a/content/docs/contributing/to-docs/style-guide/shortcodes.md
+++ b/content/docs/contributing/to-docs/style-guide/shortcodes.md
@@ -10,7 +10,7 @@ To enrich **Open 3D Engine (O3DE)** documentation pages with complex elements su
 
 ## Callout Boxes
 
-O3DE documentation supports three different call-out shortcodes: **Note** `{{</* note */>}}`, **Caution** `{{</* caution */>}}`, and **Important** `{{</* important */>}}`. To use a call-out shortcode, enclose the text that you want to display in the opening and closing shortcode brackets.
+O3DE documentation supports four different call-out shortcodes: **Note** `{{</* note */>}}`, **Tip** `{{</* tip */>}}`, **Caution** `{{</* caution */>}}`, and **Important** `{{</* important */>}}`. To use a call-out shortcode, enclose the text that you want to display in the opening and closing shortcode brackets.
 
 ### Note
 
@@ -29,6 +29,24 @@ The output is:
 {{< note >}}
 You can *still* use Markdown inside these call-outs.
 {{< /note >}}
+
+### Tip
+
+Use `{{</* tip */>}}` to draw attention to a shortcut or best practice. While the information should contain practical advice, it should _not_ be essential or critical information needed to complete a step or use a feature.
+
+For example:
+
+```markdown
+{{</* tip */>}}
+You can spawn multiple instances of `AssetBuilder.exe` and attach them to Visual Studio.
+{{</* /tip */>}}
+```
+
+The output is:
+
+{{< tip >}}
+You can spawn multiple instances of `AssetBuilder.exe` and attach them to Visual Studio.
+{{< /tip >}}
 
 ### Caution
 

--- a/content/docs/contributing/to-docs/style-guide/shortcodes.md
+++ b/content/docs/contributing/to-docs/style-guide/shortcodes.md
@@ -32,7 +32,7 @@ You can *still* use Markdown inside these call-outs.
 
 ### Tip
 
-Use `{{</* tip */>}}` to draw attention to a shortcut or best practice. While the information should contain practical advice, it should _not_ be essential or critical information needed to complete a step or use a feature.
+Use `{{</* tip */>}}` to draw attention to a shortcut or best practice. While the information should contain practical advice that's relevant to the preceding content, it should _not_ contain information that's essential or critical to completing a step or using a feature.
 
 For example:
 

--- a/content/docs/user-guide/assets/asset-processor/debugging.md
+++ b/content/docs/user-guide/assets/asset-processor/debugging.md
@@ -34,7 +34,7 @@ If Asset Processor isn't working as expected, use the information in the **Logs*
     * **Show errors** - Display logs that have errors.
     * **Show debug** - Display logs that have debug issues.
 
-    ![Create a log tab in Asset Processor.](/images/user-guide/asset_processor/create-logging-tab.png)
+    ![Create a log tab in Asset Processor](/images/user-guide/assets/asset-processor/create-logging-tab.png)
 
 1. Choose **OK**. Your log report appears as another tab in Asset Processor.
 

--- a/content/docs/user-guide/assets/asset-processor/debugging.md
+++ b/content/docs/user-guide/assets/asset-processor/debugging.md
@@ -111,9 +111,9 @@ Use the procedure below to debug in either of the following scenarios:
 
 The next time that you modify your source file, `AssetBuilder.exe` builds that asset.
 
-{{< note >}}
+{{< tip >}}
 You can spawn multiple instances of `AssetBuilder.exe` and attach them to Visual Studio.
-{{< /note >}}
+{{< /tip >}}
 
 ## Clearing the Cache
 

--- a/content/docs/user-guide/interactivity/user-interface/components/components-tooltips.md
+++ b/content/docs/user-guide/interactivity/user-interface/components/components-tooltips.md
@@ -41,8 +41,13 @@ Select a tooltip trigger condition:
 + **On Press** - The tooltip appears when the interactive element is pressed and held, and disappears when the press is released. Note that the pointer might have moved elsewhere on the canvas by the time the release action has occurred.
 + **On Click** - The tooltip appears when a pointer click, which includes a press and a release, occurs on the interactive element. The tooltip disappears when the next pointer click occurs anywhere on the canvas. Note that if the pointer clicks on the same entity, the tooltip disappears, but then reappears after the specified **Delay time**.
 
+    {{< tip >}}
 On mobile devices, you might want to use **On Press** or **On Click** instead of **On Hover**.
+    {{< /tip >}}
+
+    {{< note >}}
 In all cases, the appearance of the tooltip is delayed by the amount of time specified in **Delay time**. Furthermore, in all cases, the tooltip will disappear after a fixed amount of time set by O3DE, regardless of other criteria specified in the trigger conditions.
+    {{< /note >}}
 
 **Auto position**
 

--- a/content/docs/user-guide/interactivity/user-interface/components/other/components-other-flipbook.md
+++ b/content/docs/user-guide/interactivity/user-interface/components/other/components-other-flipbook.md
@@ -30,19 +30,35 @@ You can add the **FlipbookAnimation** component to elements that also have an [*
 1. Add a **FlipbookAnimation** component.
 
 1. Configure the **FlipbookAnimation** properties:
-**Start Frame**
-The index of the sprite sheet cell that is to be the first frame in the animation. The value must be equal to or less than the **End Frame** value.
-**End Frame**
-The index of the sprite sheet cell that is to be the last frame in the animation. The value must be equal to or greater than the **Start Frame** value.
-**Loop start frame**
-The index of the sprite sheet cell that is to be the first frame in the looped portion of an animation. This value must be equal to or greater than **Start Frame** value and less than **End Frame** value. This setting has no effect if **Loop Type** is set to **None**.
+
+* **Start Frame**
+
+    The index of the sprite sheet cell that is to be the first frame in the animation. The value must be equal to or less than the **End Frame** value.
+
+* **End Frame**
+
+    The index of the sprite sheet cell that is to be the last frame in the animation. The value must be equal to or greater than the **Start Frame** value.
+
+* **Loop start frame**
+
+    The index of the sprite sheet cell that is to be the first frame in the looped portion of an animation. This value must be equal to or greater than **Start Frame** value and less than **End Frame** value. This setting has no effect if **Loop Type** is set to **None**.
+
+    {{< tip >}}
 To loop the entire animation, specify a value that is equal to the **Start Frame** value. To create an intro sequence that appears before the looping animation, specify a value greater than the **Start Frame**.
-**Loop Type**
-Includes the following options:
-   + **None** -No looping behavior. The animation starts between the **Start Frame** and **End Frame** and then stops.
-   + **Linear** - When the animation reaches **End Frame**, it loops by next playing the **Start Frame** and continues until the **End Frame**. This continues until the player stops it manually.
-   + **PingPong** - Reverses the direction of the animation. After animation reaches the **End Frame** or the **Start Frame**, it reverses direction. The loop goes back and forth between the two frames until the player stops it.
-**Frame delay**
-Number of seconds to delay before displaying the next frame.
-**Auto Play**
-If enabled, automatically starts playing the flipbook animation when the canvas is loaded.
+    {{< /tip >}}
+
+* **Loop Type**
+
+    Includes the following options:
+
+   * **None** - No looping behavior. The animation starts between the **Start Frame** and **End Frame** and then stops.
+   * **Linear** - When the animation reaches **End Frame**, it loops by next playing the **Start Frame** and continues until the **End Frame**. This continues until the player stops it manually.
+   * **PingPong** - Reverses the direction of the animation. After animation reaches the **End Frame** or the **Start Frame**, it reverses direction. The loop goes back and forth between the two frames until the player stops it.
+
+* **Frame delay**
+
+    Number of seconds to delay before displaying the next frame.
+
+* **Auto Play**
+
+    If enabled, automatically starts playing the flipbook animation when the canvas is loaded.

--- a/content/docs/user-guide/interactivity/user-interface/editor/sprite-editor/sliced-image-type.md
+++ b/content/docs/user-guide/interactivity/user-interface/editor/sprite-editor/sliced-image-type.md
@@ -27,8 +27,9 @@ Slice resizing is useful for images with borders and corner details, such as but
 
 Using the [Sprite Editor](/docs/user-guide/interactivity/user-interface/editor/sprite-editor), you can manipulate where the sections are by dragging the dotted lines on the preview image.
 
-**Tip**
+{{< tip >}}
 You can see your changes in real time. To do this, before you open the **Sprite Editor**, change the **Image** component's **ImageType** property to **Sliced**.
+{{< /tip >}}
 
 ![Select Sliced as your ImageType.](/images/user-guide/interactivity/user-interface/editor/sprite-editor/ui-editor-sprite-editor-3.png)
 

--- a/content/docs/user-guide/interactivity/user-interface/slices/working-slices-creating.md
+++ b/content/docs/user-guide/interactivity/user-interface/slices/working-slices-creating.md
@@ -16,8 +16,10 @@ You don't need to select all of the elements to go into the new slice. If you ju
 1. Right-click the parent entity and choose **Make New Slice from Selection**.
 
 1. Save the slice with a descriptive name.
-**Tip**
+
+    {{< tip >}}
 Because you can create many slices for different purposes, we recommend that you name your slices meaningfully and organize them purposefully into directories and subdirectories.
+    {{< /tip >}}
 
 If you want the slice to appear in the slice library **New**, **Element** menu, you must save it within the `UI/Slices/Library` directory. This directory is either in the project root or within any enabled gems asset root. Adding a slice to the slice library menu makes it easy and convenient to use as a common building block for your UI canvases.
 

--- a/content/docs/user-guide/programming/components/reflection/reflecting-for-serialization.md
+++ b/content/docs/user-guide/programming/components/reflection/reflecting-for-serialization.md
@@ -8,7 +8,7 @@ weight: 50
 
 The following example reflects a component for serialization and editing:
 
-```
+```cpp
 class MyComponent
     : public AZ::Component
 {
@@ -68,7 +68,7 @@ The preceding example adds five data members to `MyComponent`. The first four da
 
 It is common for fields to be reflected for serialization, but not for editing, when using advanced reflection features such as [change notification callbacks](#change-notification-callbacks). In these cases, components may conduct complex internal calculations based on user property changes. The result of these calculations must be serialized but not exposed for editing. In such a case, you reflect the field to `SerializeContext` but do not add an entry in `EditContext`. An example follows:
 
-```
+```cpp
 serialize->Class<MyComponent>()
     ->Version(1)
     ...
@@ -107,7 +107,7 @@ A component's `Reflect()` function is invoked automatically for all relevant con
 
 The following code dynamically casts the anonymous context provided to a serialize context, which is how components discern the type of context that `Reflect()` is being called for.
 
-```
+```cpp
 AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
 ```
 
@@ -115,7 +115,7 @@ AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
 
  Reflecting a class for serialization involves a [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) style markup in C++, as follows:
 
-```
+```cpp
 serialize->Class<TestAsset>()
          ->Version(1)
          ->Field("SomeFloat", &MyComponent::m_someFloatField)
@@ -127,8 +127,9 @@ serialize->Class<TestAsset>()
 
 The example specifies that `m_someFloatField`, `m_someStringField`, `m_things`, and `m_someEnumField` should all be serialized with the component. Field names must be unique and are not user facing.
 
-**Tip**
+{{< tip >}}
 We recommend that you keep field names simple for future proofing. If your component undergoes significant changes and you want to write a data converter to maintain backward data compatibility, you must reference the field names directly.
+{{< /tip >}}
 
 The preceding example reflects two primitive types-a float, and a string-as well as a container (vector) of some structure. AZ reflection, serialization, and editing natively support a wide variety of types:
 + Primitive types, including integers (signed and unsigned, all sizes), floats, and strings
@@ -147,7 +148,7 @@ When you run O3DE tools such as O3DE Editor, an `EditContext` and a `SerializeCo
 
 The following code demonstrates basic edit context reflection:
 
-```
+```cpp
 AZ::EditContext* edit = serialize->GetEditContext();
 if (edit)
 {
@@ -168,7 +169,7 @@ Although this example demonstrates the simplest usage, many features and options
 
 An example of binding a float to a slider follows:
 
-```
+```cpp
 ->DataElement(AZ::Edit::UIHandlers::Slider, &MyComponent::m_someFloatField, "Some Float", "This is a float that means X.")
       ->Attribute(AZ::Edit::Attributes::Min, 0.f)
       ->Attribute(AZ::Edit::Attributes::Max, 10.f)
@@ -206,7 +207,7 @@ Member functions
 
 Another commonly used feature of the edit context is its ability to bind a change notification callback:
 
-```
+```cpp
 ->DataElement(AZ::Edit::UIHandlers::Default, &MyComponent::m_someStringField, "Some String", "This is a string that means Y.")
     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &MyComponent::OnStringFieldChanged)
 ```
@@ -215,7 +216,7 @@ The example binds a member function to be invoked when this property is changed,
 
 The following example causes the property grid to refresh values when `m_someStringField `is modified through the property grid. `AZ::Edit::PropertyRefreshLevels::ValuesOnly` signals the property grid to update the GUI with changes to the underlying data.
 
-```
+```cpp
 ->DataElement(AZ::Edit::UIHandlers::Default, &MyComponent::m_someStringField, "Some String", "This is a string that means Y.")
     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &MyComponent::OnStringFieldChanged)
 ...
@@ -236,7 +237,7 @@ AZ::u32 MyComponent::OnStringFieldChanged()
 
 The following more complex example binds a list of strings as options for a combo box. The list of strings is attached to a string field *Property A*. Suppose you want to modify the options available in the combo box for Property A with the values from another *Property B*. In that case you can bind the combo box `AZ::Edit::Attributes::StringList` attribute to a member function that computes and returns the list of options. In the `AZ::Edit::Attributes::ChangeNotify` attribute for Property B, you tell the system to reevaluate attributes, which in turn reinvokes the function that computes the list of options.
 
-```
+```cpp
 ...
 
 bool m_enableAdvancedOptions;

--- a/content/docs/user-guide/scripting/lua/debugging-tutorial.md
+++ b/content/docs/user-guide/scripting/lua/debugging-tutorial.md
@@ -124,9 +124,9 @@ After you connect, you can pause a script by setting breakpoints.
 
 1. Press **F11** a few times to step through the code. Note how the contents of the **Stack**, **Lua Locals**, and **Watched Variables** windows change.
 
-{{< note >}}
+    {{< tip >}}
 For greater convenience, you can float or dock these windows.
-{{< /note >}}
+    {{< /tip >}}
 
 1. To detach from debugging, click **Debugging**.
 

--- a/content/docs/user-guide/scripting/lua/lua-editor.md
+++ b/content/docs/user-guide/scripting/lua/lua-editor.md
@@ -54,9 +54,9 @@ In addition to the usual search capabilities, the **Find** feature can display t
 
 1. To go directly to the line in the code which a search result was found, double-click the line in the search results.
 
-{{< note >}}
+    {{< tip >}}
  For convenience, you can also dock or float the **Find Results** window.
-{{< /note >}}
+    {{< /tip >}}
 
 ## Perforce integration 
 

--- a/content/docs/user-guide/scripting/script-canvas/editor-reference/variables/variable-references.md
+++ b/content/docs/user-guide/scripting/script-canvas/editor-reference/variables/variable-references.md
@@ -49,9 +49,9 @@ Do one of the following:
 
 1. Use the gear button next to the variable name field that appears and select a variable to reference.
 
-    {{< note >}}
+    {{< tip >}}
 Another way to create a variable reference is to drag a variable from the **Variable Manager** onto the data pin.
-    {{< /note >}}
+    {{< /tip >}}
 
 **To convert a variable node into a variable reference**
 

--- a/content/docs/user-guide/visualization/animation/set-up-a-simulated-object.md
+++ b/content/docs/user-guide/visualization/animation/set-up-a-simulated-object.md
@@ -37,12 +37,13 @@ After you create an anim graph, you can preview the simulation. For now, keep th
 
 1. In the render window, view the collider radius of each joint in the simulated object. Select the simulated object to view all colliders or select a joint to see an individual collider.
 
-    **Tip**
-    In the render window, click the ![Joint Collision Radius Icon](/images/user-guide/actor-animation/simulated-objects-5.png) icon to toggle the collider.
+    {{< tip >}}
+In the render window, click the ![Joint Collision Radius Icon](/images/user-guide/actor-animation/simulated-objects-5.png) icon to toggle the collider.
 
-    The **Collision radius** is the distance in which the simulated object joint avoids a collider specified in the simulated object. If the value is `0`, the joint remains on the surface of the collider.
+The **Collision radius** is the distance in which the simulated object joint avoids a collider specified in the simulated object. If the value is `0`, the joint remains on the surface of the collider.
 
-    After you complete the next section, you can adjust the **Collider radius** to get your preferred results.
+After you complete the next section, you can adjust the **Collider radius** to get your preferred results.
+    {{< /tip >}}
 
     ![View how the collider radius of each joint and how it moves with the animation of the actor.](/images/user-guide/actor-animation/simulated-objects-5.gif)
 

--- a/content/docs/user-guide/visualization/animation/set-up-simulated-object-collider.md
+++ b/content/docs/user-guide/visualization/animation/set-up-simulated-object-collider.md
@@ -43,9 +43,9 @@ title: Setting Up Simulated Object Colliders
 
 1.  In the **Skeleton Outliner**, select the joints where the simulated object colliders are attached.
 
-    **Tip**
-
-    In the render window, deselect the first icon (**Solid**) and select the second (**Wireframe**) to view the capsule colliders.
+    {{< tip >}}
+In the render window, deselect the first icon (**Solid**) and select the second (**Wireframe**) to view the capsule colliders.
+    {{< /tip >}}
 
     In the render window, the colliders appear purple. If you deselect the joint, the collider appears gray.
 

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -320,6 +320,10 @@ You can have multiple paragraphs and block-level elements inside an admonition.
 | | |
 {{< /note >}}
 
+{{< tip >}}
+While not essential information, tips draw attention to a shortcut or best practice related to the preceding content.
+{{< /tip >}}
+
 {{< caution >}}
 The reader should proceed with caution.
 {{< /caution >}}

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -321,7 +321,7 @@ You can have multiple paragraphs and block-level elements inside an admonition.
 {{< /note >}}
 
 {{< tip >}}
-While not essential information, tips draw attention to a shortcut or best practice related to the preceding content.
+Tips draw attention to a shortcut or best practice related to the preceding content.
 {{< /tip >}}
 
 {{< caution >}}

--- a/layouts/shortcodes/tip.html
+++ b/layouts/shortcodes/tip.html
@@ -1,0 +1,8 @@
+{{/* This shortcode creates a tip callout. Any provided text will be enclosed in the box. */}}
+
+<blockquote class="warning callout card border-info">
+  <div class="row no-gutters">
+    <div class="col-md-2 bg-info text-white p-2"><strong>Tip: </strong></div> 
+    <div class="col p-2">  {{ trim .Inner " \n" | markdownify }}</div>
+    </div>
+</blockquote>


### PR DESCRIPTION
Signed-off-by: William Hayward <wilhayw@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Adds a tip shortcode, similar to what was available in Lumberyard docs.

A "tip" is meant to draw attention to a shortcut or best practice.

PR also includes example in `smoketest.md` and a handful of updates to docs that came over from Lumberyard that had tips.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

