### PR TITLE
Separated Source and Job Dependencies. Added a note on the upcoming

### DIFF
--- a/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
+++ b/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
@@ -8,15 +8,21 @@ toc: true
 
 Both source and product assets might have dependencies. Source asset and job dependencies are inputs to the **Asset Pipeline** and asset processing jobs. Product dependencies are outputs from the Asset Pipeline and are used to load and package product assets. Asset identifiers help ensure both types of asset dependencies are met.
 
-## Source and job dependencies
+## Source dependencies
 
-Source and job dependencies are a process time concept.
+Source dependencies are a process time concept.
 
-A source dependency triggers **Asset Processor** to rerun the process job whenever a source asset changes. For example, a `.assetinfo` file is a source dependency and triggers a process job on its source asset when it is modified.
+A source dependency triggers **Asset Processor** to rerun the process job whenever the file declared as a source dependency changes. For example, a `.assetinfo` file is a source dependency and triggers a process job on its source asset when it is modified.
 
-A job dependency requires the product asset of another process job before this process job can be run. The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader product asset is generated because the material requires information about the shader product asset.
+## Job dependencies
+
+Job dependencies are a process time concept.
+
+A job dependency is declared against another job. If a job matching that description exists in the job queue, when the job with the dependency is up next to run, it will first make sure all of its job dependencies are run. Also, if a job dependency runs again, it will trigger any jobs with that dependency to run. The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader job is completed because the material requires information from product assets of the shader job. If the source shader asset is changed, causing the shader job to re-run, then the material job with that job dependency will re-run after the shader job finishes.
 
 Required job dependencies cause the process job to fail if the required product asset is not available, however, job dependencies can be marked optional. Optional job dependencies make use of the requested product asset if it exists, but can complete without the requested product asset.
+
+Job dependencies can be declared on a product asset of the associated job. If this is done, then the job that is the dependency will only cause the job with the dependency to re-run if the hash of the contents of the specified product asset change. This is best used when the dependency has multiple product assets but the job with the dependency only references one of those product assets.
 
 ## Product dependencies
 
@@ -31,7 +37,10 @@ Product dependencies can also be marked as required or optional. If a required p
 
 ## Asset identifiers
 
-Source assets are identified by a Universally Unique Identifier (UUID). The source asset UUID is generated based on the file name and scan directory relative path. This ensures the source asset UUID is identical on any host platform machine for the project.
+Source assets are identified by a Universally Unique Identifier (UUID). This is also referenced as a Globally Unique Identifier (GUID) in some parts of O3DE. The source asset UUID is generated based on the file name and scan directory relative path. This ensures the source asset UUID is identical on any host platform machine for the project.
 
 
 Product assets are identified by a combination of the UUID for the source asset and a sub ID based on the fingerprint of the **Asset Builder** that produced the product asset. This ensures each product asset ID is deterministic and unique, and that references to these product assets can be maintained when assets are updated. In the rare event of a product asset ID collision, Asset Processor notifies you that an asset already exists with the product ID so you can resolve the issue.
+
+
+Note that source assets are not specific to platforms, but product assets are unique across platforms. If you are authoring a builder that outputs product assets differently for different platforms, you should consider how you will access these product assets at runtime. Most of the time the product asset differences are performance optimizations per platform, and in that case it's recommended that the same sub ID is used for similar assets for each platform. For example, the source asset _dev_purple.tif generates a streamingimage file _dev_purple.tif.streamingimage for all platforms, which has the sub ID 1000 on all platforms. This means that any other content referencing this file can reference that sub ID and get the same functional image regardless of which platform the project is running on.

--- a/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
+++ b/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
@@ -12,17 +12,17 @@ Both source and product assets might have dependencies. Source asset and job dep
 
 Source dependencies are a process time concept.
 
-A source dependency triggers **Asset Processor** to rerun the process job whenever the file declared as a source dependency changes. For example, a `.assetinfo` file is a source dependency and triggers a process job on its source asset when it is modified.
+A source dependency triggers **Asset Processor** to rerun the process job whenever the file declared as a source dependency changes. For example, image files declare a source dependency on the `.preset` file containing the preset information used to process the image, so if the preset changes the image will be reprocessed and use the new preset settings.
 
 ## Job dependencies
 
 Job dependencies are a process time concept.
 
-A job dependency is declared against another job. If a job matching that description exists in the job queue, when the job with the dependency is up next to run, it will first make sure all of its job dependencies are run. Also, if a job dependency runs again, it will trigger any jobs with that dependency to run. The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader job is completed because the material requires information from product assets of the shader job. If the source shader asset is changed, causing the shader job to re-run, then the material job with that job dependency will re-run after the shader job finishes.
+A job dependency should be used when processing one asset requires reading the product asset output of another, different job. A job dependency is declared against another job. If a job matching that description exists in the job queue, when the job with the dependency is up next to run, it will first make sure all of its job dependencies are run. When a job runs again, it will trigger any jobs that depend on it to run. The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader job is completed because the material requires information from product assets of the shader job. If the source shader asset is changed, causing the shader job to re-run, then the material job with that job dependency will re-run after the shader job finishes.
 
-Required job dependencies cause the process job to fail if the required product asset is not available, however, job dependencies can be marked optional. Optional job dependencies make use of the requested product asset if it exists, but can complete without the requested product asset.
+Required job dependencies cause the process job to fail if the required product asset is not available.
 
-Job dependencies can be declared on a product asset of the associated job. If this is done, then the job that is the dependency will only cause the job with the dependency to re-run if the hash of the contents of the specified product asset change. This is best used when the dependency has multiple product assets but the job with the dependency only references one of those product assets.
+Job dependencies can optionally specify a set of product assets from the associated job. If this is done, then the job that is the dependency will only cause the job with the dependency to re-run if the hash of the contents of the specified product asset(s) change. This is best used when the dependency has multiple product assets but the job with the dependency does not reference all of these product assets. As an example, if one job outputs a configuration file and a logic file (for example, shaders), and another job uses the configuration file (for example, materials), by declaring a job dependency on the configuration product asset, the job with this dependency would only re-run if the configuration asset changes, and not if the logic asset changes.
 
 ## Product dependencies
 
@@ -32,15 +32,12 @@ Product dependencies contain data on the relationships between product assets. P
 
 When a product asset is loaded at runtime, the product dependencies specify other product assets that must be loaded for this product asset to function. Similarly, when bundling assets, the product dependencies specify additional product assets required by the assets being bundled. An easy to understand example is a level prefab.  All the meshes, shaders, materials, audio files, and scripts used by entities and prefabs that are placed in the level are dependencies of the level prefab. When you load or bundle a level prefab, the chain of asset dependencies specifies all the product assets required by the level prefab, as well as the product assets referenced by those dependencies, and so on, until all the product dependencies are met.
 
-
 Product dependencies can also be marked as required or optional. If a required product dependency is not available, the runtime load process or the bundling process fails. If an optional product dependency is not available, the runtime load process or bundling process can proceed.
 
 ## Asset identifiers
 
 Source assets are identified by a Universally Unique Identifier (UUID). This is also referenced as a Globally Unique Identifier (GUID) in some parts of O3DE. The source asset UUID is generated based on the file name and scan directory relative path. This ensures the source asset UUID is identical on any host platform machine for the project.
 
-
-Product assets are identified by a combination of the UUID for the source asset and a sub ID based on the fingerprint of the **Asset Builder** that produced the product asset. This ensures each product asset ID is deterministic and unique, and that references to these product assets can be maintained when assets are updated. In the rare event of a product asset ID collision, Asset Processor notifies you that an asset already exists with the product ID so you can resolve the issue.
-
+Product assets are identified by a combination of the UUID for the source asset and a sub ID defined by the **Asset Builder** that produced the product asset. It is the responsibility of the builder author to make sure their sub IDs are deterministic and unique, so that references to these product assets can be maintained when assets are updated. When authoring a builder, keep in mind that other builders may process the same source asset and also generate products, which is one area sub ID collisions can occur. When authoring a builder, try to keep sub IDs as consistent as possible across changes to a source asset, otherwise downstream references, such as a prefab file referencing a product asset via asset ID, will break if that sub ID no longer resolves, or resolves to a different product asset. In the rare event of a product asset ID collision, Asset Processor notifies you that an asset already exists with the product ID so you can resolve the issue.
 
 Note that source assets are not specific to platforms, but product assets are unique across platforms. If you are authoring a builder that outputs product assets differently for different platforms, you should consider how you will access these product assets at runtime. Most of the time the product asset differences are performance optimizations per platform, and in that case it's recommended that the same sub ID is used for similar assets for each platform. For example, the source asset _dev_purple.tif generates a streamingimage file _dev_purple.tif.streamingimage for all platforms, which has the sub ID 1000 on all platforms. This means that any other content referencing this file can reference that sub ID and get the same functional image regardless of which platform the project is running on.

--- a/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
+++ b/content/docs/user-guide/assets/pipeline/asset-dependencies-and-identifiers.md
@@ -10,27 +10,31 @@ Both source and product assets might have dependencies. Source asset and job dep
 
 ## Source dependencies
 
-Source dependencies are a process time concept.
+Source dependencies are a process time concept. This means that this dependency type is used when processing assets for your project, source dependencies are not used at runtime.
 
-A source dependency triggers **Asset Processor** to rerun the process job whenever the file declared as a source dependency changes. For example, image files declare a source dependency on the `.preset` file containing the preset information used to process the image, so if the preset changes the image will be reprocessed and use the new preset settings.
+A source dependency triggers **Asset Processor** to rerun the job process step whenever the file declared as a source dependency changes. For example, image files declare a source dependency on the `.preset` file containing the preset information used to process the image, so if the preset changes the image will be reprocessed and use the new preset settings.
 
 ## Job dependencies
 
 Job dependencies are a process time concept.
 
-A job dependency should be used when processing one asset requires reading the product asset output of another, different job. A job dependency is declared against another job. If a job matching that description exists in the job queue, when the job with the dependency is up next to run, it will first make sure all of its job dependencies are run. When a job runs again, it will trigger any jobs that depend on it to run. The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader job is completed because the material requires information from product assets of the shader job. If the source shader asset is changed, causing the shader job to re-run, then the material job with that job dependency will re-run after the shader job finishes.
+A job dependency is used when a job must read the product asset output of another job. A job dependency is declared against another job. When a job that has a job dependency is run, it first ensures that all of its job dependencies are run. If a job that is a job depenedency is run, it will trigger any jobs that depend on it to run.
 
-Required job dependencies cause the process job to fail if the required product asset is not available.
+The shader and material relationship is an example of a job dependency. The material cannot be processed until the shader job is completed because the material requires information from product assets of the shader job. If the source shader asset is changed, causing the shader job to run, then the material job with that job dependency will run after the shader job finishes.
 
-Job dependencies can optionally specify a set of product assets from the associated job. If this is done, then the job that is the dependency will only cause the job with the dependency to re-run if the hash of the contents of the specified product asset(s) change. This is best used when the dependency has multiple product assets but the job with the dependency does not reference all of these product assets. As an example, if one job outputs a configuration file and a logic file (for example, shaders), and another job uses the configuration file (for example, materials), by declaring a job dependency on the configuration product asset, the job with this dependency would only re-run if the configuration asset changes, and not if the logic asset changes.
+Required job dependencies cause the job to fail if the required product asset is not available.
+
+Jobs can generate multiple product assets, but a job might not need all product assets from another job that was declared as a job dependency. In this scenario, the required product assets are specified for the job dependency. If the hash of any of the specified product assets changes, the job with the dependency is run.
+
+A material, for example, has a job dependency on a shader. The shader job generates multiple product assets including assets that contain shader logic and a shader configuration. The material job dependency only needs the configuration from the shader, not the logic. The material job runs when the shader configuration is changed, not when the shader logic is changed.
 
 ## Product dependencies
 
-Product dependencies are a runtime concept.
+Product dependencies are a packaging and runtime concept. This means these dependencies are not used during processing of assets, but they are declared there.
 
 Product dependencies contain data on the relationships between product assets. Product dependencies are used during runtime loading and asset bundling.
 
-When a product asset is loaded at runtime, the product dependencies specify other product assets that must be loaded for this product asset to function. Similarly, when bundling assets, the product dependencies specify additional product assets required by the assets being bundled. An easy to understand example is a level prefab.  All the meshes, shaders, materials, audio files, and scripts used by entities and prefabs that are placed in the level are dependencies of the level prefab. When you load or bundle a level prefab, the chain of asset dependencies specifies all the product assets required by the level prefab, as well as the product assets referenced by those dependencies, and so on, until all the product dependencies are met.
+When a product asset is loaded at runtime, the product dependencies specify other product assets that must be loaded for this product asset to function. Similarly, when bundling assets, the product dependencies specify additional product assets required by the assets being bundled. An easy to understand example is a level prefab. All the meshes, shaders, materials, audio files, and scripts used by entities and prefabs that are placed in the level are dependencies of the level prefab. When you load or bundle a level prefab, the chain of asset dependencies specifies all the product assets required by the level prefab, as well as the product assets referenced by those dependencies, and so on, until all the product dependencies are met.
 
 Product dependencies can also be marked as required or optional. If a required product dependency is not available, the runtime load process or the bundling process fails. If an optional product dependency is not available, the runtime load process or bundling process can proceed.
 
@@ -38,6 +42,15 @@ Product dependencies can also be marked as required or optional. If a required p
 
 Source assets are identified by a Universally Unique Identifier (UUID). This is also referenced as a Globally Unique Identifier (GUID) in some parts of O3DE. The source asset UUID is generated based on the file name and scan directory relative path. This ensures the source asset UUID is identical on any host platform machine for the project.
 
-Product assets are identified by a combination of the UUID for the source asset and a sub ID defined by the **Asset Builder** that produced the product asset. It is the responsibility of the builder author to make sure their sub IDs are deterministic and unique, so that references to these product assets can be maintained when assets are updated. When authoring a builder, keep in mind that other builders may process the same source asset and also generate products, which is one area sub ID collisions can occur. When authoring a builder, try to keep sub IDs as consistent as possible across changes to a source asset, otherwise downstream references, such as a prefab file referencing a product asset via asset ID, will break if that sub ID no longer resolves, or resolves to a different product asset. In the rare event of a product asset ID collision, Asset Processor notifies you that an asset already exists with the product ID so you can resolve the issue.
+Product assets are identified by a combination of the UUID for the source asset and a sub ID defined by the **Asset Builder** that produced the product asset. Builder sub IDs must be deterministic and unique, so that references to the product assets can be maintained when assets are updated. When authoring a builder, keep the following in mind:
 
-Note that source assets are not specific to platforms, but product assets are unique across platforms. If you are authoring a builder that outputs product assets differently for different platforms, you should consider how you will access these product assets at runtime. Most of the time the product asset differences are performance optimizations per platform, and in that case it's recommended that the same sub ID is used for similar assets for each platform. For example, the source asset _dev_purple.tif generates a streamingimage file _dev_purple.tif.streamingimage for all platforms, which has the sub ID 1000 on all platforms. This means that any other content referencing this file can reference that sub ID and get the same functional image regardless of which platform the project is running on.
+* Other builders may process the same source asset and also generate products. This is an area where sub ID collisions can occur.
+* Keep sub IDs as consistent as possible for product assets based on changes to a source asset.
+
+Downstream references, such as a prefab file referencing a product asset via asset ID, break if the sub ID doesn't resolve, or resolves to a different product asset. In the rare event of a product asset ID collision, Asset Processor notifies you that an asset already exists with the product ID so that you can resolve the issue.
+
+{{< note >}}
+Product assets are unique across target platforms. The differences for each target platform most often are platform performance optimizations.
+
+If you author a builder that outputs product assets for different target platforms, you should consider how the product assets are accessed at runtime. It's recommended to use the same sub ID for similar assets for each target platform. For example, the source asset `_dev_purple.tif` generates a streamingimage file `_dev_purple.tif.streamingimage` , which has the sub ID 1000, for all platforms. This means that any other content that references `_dev_purple.tif.streamingimage` can reference the sub ID and get the same functional image on each target platform.
+{{< /note >}}


### PR DESCRIPTION
feature for Job Dependencies on Product Assets. Updated Asset Identifiers to note that GUID is sometimes used instead of UUID, and to explain platforms.

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ X ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ X ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ X ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ X ] **Help the user** - Does the documentation show the user something *meaningful*?

