### PR TITLE
Asset Processor main page cleanup.

### DIFF
--- a/content/docs/user-guide/assets/asset-processor/_index.md
+++ b/content/docs/user-guide/assets/asset-processor/_index.md
@@ -22,7 +22,7 @@ With Asset Processor, a **Launcher** can be run on a target platform without dep
 
 On a host platform, connections between Asset Processor and O3DE Editor are automatically maintained.
 
-When you launch software that requires an Asset Processor connection, such as the O3DE Editor or Launcher in a non-release configuration, the Asset Processor will automatically be launched. If the Asset Processor has been launched this way, it will automatically shut down when you close the Editor or Launcher.
+When you launch software that requires an Asset Processor connection, such as the O3DE Editor or Launcher in a non-release configuration, Asset Processor is automatically launched. If Asset Processor has been launched this way, it automatically shuts down when you close the Editor or Launcher.
 
 {{< note >}}
 Symbolic links are not supported when using Asset Processor. To ensure that Asset Processor works properly, follow these guidelines:

--- a/content/docs/user-guide/assets/asset-processor/_index.md
+++ b/content/docs/user-guide/assets/asset-processor/_index.md
@@ -20,7 +20,9 @@ toc: true
 
 With Asset Processor, a **Launcher** can be run on a target platform without deploying assets to that platform. Instead, the assets are accessed from the Asset Cache on a connected host platform. Asset Processor communicates through a USB connection with mobile target platforms using proxy requests.
 
-On a host platform, connections between Asset Processor and O3DE Editor are automatically maintained. Asset Processor automatically restarts if you retrieve a new version or modify any of the data files that it needs to operate.
+On a host platform, connections between Asset Processor and O3DE Editor are automatically maintained.
+
+When you launch software that requires an Asset Processor connection, such as the O3DE Editor or Launcher in a non-release configuration, the Asset Processor will automatically be launched. If the Asset Processor has been launched this way, it will automatically shut down when you close the Editor or Launcher.
 
 {{< note >}}
 Symbolic links are not supported when using Asset Processor. To ensure that Asset Processor works properly, follow these guidelines:


### PR DESCRIPTION
Removed a note that claimed the Asset Processor would automatically shut down and re-launch itself. This was Lumberyard 1.x behavior that does not exist in O3DE.
Added a note that, by default the Asset Processor will be launched when you open the Editor or launcher, and will shut down when you close them.

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

