### PR TITLE
Website navigation experience: Separate section’s group title and page title

### DIFF
--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -4,15 +4,17 @@
         {{ $isHere := in $here .RelPermalink }}
         <li>
             <a href="{{ .RelPermalink }}"
-            class="docs-link{{ if .Pages }} has-children{{ end }}">
-            {{ .LinkTitle }}</a>
+            class="docs-link{{ if .Pages }} has-children{{ end }}"> 
+                {{.LinkTitle}} 
+            </a>
             {{ if .Pages }}
                 <ul>
                     {{ if and ( .IsSection ) (ge (len .Content) 1) }}
                     <li>
                         <a href="{{ .RelPermalink }}"
-                        class="docs-link">
-                        {{ .LinkTitle }}</a>
+                        class="docs-link">                        
+                            {{ if .Params.sectionPageTitle }} {{.Params.sectionPageTitle}} {{else}} {{.LinkTitle}} {{end}}
+                        </a>
                     </li>
                     {{ end }}
                     {{ partial "section-nav-walk.html" . }}


### PR DESCRIPTION

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

### Problem

A *section* in the docs contains at least an `_index.md` and other single pages or nested sections.  In the section’s `_index.md` file, the `linkTitle` parameter defines the section’s navigation group title and page title on the website’s *doc section navigation* on the left-hand side (see image below). The problem with this is you can’t rename the the page title to a fitting name such as “Overview”. 

![image](https://user-images.githubusercontent.com/75444793/159076971-1dc1a47c-e152-4fd7-9dad-64fd544bc2ab.png)


### Past solution

*I investigated this problem earlier in the year and tried the following solution, but it’s not the cleanest.* 

For a sections in the docs, I removed the contents of `_index.md` file except for the metadata, so it doesn’t render on the doc section navigation in the website. Instead, I put those contents in another page (e.g. `[overview.md](http://overview.md)`) and set that page as the first page of the section. The problem here is that the section’s page, a commonly visited page by users, will be empty. You can see this in the example below, where the first page of the Gem’s section is successfully titled “Overview”, but directs you to the `docs/user-guide/gems/overview/` page (see A), leaving the `docs/user-guide/gems/` page empty (see B). 

Even if all links on the website direct users to the separate overview page `docs/user-guide/gems/overview/` instead of the section’s landing page. `docs/user-guide/gems/`, the section’s landing page still gets rendered. So it’s very likely for users to chance upon that page and see that it’s empty, causing confusion in their experience with the website. An empty page is especially undesirable when the website is viewed in “mobile” mode, because the doc section navigation is hidden by default, making it even less likely for users to find section topics. 

**A**

![image](https://user-images.githubusercontent.com/75444793/159076990-ae795307-66bc-4d77-a218-f8ba95576d7c.png)


**B**

![image](https://user-images.githubusercontent.com/75444793/159077008-544b28f1-0c5e-47bf-8024-8bcad56d05e1.png)

### Proposed solution

This is my new proposed solution. 

I introduce a new variable in Hugo pages, `.sectionPageTitle`, where you can define the section’s page title by including it in the metadata. Then, in the `section-nav-walk.html` file, I added a functionality so that if the page is a section, it’s page title will appear on the doc section navigation with the name provided by the `.sectionPageTitle` parameter, if one is provided. The section’s group title in the doc section navigation remains set by the `linkTitle` parameter, as usual.

In the example below, the `docs/user-guide/editor/_index.md` page contains the following metadata and renders the website as shown in the image after: 

```markdown
---
linkTitle: Editor
title: O3DE Editor
sectionPageTitle: Overview
weight: 300
---
```
![image](https://user-images.githubusercontent.com/75444793/159077024-5d106dc0-c731-476e-954d-4d31c18bb12f.png)


### Other notes

- Because of the logic in `section-nav-walk.html` , any page that isn’t a section (doesn’t contain `_index.md`) is not affected by a `.sectionPageTitle` parameter in the metadata.
- The `.sectionPageTitle` parameter also applies to high-level sections, such as **User Guide**, **Contributing**, **Tutorials**, and so on.
- `.sectionPageTitle` is a user-created page variable (that I created for the purpose here) and can be accessed using the [`.Params` function](https://gohugo.io/functions/param/#readout).

## Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

