### PR TITLE
Remove references to GridMate/GridHub

### DIFF
--- a/content/docs/api/frameworks/_index.md
+++ b/content/docs/api/frameworks/_index.md
@@ -14,4 +14,3 @@ description: Reference index for Open 3D Engine frameworks.
 * [AzTest](/docs/api/frameworks/aztest)
 * [AzToolsFramework](/docs/api/frameworks/aztoolsframework)
 * [GFxFramework](/docs/api/frameworks/gfxframework)
-* [GridMate](/docs/api/frameworks/gridmate)

--- a/content/docs/user-guide/scripting/lua/_index.md
+++ b/content/docs/user-guide/scripting/lua/_index.md
@@ -10,17 +10,9 @@ You can use Lua in **Open 3D Engine (O3DE)** to facilitate quick iteration of yo
 
 O3DE uses Lua version {{< versions/lua >}}.
 
-## Lua Editor and GridHub
+## Lua Editor and Debugging
 
-The Lua development environment in O3DE includes the **Lua Editor**. The debugger that is included with the Lua Editor uses a connection hub called **GridHub**. These two applications are built when the **O3DE Editor** is built.
-
-### Building Lua Editor and GridHub
-
-To build Lua Editor and GridHub separately, navigate to the directory where you build your project (or where you build the O3DE engine, if you build the engine separately) and run the following command, inserting the path to your build directory.
-
-```cmd
-cmake --build <build-directory> --target LuaIDE GridHub --config profile -- -m
-```
+The Lua development environment in O3DE includes the **Lua Editor**. The debugger that is included with the Lua Editor uses AzNetworking connections managed by AzFramework's TargetManagement.
 
 ## Learning Lua 
 

--- a/content/docs/user-guide/scripting/lua/debugging-tutorial.md
+++ b/content/docs/user-guide/scripting/lua/debugging-tutorial.md
@@ -68,9 +68,9 @@ This tutorial shows you how to use O3DE Lua Editor to perform debugging operatio
 
     ![Launch Lua Editor from Lua Script component in O3DE Editor](/images/user-guide/scripting/lua/lua-component-open-in-lua-editor.png)
     
-## Connect to O3DE Editor with GridHub
+## Connect to O3DE Editor
 
-Connection is facilitated by **GridHub**, which is O3DE's central connection hub for debugging. GridHub starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
+Connection is facilitated by **TargetManagement**, which is facilitates O3DE applications locally connecting to each other. TargetManagement starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
 
 1. In the Lua Editor toolbar, choose **Target: None**, and then choose **Editor(*ID*)** to connect to O3DE Editor.
 

--- a/content/docs/user-guide/scripting/lua/debugging-tutorial.md
+++ b/content/docs/user-guide/scripting/lua/debugging-tutorial.md
@@ -70,7 +70,7 @@ This tutorial shows you how to use O3DE Lua Editor to perform debugging operatio
     
 ## Connect to O3DE Editor
 
-Connection is facilitated by **TargetManagement**, which is facilitates O3DE applications locally connecting to each other. TargetManagement starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
+Connection is facilitated by **TargetManagement**, which facilitates O3DE applications locally connecting to each other. TargetManagement starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
 
 1. In the Lua Editor toolbar, choose **Target: None**, and then choose **Editor(*ID*)** to connect to O3DE Editor.
 

--- a/content/docs/user-guide/scripting/lua/debugging-tutorial.md
+++ b/content/docs/user-guide/scripting/lua/debugging-tutorial.md
@@ -70,7 +70,7 @@ This tutorial shows you how to use O3DE Lua Editor to perform debugging operatio
     
 ## Connect to O3DE Editor
 
-Connection is facilitated by **TargetManagement**, which facilitates O3DE applications locally connecting to each other. TargetManagement starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
+**TargetManagement** facilitates local connections between O3DE applications. TargetManagement starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
 
 1. In the Lua Editor toolbar, choose **Target: None**, and then choose **Editor(*ID*)** to connect to O3DE Editor.
 

--- a/content/docs/user-guide/scripting/script-canvas/debugging.md
+++ b/content/docs/user-guide/scripting/script-canvas/debugging.md
@@ -135,12 +135,6 @@ For in-game debugging, you use the Script Canvas debugger to connect to a runnin
 
 **To debug a running game**
 
-1. Run `GridHub.exe` from your O3DE build directory. GridHub is the network environment that provides connectivity between O3DE and its tools.
-
-   {{< note >}}
-GridHub must be active for non-editor targets to appear in the **Live** tab.
-   {{< /note >}}
-
 1. Run the launcher for your game.
 
 1. On the **Live** tab of the Script Canvas debugger, choose the launcher from the list of debug targets. When you choose the launcher as the debug target, Script Canvas execution is recorded for the graphs that you specify.


### PR DESCRIPTION
Signed-off-by: puvvadar [puvvadar@amazon.com](mailto:puvvadar@amazon.com)

## Change summary

This change updates documentation to remove references to GridMate and GridHub which will be red coded following work outlined in https://github.com/o3de/sig-content/issues/49. Note that this does not update images and references in the Profiler docs page. GridMate is used as an example name in that scenario so I opted not to redo all the associated screenshots.

