### PR TITLE
Fix broken links - GHI 1406, 1407, 1422, 1445

### DIFF
--- a/content/docs/atom-guide/look-dev/color-management/index.md
+++ b/content/docs/atom-guide/look-dev/color-management/index.md
@@ -4,7 +4,6 @@ title: "Color Management"
 description: "Learn about the color space conversion workflow used in the Atom Renderer."
 toc: true
 weight: 500
-draft: true
 ---  
 
 {{< placeholder >}}

--- a/content/docs/atom-guide/look-dev/color-management/index.md
+++ b/content/docs/atom-guide/look-dev/color-management/index.md
@@ -8,4 +8,3 @@ weight: 500
 
 {{< placeholder >}}
 
-## Color Space Conversion Workflow

--- a/content/docs/atom-guide/look-dev/textures/_index.md
+++ b/content/docs/atom-guide/look-dev/textures/_index.md
@@ -7,4 +7,3 @@ weight: 300
 
 {{< placeholder >}}
 
-This topic is about how to import textures with the Atom Renderer. 

--- a/content/docs/atom-guide/look-dev/textures/_index.md
+++ b/content/docs/atom-guide/look-dev/textures/_index.md
@@ -3,9 +3,8 @@ title: "Textures"
 description: "Learn about how textures are supported and processed in Atom Renderer."
 toc: true
 weight: 300
-draft: true
 ---  
 
 {{< placeholder >}}
 
-This topic is about  how to import textures with the Atom Renderer. 
+This topic is about how to import textures with the Atom Renderer. 

--- a/content/docs/user-guide/programming/gems/_index.md
+++ b/content/docs/user-guide/programming/gems/_index.md
@@ -17,4 +17,4 @@ weight: 120
 
 | Topic | Description |
 |---|---|
-| [Gems in Open 3D Engine](/docs/user-guide/gems/) | Learn about the Gems that extend O3DE. |
+| [Gems in Open 3D Engine](/docs/user-guide/gems/overview) | Learn about the Gems that extend O3DE. |

--- a/content/docs/user-guide/programming/gems/manifest.md
+++ b/content/docs/user-guide/programming/gems/manifest.md
@@ -5,6 +5,6 @@ title: Gem Manifest File (gem.json)
 weight: 400
 ---
 
-{{< todo >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/416" >}}
 We need a full reference of the gem.json manifest. This can appear here, or be moved to a 'references' section.
 {{< /todo >}}

--- a/content/docs/user-guide/programming/gems/manifest.md
+++ b/content/docs/user-guide/programming/gems/manifest.md
@@ -1,8 +1,10 @@
 ---
+linkTitle: Gem Manifest File
 description: Learn about the format and structure of the manifest file that defines Open 3D Engine Gems.
 title: Gem Manifest File (gem.json)
 weight: 400
-draft: true
 ---
 
-<!-- TODO: We need a full reference of the gem.json manifest. This can appear here, or be moved to a 'references' section. -->
+{{< todo >}}
+We need a full reference of the gem.json manifest. This can appear here, or be moved to a 'references' section.
+{{< /todo >}}

--- a/content/docs/user-guide/project-config/register-gems.md
+++ b/content/docs/user-guide/project-config/register-gems.md
@@ -6,7 +6,7 @@ toc: true
 weight: 140
 ---
 
-**Open 3D Engine (O3DE)** includes many Gems that extend features and add assets to your project. For a full list, refer to the [Gem Reference](/docs/user-guide/gems/reference). These Gems have already been registered to the engine and are ready to be added to a project.
+**Open 3D Engine (O3DE)** includes many Gems that extend features and add assets to your project. For a full list, refer to the [Gem Reference](/docs/user-guide/gems/overview). These Gems have already been registered to the engine and are ready to be added to a project.
 
 You can also register *external* Gems from a source outside of O3DE so that they too can be used in your project. Registering a Gem enables your project to find the Gem. Gem folders can be located anywhere on your computer.
 


### PR DESCRIPTION
## Change summary

1445: Removed draft from linked pages.
1422: Changed link to point to gems/overview.
1407: Removed draft from linked page, added TODO.
1406: Changed link to point to gems/overview.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #1445; Fix #1422; Fix #1407; Fix #1406