### PR TITLE
Documented new option to use checked version of PhysX library

### DIFF
--- a/content/docs/user-guide/interactivity/physics/debugging.md
+++ b/content/docs/user-guide/interactivity/physics/debugging.md
@@ -14,6 +14,7 @@ You must first enable the [PhysX Debug](/docs/user-guide/gems/reference/physics/
 + [PhysX Debug Console Variables](#physx-debug-console-variables)
 + [Debugging with the ImGui Tool](#debugging-with-the-imgui-tool)
 + [Debug Options in the PhysX Configuration](#debug-options-in-the-physx-configuration)
++ [Enable additional checks and error reporting in PhysX SDK](#enable-additional-checks-and-error-reporting-in-physx-sdk)
 
 ## PhysX Debug Console Variables 
 
@@ -87,3 +88,15 @@ You must enable the [ImGui Gem](/docs/user-guide/gems/reference/debug/imgui) to 
 ## Debug Options in the PhysX Configuration 
 
 You can also specify debug settings in the **PhysX Configuration** tool. See [Debugger Configuration](/docs/user-guide/interactivity/physics/nvidia-physx/configuring/configuration-debugger/).
+
+## Enable additional checks and error reporting in PhysX SDK
+
+You can make the profile configuration of O3DE to use the **checked** version of PhysX SDK library. PhysX will perform additional checks to detect invalid parameters, API race conditions and other incorrect uses of the API which might otherwise cause mysterious crashes or failures in simulation. The benefit is to enable the same safety checks as in debug configuration but without having to run O3DE on debug, where low framerates could spoil the simulation.
+
+Using checked version of PhysX has an impact on performance. Use it to detect errors in the simulation or to make sure that the scene is properly set up, but disable it when doing profiling or trying to identify performance bottlenecks.
+
+You can enable checked version of PhysX by setting **LY_PHYSX_PROFILE_USE_CHECKED_LIBS** to **TRUE** during cmake configuration:
+
+```
+-DLY_PHYSX_PROFILE_USE_CHECKED_LIBS=TRUE
+```

--- a/content/docs/user-guide/interactivity/physics/debugging.md
+++ b/content/docs/user-guide/interactivity/physics/debugging.md
@@ -91,11 +91,11 @@ You can also specify debug settings in the **PhysX Configuration** tool. See [De
 
 ## Enable additional checks and error reporting in PhysX SDK
 
-You can make the profile configuration of O3DE to use the **checked** version of PhysX SDK library. PhysX will perform additional checks to detect invalid parameters, API race conditions and other incorrect uses of the API which might otherwise cause mysterious crashes or failures in simulation. The benefit is to enable the same safety checks as in debug configuration but without having to run O3DE on debug, where low framerates could spoil the simulation.
+You can make the profile configuration of O3DE use the **checked** version of PhysX SDK library. PhysX will perform additional checks to detect invalid parameters, API race conditions and other incorrect uses of the API which might otherwise cause mysterious crashes or failures in simulation. The benefit is to enable the same safety checks as in debug configuration but without having to run O3DE on debug, where low framerates could spoil the simulation.
 
 Using checked version of PhysX has an impact on performance. Use it to detect errors in the simulation or to make sure that the scene is properly set up, but disable it when doing profiling or trying to identify performance bottlenecks.
 
-You can enable checked version of PhysX by setting **LY_PHYSX_PROFILE_USE_CHECKED_LIBS** to **TRUE** during cmake configuration:
+You can enable the checked version of PhysX by setting **LY_PHYSX_PROFILE_USE_CHECKED_LIBS** to **TRUE** during cmake configuration:
 
 ```
 -DLY_PHYSX_PROFILE_USE_CHECKED_LIBS=TRUE

--- a/content/docs/user-guide/interactivity/physics/debugging.md
+++ b/content/docs/user-guide/interactivity/physics/debugging.md
@@ -91,11 +91,11 @@ You can also specify debug settings in the **PhysX Configuration** tool. See [De
 
 ## Enable additional checks and error reporting in PhysX SDK
 
-You can make the profile configuration of O3DE use the **checked** version of PhysX SDK library. PhysX will perform additional checks to detect invalid parameters, API race conditions and other incorrect uses of the API which might otherwise cause mysterious crashes or failures in simulation. The benefit is to enable the same safety checks as in debug configuration but without having to run O3DE on debug, where low framerates could spoil the simulation.
+You can make the profile configuration of O3DE use the **checked** version of the PhysX SDK library. PhysX will perform additional checks to detect invalid parameters, API race conditions and other incorrect uses of the API which might otherwise cause mysterious crashes or failures in simulation. The benefit of doing this is the same safety checks from the debug configuration are enabled without having to run O3DE in debug, where low framerates could impact the simulation.
 
-Using checked version of PhysX has an impact on performance. Use it to detect errors in the simulation or to make sure that the scene is properly set up, but disable it when doing profiling or trying to identify performance bottlenecks.
+Using the checked version of PhysX has an impact on performance. Use it to detect errors in the simulation or to make sure that the scene is properly set up, but disable it when doing profiling or trying to identify performance bottlenecks.
 
-You can enable the checked version of PhysX by setting **LY_PHYSX_PROFILE_USE_CHECKED_LIBS** to **TRUE** during cmake configuration:
+You can enable the checked version of PhysX by setting **LY_PHYSX_PROFILE_USE_CHECKED_LIBS** to **TRUE** during CMake configuration:
 
 ```
 -DLY_PHYSX_PROFILE_USE_CHECKED_LIBS=TRUE


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Documented new option to use **checked** version of PhysX library to perform additional error checking.
This is a change for O3DE 2205 release so it's being merged into main branch.
Closes https://github.com/o3de/o3de/issues/6383

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

