### PR TITLE
Replaced references to slices with prefabs in physx documentation

### DIFF
--- a/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-cloth.md
+++ b/content/docs/user-guide/gems/reference/physics/nvidia/nvidia-cloth.md
@@ -19,7 +19,7 @@ The NVIDIA Cloth Gem provides the following:
 
 * Cloth colliders that can be added to actors in **Animation Editor**.
 
-* Mesh and Actor example assets and slices located in: `\Gems\NvCloth\Assets\`.
+* Mesh and Actor example assets and prefabs located in: `\Gems\NvCloth\Assets\`.
 
 * A public C++ API that allows other systems and Gems to access cloth simulation functionality.
 

--- a/content/docs/user-guide/interactivity/physics/nvidia-physx/wind-provider.md
+++ b/content/docs/user-guide/interactivity/physics/nvidia-physx/wind-provider.md
@@ -40,7 +40,7 @@ If you choose to use the **Local wind tag**, the wind will only affect entities 
 
    ![PhysX Wind entity setup](/images/user-guide/physx/physx/ui-physx-wind-entity.png)
 
-1. To test the wind provider, add an entity with a **Cloth** mesh. There is an example slice asset you can drag into **Perspective** from **Asset Browser**. Navigate to `Gems\NvCloth\Assets\slices` in **Asset Browser**. Locate the `cloth_locked_corners_two.slice` and drag and drop the slice into **Perspective**.
+1. To test the wind provider, add an entity with a **Cloth** mesh. There is an example prefab asset you can drag into **Perspective** from **Asset Browser**. Navigate to `Gems\NvCloth\Assets\prefabs` in **Asset Browser**. Locate the `cloth_locked_corners_two.prefab` and drag and drop the prefab into **Perspective**.
 
 1. Use the **Move** tool to place the cloth entity. If you are using the **Local wind tag**, you must place the cloth asset inside the **PhysX Collider** volume.
 


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Replaced references to slices with prefabs in physx documentation.
This is a change for O3DE 2205 release so it's being merged into main branch.
Closes https://github.com/o3de/o3de/issues/6293

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

