### PR TITLE
Updated image-width shortcode to use named parameters.

### DIFF
--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -26,21 +26,21 @@ Image output:
 
 The `image-width` shortcode adds an image with alternate text and restricts the image's width. The `image-width` shortcode can ensure image sizes are consistent within a topic, and that large images don't scale overly large in wide browser windows. Use this method when adding `.svg` diagrams, very large images, and in topics with multiple images where consistent image widths are desirable.
 
-`image-width` takes three double-quoted parameters in order:
+`image-width` takes three double-quoted named parameters:
 
-1. image link
-1. width
-1. alternate text
+1. `src="/images/<image.png>"` - Image file path.
+1. `width="<200>"` - Scale the image by specifying a width in pixels.
+1. `alt="<image description>"` - A string describing the image.
 
 `image-width` example:
 
 ```markdown
-{{</* image-width "/images/welcome-guide/wg-welcome-page-color.png" "700" "The O3DE Welcome Guide splash image." */>}}
+{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width"700" alt="The O3DE Welcome Guide splash image." */>}}
 ```
 
 `image-width` example output:
 
-{{< image-width "/images/welcome-guide/wg-welcome-page-color.png" "700" "The O3DE Welcome Guide splash image." >}}
+{{< image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." >}}
 
 
 ## Alternate text

--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -35,7 +35,7 @@ The `image-width` shortcode adds an image with alternate text and restricts the 
 `image-width` example:
 
 ```markdown
-{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width"700" alt="The O3DE Welcome Guide splash image." */>}}
+{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." */>}}
 ```
 
 `image-width` example output:

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -1,7 +1,7 @@
 ---
 title: Docs smoke test page
 main_menu: false
-draft: false
+draft: true
 ---
 
 This page serves two purposes:

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -1,7 +1,7 @@
 ---
 title: Docs smoke test page
 main_menu: false
-draft: true
+draft: false
 ---
 
 This page serves two purposes:
@@ -452,21 +452,21 @@ You can add inline O3DE GUI icons with the `icon` shortcode. Icon `.svg` files a
 
 The `image-width` shortcode adds an image with alternate text and restricts the image's width. The `image-width` shortcode can ensure image sizes are consistent within a topic, and that large images and `.svg` diagrams don't scale overly large in wide browser windows.
 
-`image-width` takes three double-quoted parameters in order:
+`image-width` takes three double-quoted named parameters:
 
-1. image link
-1. width
-1. alt text
+1. `src="/images/<image.png>"` - Image file path.
+1. `width="<200>"` - Scale the image by specifying a width in pixels.
+1. `alt="<image description>"` - A string describing the image.
 
 `image-width` example:
 
 ```markdown
-{{</* image-width "/images/welcome-guide/ui-editor-labeled.png" "700" "An annotated image of O3DE editor's user interface." */>}}
+{{</* image-width src="/images/welcome-guide/ui-editor-labeled.png" width="700" alt="An annotated image of O3DE editor's user interface." */>}}
 ```
 
 `image-width` example output:
 
-{{< image-width "/images/welcome-guide/ui-editor-labeled.png" "700" "An annotated image of O3DE editor's user interface." >}}
+{{< image-width src="/images/welcome-guide/ui-editor-labeled.png" width="700" alt="An annotated image of O3DE editor's user interface." >}}
 
 
 ## Embedding Youtube videos with the `youtube-width` shortcode

--- a/layouts/shortcodes/image-width.html
+++ b/layouts/shortcodes/image-width.html
@@ -1,5 +1,12 @@
-<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely. When clicked, the full size image opens in a new tab.
+<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely.
+    When clicked, the full size image opens in a new tab.
+    
+    Use named parameters src, width, and alt. Ordered parameters are for backward compatibility.
 -->
-<a href={{ .Get 0 }} target="_blank"><img src={{ .Get 0 }} width={{ .Get 1 }} alt={{ .Get 2 }}></a>
+<a href={{ if .Get "src" }}{{ .Get "src" }}{{ else }}{{ .Get 0 }}{{ end }} target="_blank"><img 
+    {{ if .Get "src" }}src={{ .Get "src" }}{{ else }}src={{ .Get 0 }}{{ end }}
+    {{ if .Get "width" }}width={{ .Get "width" }}{{ else }}width={{ .Get 1 }}{{ end }}
+    {{ if .Get "alt" }}alt={{ .Get "alt" }}{{ else }}alt={{ .Get 2 }}{{ end }}></a>
+</a>
 <br>
 <br>


### PR DESCRIPTION
 Ordered parameters are still supported for backwards compatibility.

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

