### PR TITLE
Update placeholder and todo shortcodes with GHI links

### DIFF
--- a/content/docs/atom-guide/atom-sample-viewer/graphics-feature-samples.md
+++ b/content/docs/atom-guide/atom-sample-viewer/graphics-feature-samples.md
@@ -6,7 +6,6 @@ toc: true
 
 This section dives into the graphic feature samples demonstrated in the Atom Sample Viewer. 
 
-{{< placeholder >}}
 {{< todo issue="https://github.com/o3de/o3de.org/issues/687" >}}
 {{< /todo >}}
 

--- a/content/docs/atom-guide/atom-sample-viewer/rhi-samples.md
+++ b/content/docs/atom-guide/atom-sample-viewer/rhi-samples.md
@@ -6,7 +6,6 @@ toc: true
 
 This section dives into the RHI samples demonstrated in the Atom Sample Viewer. 
 
-{{< placeholder >}}
 {{< todo issue="https://github.com/o3de/o3de.org/issues/687" >}}
 {{< /todo >}}
 

--- a/content/docs/atom-guide/atom-sample-viewer/rpi-samples.md
+++ b/content/docs/atom-guide/atom-sample-viewer/rpi-samples.md
@@ -6,7 +6,6 @@ toc: true
 
 This section dives into the RPI samples demonstrated in the Atom Sample Viewer.   
 
-{{< placeholder >}}
 {{< todo issue="https://github.com/o3de/o3de.org/issues/687" >}}
 {{< /todo >}}
 

--- a/content/docs/atom-guide/dev-guide/materials/material-build-pipeline.md
+++ b/content/docs/atom-guide/dev-guide/materials/material-build-pipeline.md
@@ -3,4 +3,5 @@ title: Material Build Pipeline
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1556" >}}
+{{< /todo >}}

--- a/content/docs/atom-guide/dev-guide/materials/material-system-data-flow.md
+++ b/content/docs/atom-guide/dev-guide/materials/material-system-data-flow.md
@@ -3,4 +3,5 @@ title: Material System Data Flow
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1557" >}}
+{{< /todo >}}

--- a/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
+++ b/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
@@ -108,6 +108,5 @@ Ptr<Pass> myPass4 = PassSystemInterface::Get()->CreatePassFromRequest(&myPassReq
 ```
 
 #### Customized Pass Instantiation
-{{< todo >}}
-
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1547">}}
 {{< /todo >}}

--- a/content/docs/atom-guide/dev-guide/rpi/creating-a-feature-processor.md
+++ b/content/docs/atom-guide/dev-guide/rpi/creating-a-feature-processor.md
@@ -6,4 +6,5 @@ weight: 500
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1558" >}}
+{{< /todo >}}

--- a/content/docs/atom-guide/dev-guide/shaders/runtime-api.md
+++ b/content/docs/atom-guide/dev-guide/shaders/runtime-api.md
@@ -7,4 +7,5 @@ weight: 300
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1559" >}}
+{{< /todo >}}

--- a/content/docs/atom-guide/look-dev/color-management/index.md
+++ b/content/docs/atom-guide/look-dev/color-management/index.md
@@ -4,7 +4,7 @@ title: "Color Management"
 description: "Learn about the color space conversion workflow used in the Atom Renderer."
 toc: true
 weight: 500
----  
+---
 
-{{< placeholder >}}
-
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1560" >}}
+{{< /todo >}}

--- a/content/docs/atom-guide/look-dev/materials/material-type-file-spec.md
+++ b/content/docs/atom-guide/look-dev/materials/material-type-file-spec.md
@@ -58,13 +58,13 @@ An array of material functors. Each one reads material property values, performs
 
 * **args**: An object containing key/value pairs of all the arguments to send to this functor. The attributes vary depending on functor type. For 'Lua' functors, there is a single 'file' argument that references the Lua file. 
 
-{{< todo >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1549" >}}
 Need a list of available functor types and their expected arguments. 
 {{< /todo >}}
 
 ### **uvNameMap** *(optional)*
 This array lists default identifiers for mesh UV streams. 
 
-{{< todo >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1548" >}}
 Need a document about UV streams. 
 {{< /todo >}}

--- a/content/docs/atom-guide/look-dev/textures/_index.md
+++ b/content/docs/atom-guide/look-dev/textures/_index.md
@@ -5,5 +5,5 @@ toc: true
 weight: 300
 ---  
 
-{{< placeholder >}}
-
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1563" >}}
+{{< /todo >}}

--- a/content/docs/learning-guide/cookbooks/_index.md
+++ b/content/docs/learning-guide/cookbooks/_index.md
@@ -6,6 +6,7 @@ weight: 100
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1564" >}}
+{{< /todo >}}
 
 Discover practical, tested solutions for common scenarios in **Open 3D Engine (O3DE)**.

--- a/content/docs/user-guide/gems/reference/aws/aws-client-auth/scripting.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-client-auth/scripting.md
@@ -39,16 +39,12 @@ Note the variables created for providers, tokens, and credentials.
 
 ![Scripting password sign in with the Amazon Cognito user pool](/images/user-guide/gems/reference/aws/aws-client-auth/scripting-password-sign-in.png)
 
-{{< todo >}}
-Break this image into smaller pieces and describe each one.
-{{< /todo >}}
-
 ### Login with Amazon device sign-in flow
 
 ![Scripting LWA device sign in](/images/user-guide/gems/reference/aws/aws-client-auth/scripting-lwa-device-sign-in.png)
 
-{{< todo >}}
-Break this image into smaller pieces and describe each one.
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1550" >}}
+Break these images into smaller pieces and describe each one.
 {{< /todo >}}
 
 ## Lua

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/multiplayer-sample.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/multiplayer-sample.md
@@ -7,5 +7,5 @@ weight: 1000
 draft: true
 ---
 
-{{< placeholder >}}
-
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1561" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/gems/reference/aws/aws-metrics/scripting.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-metrics/scripting.md
@@ -16,7 +16,7 @@ The following image shows how to submit a metrics event and listen to the succes
 
 ![Script Canvas graph example of submitting a metrics event](/images/user-guide/gems/reference/aws/aws-metrics/scripting-submitting-metrics-event.png)
 
-{{< todo >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1551" >}}
 Break this image into smaller pieces and describe each one.
 {{< /todo >}}
 

--- a/content/docs/user-guide/interactivity/entities/_index.md
+++ b/content/docs/user-guide/interactivity/entities/_index.md
@@ -3,4 +3,5 @@ title: Entities
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1562" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/interactivity/navigation-and-pathfinding/_index.md
+++ b/content/docs/user-guide/interactivity/navigation-and-pathfinding/_index.md
@@ -3,4 +3,5 @@ title: Navigation and Pathfinding
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1555" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/interactivity/prefabs/_index.md
+++ b/content/docs/user-guide/interactivity/prefabs/_index.md
@@ -2,4 +2,5 @@
 title: Prefabs
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/962" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/programming/cvars.md
+++ b/content/docs/user-guide/programming/cvars.md
@@ -4,4 +4,5 @@ description: ' Use the console variable (CVAR) tutorial to modify and create con
 title: Console Variable Tutorial
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1554" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/project-config/project-source-control.md
+++ b/content/docs/user-guide/project-config/project-source-control.md
@@ -4,4 +4,5 @@ weight: 500
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1553" >}}
+{{< /todo >}}

--- a/content/docs/user-guide/visualization/animation/character-editor/_index.md
+++ b/content/docs/user-guide/visualization/animation/character-editor/_index.md
@@ -3,4 +3,5 @@ title: Character editor
 date: 2021-03-04
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/153" >}}
+{{< /todo >}}

--- a/content/docs/welcome-guide/setup/updating.md
+++ b/content/docs/welcome-guide/setup/updating.md
@@ -5,4 +5,5 @@ weight: 500
 draft: true
 ---
 
-{{< placeholder >}}
+{{< todo issue="https://github.com/o3de/o3de.org/issues/1552" >}}
+{{< /todo >}}


### PR DESCRIPTION
## Change summary

- Removed placeholders where there was also a todo.
- Linked a few placeholders and todos to existing GHI (converting placeholders to todos).
- Created new GHI and linked the remaining placeholders.  Most are in the drafted state.

~30 drafted pages did not have a placeholder shortcode, but they could receive the same treatment.

