### PR TITLE
Added description of the different EBus threading configuration options.

### DIFF
--- a/content/docs/user-guide/programming/ebus/design.md
+++ b/content/docs/user-guide/programming/ebus/design.md
@@ -44,7 +44,7 @@ static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single
 static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 ```
 
-### Many Handlers 
+### Many Handlers
 
 Another common configuration is one in which many handlers can be present. You can use this configuration to implement observer patterns, subscriptions to system events, or general-purpose broadcasting.
 
@@ -90,7 +90,7 @@ A common use for this approach is for communication among the components of a si
 
 ![Addressing based on specific IDs](/images/user-guide/programming/ebus/ebus-in-depth-3.png)
 
-#### Example Without Address Ordering 
+#### Example Without Address Ordering
 
 In the following example, messages broadcast with an ID arrive at each address in no particular order.
 
@@ -144,7 +144,7 @@ static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
 using BusIdType = AZ::EntityId;
 ```
 
-#### Example: With Address Ordering 
+#### Example: With Address Ordering
 
 In the following example, messages broadcast with an ID arrive at each address in a specified order. At each address, the order in which handlers receive the message is defined by the `EBusHandlerPolicy`, which in this example is `ByIdAndOrdered`.
 
@@ -163,23 +163,31 @@ using BusIdOrderCompare = AZStd::greater<BusIdType>;
 ```
 
 ## Multithreaded Dispatches
+
 EBuses can be configured for use in a multithreaded environment. Locking strategies are available for many common use cases.
 
 ### Single-Threaded
+
 By default, an EBus is configured for single-threaded usage. Attempts to use it from multiple threads will result in asserts. This configuration is defined by setting the `MutexType` to `NullMutex`.
+
 ```cpp
 // This EBus only supports single-threaded usage.
 using MutexType = NullMutex;
 ```
+
 ### Multi-Threaded With Blocking Dispatches
+
 To configure the EBus to allow for bus connects, disconnects, and event dispatches from multiple threads, set the MutexType to either `AZStd::mutex` or `AZStd::recursive_mutex`. Each operation on the EBus will lock the mutex to protect from multiple threads executing simultaneously. This configuration ensures that a bus handler cannot disconnect while it is in the middle of handling an event on a different thread. For simple multithreading cases, `AZStd::mutex` can be used. However, if the bus handler sends new events or connects / disconnects to a bus while handling an event on the same bus, `AZStd::recursive_mutex` should be chosen to ensure a single thread can't deadlock itself.
+
 ```cpp
 // This EBus supports multi-threaded usage, though only one thread will execute at a time.
 using MutexType = AZStd::recursive_mutex;
 ```
 
 ### Shared Locks
+
 Inherit from `EBusSharedDispatchTraits` to configure the EBus so that it exclusively locks during bus connects and disconnects but uses a shared lock for event dispatches. Shared locks enable multiple concurrent event dispatches while still ensuring that bus connects / disconnects cannot occur during an event dispatch. This configuration is useful for an EBus that services requests from many threads and also has handlers that frequently connect and disconnect during the application lifetime. `EBusSharedDispatchTraits` sets the MutexType and the related LockGuard types to custom policies that enable concurrent event dispatches and ensure connects / disconnects only occur when no event dispatches are in progress.
+
 ```cpp
 // This EBus supports concurrent multi-threaded event dispatches and protects
 // from connects / disconnects occuring during event dispatches.
@@ -190,7 +198,9 @@ class MyBus : public AZ::EBusSharedDispatchTraits<MyBus>
 ```
 
 ### Lockless Dispatches
+
 To configure the EBus so that it only locks during bus connects and disconnects, but not during event dispatches, set `LocklessDispatch` to true. The MutexType still needs to be set as well to configure the EBus as a multithreaded EBus and to guard against concurrent connects / disconnects. This is useful for an EBus that has handlers that only connect at startup and disconnect at shutdown, and never have handlers change connections status while the bus is in use. Lockless dispatches allow multiple events to execute concurrently with the least amount of event dispatch overhead.
+
 ```cpp
 // Locking primitive to use for connects and disconnects.
 using MutexType = AZStd::recursive_mutex;
@@ -225,5 +235,6 @@ Asynchronous messages have the following advantages:
 ## Additional Features
 
 EBuses contain other features that address various patterns and use cases:
+
 * **Cache a pointer to which messages can be dispatched** - This is handy for EBuses that have IDs. Instead of looking up the EBus address by ID for each event, you can use the cached pointer for faster dispatching.
 * **Queue any callable function on an EBus** - When you use queued messaging, you can queue a Lambda function or bound function against an EBus for execution on another thread. This is useful for general purpose thread-safe queuing.


### PR DESCRIPTION
Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

EBusSharedDispatchTraits was recently added to o3de, which provides a new method of multi-threaded dispatches. This change adds documentation for the new traits and also covers the previously-existing alternative EBus configurations, since they would also benefit from having documentation on how and when to use them.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

