### PR TITLE
Updated image-width shortcode to use named parameters.

### DIFF
--- a/content/docs/contributing/to-docs/style-guide/media.md
+++ b/content/docs/contributing/to-docs/style-guide/media.md
@@ -26,21 +26,21 @@ Image output:
 
 The `image-width` shortcode adds an image with alternate text and restricts the image's width. The `image-width` shortcode can ensure image sizes are consistent within a topic, and that large images don't scale overly large in wide browser windows. Use this method when adding `.svg` diagrams, very large images, and in topics with multiple images where consistent image widths are desirable.
 
-`image-width` takes three double-quoted parameters in order:
+`image-width` takes three double-quoted named parameters:
 
-1. image link
-1. width
-1. alternate text
+1. `src="/images/<image.png>"` - Image file path.
+1. `width="<image width>"` - Scale the image by specifying a width in pixels.
+1. `alt="<image description>"` - A string describing the image.
 
 `image-width` example:
 
 ```markdown
-{{</* image-width "/images/welcome-guide/wg-welcome-page-color.png" "700" "The O3DE Welcome Guide splash image." */>}}
+{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." */>}}
 ```
 
 `image-width` example output:
 
-{{< image-width "/images/welcome-guide/wg-welcome-page-color.png" "700" "The O3DE Welcome Guide splash image." >}}
+{{< image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." >}}
 
 
 ## Alternate text
@@ -78,6 +78,7 @@ Screenshots are images of various O3DE user interfaces, or the interfaces of oth
 
 * Use the PNG format (`.png`) for all screenshots.
 * Take interface screenshots at HD resolution (1920x1080).
+* Ensure the image resolution has an even number of pixels in both width and height.
 * Don't use aggressive compression for interface screenshots. Heavily compressed files may make text and UI elements less legible.
 * Screenshots should not exceed 512 KB in size.
 * Use the default interface scale for screenshots.
@@ -145,6 +146,7 @@ Keep the following in mind when submitting videos in docs contributions:
 * Videos should be smaller than 512 KB and must not exceed 1 MB in size.
 * Ensure text in the video is legible if required.
 * Ensure the video resolution is no larger than necessary.
+* Ensure the video resolution has an even number of pixels in both width and height.
 * Crop and frame the subject of the video appropriately.
 * Videos shouldn't include audio unless required by the example.
 * Though a poster image is not required, it is recommended.

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -228,21 +228,21 @@ image.
 
 The `image-width` shortcode adds an image with alternate text and restricts the image's width. The `image-width` shortcode can ensure image sizes are consistent within a topic, and that large images and `.svg` diagrams don't scale overly large in wide browser windows.
 
-`image-width` takes three double-quoted parameters in order:
+`image-width` takes three double-quoted named parameters:
 
-1. image link
-1. width
-1. alt text
+1. `src="/images/<image.png>"` - Image file path.
+1. `width="<image width>"` - Scale the image by specifying a width in pixels.
+1. `alt="<image description>"` - A string describing the image.
 
 `image-width` example:
 
 ```markdown
-{{</* image-width "/images/welcome-guide/ui-editor-labeled.png" "700" "An annotated image of O3DE editor's user interface." */>}}
+{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." */>}}
 ```
 
 `image-width` example output:
 
-{{< image-width "/images/welcome-guide/ui-editor-labeled.png" "700" "An annotated image of O3DE editor's user interface." >}}
+{{< image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." >}}
 
 An image can also be a link. This time the O3DE icon links to the O3DE website. Outer square brackets enclose
 the entire image tag, and the link target is in the parentheses at the end.

--- a/layouts/shortcodes/image-width.html
+++ b/layouts/shortcodes/image-width.html
@@ -1,5 +1,12 @@
-<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely. When clicked, the full size image opens in a new tab.
+<!-- This shortcode adds an image with a maximum width specified in pixels and an alt text caption. Particularly useful for .svgs that can scale infinitely.
+    When clicked, the full size image opens in a new tab.
+    
+    Use named parameters src, width, and alt. Ordered parameters are for backward compatibility.
 -->
-<a href={{ .Get 0 }} target="_blank"><img src={{ .Get 0 }} width={{ .Get 1 }} alt={{ .Get 2 }}></a>
+<a href={{ if .Get "src" }}{{ .Get "src" }}{{ else }}{{ .Get 0 }}{{ end }} target="_blank"><img 
+    {{ if .Get "src" }}src={{ .Get "src" }}{{ else }}src={{ .Get 0 }}{{ end }}
+    {{ if .Get "width" }}width={{ .Get "width" }}{{ else }}width={{ .Get 1 }}{{ end }}
+    {{ if .Get "alt" }}alt={{ .Get "alt" }}{{ else }}alt={{ .Get 2 }}{{ end }}></a>
+</a>
 <br>
 <br>


### PR DESCRIPTION
 Ordered parameters are still supported for backwards compatibility with prior documentation.

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>