### PR TITLE
Fix broken link: user-guide/_index

### DIFF
--- a/content/docs/user-guide/_index.md
+++ b/content/docs/user-guide/_index.md
@@ -35,7 +35,7 @@ Read about [the features provided by Open 3D Engine](/docs/welcome-guide/feature
 | Documentation                        | Details |
 |--------------------------------------|---------|
 | [Glossary](appendix/glossary) | Common terms and concepts used in O3DE development. |
-| [Asset file types](appendix/asset-file-types/) | Reference for the asset file types supported in O3DE by default. |
+| [Asset file types](assets/asset-types/) | Reference for the asset file types supported in O3DE by default. |
 | [Console variable reference](appendix/cvars/) | Reference for the O3DE console variables (CVARs). |
 | [Log files](appendix/log-files) | Learn where to find common log files in O3DE. |
 


### PR DESCRIPTION
## Change summary

Link in the appendix points to https://www.o3de.org/docs/user-guide/assets/asset-types/.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

