### PR TITLE
Updated instructions to setup Hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ You can download this repository or clone it onto your local machine. Cloning th
    
     *Note: You must install the **extended version** of Hugo.*
 
-2. To install **npm**, follow the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation.
+2. To install **npm**, follow the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation. Installing npm also installs **Node.js**.
 
 3. To install dependencies, run the following command from the `o3de.org` repository:
 
     ```shell
-    cd <path-to-repo>\o3de.org
+    cd <path-to-repo>/o3de.org
     npm install
     ```
 
@@ -40,7 +40,7 @@ You can download this repository or clone it onto your local machine. Cloning th
 1. Open a terminal or shell and navigate to the `o3de.org` repository.
    
     ```shell
-    cd <path-to-repo>\o3de.org
+    cd <path-to-repo>/o3de.org
     ```
    
 2. Run the command `hugo serve`. 
@@ -92,7 +92,7 @@ For a complete list of required dependencies, see `package.json`.
 
 ### Steps to fix
 
-1. Open a shell or terminal and navigate to `o3de.org` repository: `cd <path-to-o3de.org>`
+1. Open a shell or terminal and navigate to `o3de.org` repository: `cd <path-to-repo>/o3de.org`
 
 2. Verify that the required dependencies have been installed by running the command, `npm list`. This outputs the list of dependencies and indicates whether or not they've been installed.
 

--- a/README.md
+++ b/README.md
@@ -21,51 +21,80 @@ You can download this repository or clone it onto your local machine. Cloning th
   1. Open a terminal or shell in the directory where you want this repository to be in. 
   2. Run the command `git clone https://github.com/o3de/o3de.org.git`.
 
-### Setup Hugo, npm, and bootstrap
+### Setup Hugo, npm, and dependencies
 1. To install **Hugo (extended version)**, follow the instructions for your machine in the [Hugo documentation](https://gohugo.io/getting-started/installing). 
    
     *Note: You must install the **extended version** of Hugo.*
 
-1. To install **npm**, following the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation. Installing npm also installs **nodejs**. 
+2. To install **npm**, follow the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation.
 
-2. To install **bootstrap**, run the following command in a terminal or shell in the root of your o3de.org clone: `npm install bootstrap`.
+3. To install dependencies, run the following command from the `o3de.org` repository:
 
-    *Note: `npm` is only one way to install bootstrap. You can use other package managers to install bootstrap, such as [yarn](https://yarnpkg.com/package/bootstrap).*
+    ```shell
+    cd <path-to-repo>\o3de.org
+    npm install
+    ```
+
 
 ### Build the site
 1. Open a terminal or shell and navigate to the `o3de.org` repository.
    
-```shell
-$ cd <path-to-repo>\o3de.org
-```
+    ```shell
+    cd <path-to-repo>\o3de.org
+    ```
    
 2. Run the command `hugo serve`. 
-   
-```shell
-$ hugo serve
-Start building sites …
+      
+    ```shell
+    $ hugo serve
+    Start building sites …
 
-                   |  EN
--------------------+--------
-  Pages            |   902
-  Paginator pages  |     0
-  Non-page files   |     0
-  Static files     | 17173
-  Processed images |     0
-  Aliases          |     0
-  Sitemaps         |     1
-  Cleaned          |     0
+                      |  EN
+    -------------------+--------
+      Pages            |   902
+      Paginator pages  |     0
+      Non-page files   |     0
+      Static files     | 17173
+      Processed images |     0
+      Aliases          |     0
+      Sitemaps         |     1
+      Cleaned          |     0
 
-Built in 10394 ms
-Watching for changes in C:\O3DE\o3de.org\{assets,content,layouts,package.json,static}
-Watching for config changes in C:\O3DE\o3de.org\config.toml
-Environment: "development"
-Serving pages from memory
-Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
-Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
-Press Ctrl+C to stop
-```
+    Built in 10394 ms
+    Watching for changes in C:\O3DE\o3de.org\{assets,content,layouts,package.json,static}
+    Watching for config changes in C:\O3DE\o3de.org\config.toml
+    Environment: "development"
+    Serving pages from memory
+    Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
+    Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
+    Press Ctrl+C to stop
+    ```
 
 3. To view a local build of the O3DE website, open a web browser and go to http://localhost:1313/.
 
 You can now view the O3DE website on your local machine! Find the O3DE documentation under the **Learn** section of the O3DE website.
+
+## Troubleshooting
+
+### Issue
+
+Running `hugo serve` outputs the following error:
+
+```cmd
+Error: Error building site: TOCSS: failed to transform "blah.sass" (text/x-sass): SCSS processing failed: file "stdin", line 26, col 1: File to import not found or unreadable: bootstrap/scss/functions.
+```
+
+### Description
+
+This indicates that your local `o3de.org` repository may be missing bootstrap, or that the wrong version is installed. Similar errors may indicate that other dependent packages are missing.
+
+For a complete list of required dependencies, see `package.json`.
+
+### Steps to fix
+
+1. Open a shell or terminal and navigate to `o3de.org` repository: `cd <path-to-o3de.org>`
+
+2. Verify that the required dependencies have been installed by running the command, `npm list`. This outputs the list of dependencies and indicates whether or not they've been installed.
+
+3. Install missing dependencies. You can install all of the dependencies by running the command, `npm install`. Or, you can install a specific dependency. For example: `npm install bootstrap@4.6.1`
+

--- a/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
+++ b/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
@@ -146,14 +146,13 @@ Hugo is the static site builder that O3DE documentation uses. When you have Hugo
 
 1. Get the **extended** Hugo binary. For Hugo installation, refer to [Install Hugo](https://gohugo.io/getting-started/installing/). The extended binary is required for some of the features that the O3DE documentation site uses.
 
-2. You need to add the Node.js bootstrap package. Bootstrap contains some modules that are used to style the O3DE documentation site. Get Node.js here [Download Node.js](https://nodejs.org/en/download/) and run the installer.
+1. To install **npm**, follow the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation. Installing npm also installs **Node.js**.
 
-3. In the terminal `cd` to the root of your o3de.org clone.
-
-4. Use `npm` to install bootstrap with the command below:
+1. To install dependencies, run the following command from the `o3de.org` repository:
 
     ```shell
-    npm install bootstrap
+    cd <path-to-repo>/o3de.org
+    npm install
     ```
 
 ### Run a Hugo server
@@ -175,12 +174,11 @@ Now you can test your setup by running a local Hugo server and viewing the O3DE 
     ```
 
     {{< note >}}
-    If you use the **macOS** platform for docs development, you must run Hugo with the `--watch=false` switch enabled. For example:
+If you use the **macOS** platform for docs development, you must run Hugo with the `--watch=false` switch enabled. For example:
 
-    ```bash
-    hugo server --port 44541 --bind=0.0.0.0 --watch=false
-    ```
-
+```bash
+hugo server --port 44541 --bind=0.0.0.0 --watch=false
+```
     {{< /note >}}
 
 ## Create a branch
@@ -204,7 +202,7 @@ As a general rule follow, the steps in [Sync your clone](#sync-your-clone) befor
     ```
 
     {{< note >}}
-    When naming branches, we recommend a short dash separated name that clearly denotes the contents of the branch. For example, `camera-follow-tutorial`.
+When naming branches, we recommend a short dash separated name that clearly denotes the contents of the branch. For example, `camera-follow-tutorial`.
     {{< /note >}}
 
 1. Switch to your new branch.

--- a/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
+++ b/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
@@ -163,11 +163,32 @@ Now you can test your setup by running a local Hugo server and viewing the O3DE 
 
 1. Start the server.
 
-    ```shell
-    hugo server
+    ```cmd
+    $ hugo serve
+    Start building sites …
+
+                    |  EN
+    -------------------+--------
+    Pages            |   902
+    Paginator pages  |     0
+    Non-page files   |     0
+    Static files     | 17173
+    Processed images |     0
+    Aliases          |     0
+    Sitemaps         |     1
+    Cleaned          |     0
+
+    Built in 10394 ms
+    Watching for changes in C:\O3DE\o3de.org\{assets,content,layouts,package.json,static}
+    Watching for config changes in C:\O3DE\o3de.org\config.toml
+    Environment: "development"
+    Serving pages from memory
+    Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
+    Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
+    Press Ctrl+C to stop
     ```
 
-1. The above command starts a server on `localhost` using an available port (usually `1333`). The command prints the address and port in the console. You can view your server in a web browser. The server will continue to run as long as the terminal that is running the server remains open. If you need to view the site over a network connection, you can use the command below to specify a server and port.
+1. The above command starts a server on `localhost` using an available port (usually `1313`). The command prints the address and port in the console. You can view your server in a web browser. The server will continue to run as long as the terminal that is running the server remains open. If you need to view the site over a network connection, you can use the command below to specify a server and port.
 
     ```shell
     hugo server --port 44541 --bind=0.0.0.0

--- a/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
+++ b/content/docs/contributing/to-docs/o3de-docs-repo-setup.md
@@ -164,7 +164,7 @@ Now you can test your setup by running a local Hugo server and viewing the O3DE 
 1. Start the server.
 
     ```cmd
-    $ hugo serve
+    $ hugo server
     Start building sites …
 
                     |  EN


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->
Previously, the instructions told users to run `npm install bootstrap`, which would install the latest version. But we found that o3de.org doesn't support bootstrap version 5, the latest version. 
I updated the instructions to simply run `npm install`, which will install the dependencies listed in `package.json`.

## Change summary

- Updated instructions
- Added troubleshooting in README.md for a common problem when setting up Hugo.
- Fixed style problems

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

