### PR TITLE
Removing redundant whitespaces from the ScriptEvents_Broadcast.lua script on the Using Script Events in Lua documentation page

### DIFF
--- a/content/docs/user-guide/scripting/script-events/using-in-lua.md
+++ b/content/docs/user-guide/scripting/script-events/using-in-lua.md
@@ -91,7 +91,7 @@ The `ScriptEvents_Broadcast.lua` example script implements a handler for a broad
 
 ```lua
 -- ScriptEvents_Broadcast.lua
-            function ScriptTrace(txt)
+function ScriptTrace(txt)
     Debug.Log(txt)
 end
 


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Removed redundant whitespaces in the ScriptEvents_Broadcast.lua Example script on the https://www.o3de.org/docs/user-guide/scripting/script-events/using-in-lua/ documentation page.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?