### PR TITLE
Update smoketest image-width example

### DIFF
--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -237,12 +237,12 @@ The `image-width` shortcode adds an image with alternate text and restricts the 
 `image-width` example:
 
 ```markdown
-{{</* image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." */>}}
+{{</* image-width src="/images/welcome-guide/guide_img.png" width="700" alt="The O3DE Welcome Guide splash image." */>}}
 ```
 
 `image-width` example output:
 
-{{< image-width src="/images/welcome-guide/wg-welcome-page-color.png" width="700" alt="The O3DE Welcome Guide splash image." >}}
+{{< image-width src="/images/welcome-guide/guide_img.png" width="700" alt="The O3DE Welcome Guide splash image." >}}
 
 An image can also be a link. This time the O3DE icon links to the O3DE website. Outer square brackets enclose
 the entire image tag, and the link target is in the parentheses at the end.


### PR DESCRIPTION
## Change summary

Updated the image used in the image-width example.  The previous image was deleted.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

