### PR TITLE
Fixed letter capitalization on PhysX Gem documentation page

### DIFF
--- a/content/docs/user-guide/gems/reference/physics/nvidia/physx.md
+++ b/content/docs/user-guide/gems/reference/physics/nvidia/physx.md
@@ -5,6 +5,6 @@ description: The PhysX Gem provides physics simulation with NVIDIA PhysX includi
 toc: true
 ---
 
-OPen 3D Engine's (O3DE) PhysX system acts upon entities to create realistic physical effects such as collision detection and rigid body dynamics simulation. Enable the PhysX gem to use the PhysX system for your game project.
+Open 3D Engine's (O3DE) PhysX system acts upon entities to create realistic physical effects such as collision detection and rigid body dynamics simulation. Enable the PhysX gem to use the PhysX system for your game project.
 
 For more information, see [Simulating physics behavior with the PhysX system](/docs/user-guide/interactivity/physics/nvidia-physx/).


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Fixed letter capitalization on the PhysX Gem (https://www.o3de.org/docs/user-guide/gems/reference/physics/nvidia/physx/) documentation page.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?