### PR TITLE
Clarify O3DE CLI examples

### DIFF
--- a/content/docs/user-guide/programming/components/create-component.md
+++ b/content/docs/user-guide/programming/components/create-component.md
@@ -28,8 +28,12 @@ Use the `o3de` CLI script in the O3DE `scripts` directory to create a common run
 Format:
 
 ```cmd
-scripts\o3de.bat create-from-template -dp <destination-dir> -dn <component-name> -tn DefaultComponent -r ${GemName} <gem-name>
+scripts\o3de.bat create-from-template -dp <destination-dir> -dn <component-name> -tn DefaultComponent -kr -r ${GemName} <gem-name>
 ```
+
+{{< tip >}}
+If you would like to keep the default license, include the `-kl` parameter.
+{{< /tip >}}
 
 The template appends the word "Component" to the component name you provide.
 
@@ -38,7 +42,7 @@ Supply the component's namespace as the replacement value for the `${GemName}` p
 For example, to create a component called `MyTestComponent` in the `MyGem` namespace, do the following:
 
 ```cmd
-scripts\o3de.bat create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -r ${GemName} MyGem
+scripts\o3de.bat create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem
 ```
 
 {{< note >}}
@@ -50,7 +54,7 @@ To create the component in an existing directory, such as the `Code` directory o
 For example, to create a component called `MyTestComponent` in the `MyGem` namespace in the Gem's `Code` directory, do the following:
 
 ```cmd
-scripts\o3de.bat create-from-template -dp C:\Gems\MyGem\Code -dn MyTest -tn DefaultComponent -r ${GemName} MyGem -f
+scripts\o3de.bat create-from-template -dp C:\Gems\MyGem\Code -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem -f
 ```
 
     {{% /tab %}}
@@ -59,8 +63,12 @@ scripts\o3de.bat create-from-template -dp C:\Gems\MyGem\Code -dn MyTest -tn Defa
 Format:
 
 ```bash
-scripts/o3de.sh create-from-template -dp <destination-dir> -dn <component-name> -tn DefaultComponent -r ${GemName} <gem-name>
+scripts/o3de.sh create-from-template -dp <destination-dir> -dn <component-name> -tn DefaultComponent -kr -r ${GemName} <gem-name>
 ```
+
+{{< tip >}}
+If you would like to keep the default license, include the `-kl` parameter.
+{{< /tip >}}
 
 The template appends the word "Component" to the component name you provide.
 
@@ -69,7 +77,7 @@ Supply the component's namespace as the replacement value for the `${GemName}` p
 For example, to create a component called `MyTestComponent` in the `MyGem` namespace, do the following:
 
 ```bash
-scripts/o3de.sh create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -r ${GemName} MyGem
+scripts/o3de.sh create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem
 ```
 
 To create the component in an existing directory, such as the `Code` directory of a Gem that's in progress, add the `-f` option to the `create-from-template` command to force the creation of the component files there.
@@ -77,7 +85,7 @@ To create the component in an existing directory, such as the `Code` directory o
 For example, to create a component called `MyTestComponent` in the `MyGem` namespace in the Gem's `Code` directory, do the following:
 
 ```bash
-scripts/o3de.sh create-from-template -dp Gems/MyGem/Code -dn MyTest -tn DefaultComponent -r ${GemName} MyGem -f
+scripts/o3de.sh create-from-template -dp Gems/MyGem/Code -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem -f
 ```
 
     {{% /tab %}}

--- a/content/docs/user-guide/programming/components/create-component.md
+++ b/content/docs/user-guide/programming/components/create-component.md
@@ -41,6 +41,10 @@ For example, to create a component called `MyTestComponent` in the `MyGem` names
 scripts\o3de.bat create-from-template -dp MyCode -dn MyTest -tn DefaultComponent -r ${GemName} MyGem
 ```
 
+{{< note >}}
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `-r '${GemName}' MyGem`.
+{{< /note >}}
+
 To create the component in an existing directory, such as the `Code` directory of a Gem that's in progress, add the `-f` option to the `create-from-template` command to force the creation of the component files there.
 
 For example, to create a component called `MyTestComponent` in the `MyGem` namespace in the Gem's `Code` directory, do the following:

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -200,29 +200,56 @@ o3de.bat set-global-project -pp PROJECT_PATH -o <USER_DIRECTORY>\.o3de\Registry\
 
 ## `create-template`
 
-Creates a template out of the specified source path.
+Creates a template out of the specified source path and registers the template in the O3DE manifest. Users can then create custom source content from this template using the `create-from-template` command.
 
 ### Format
 
 ``` cmd
-create-template [-h] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
+create-template [-h] [-v] -sp SOURCE_PATH [-tp TEMPLATE_PATH]
                 [-srp SOURCE_RESTRICTED_PATH | -srn SOURCE_RESTRICTED_NAME]
                 [-trp TEMPLATE_RESTRICTED_PATH | -trn TEMPLATE_RESTRICTED_NAME]
                 [-sn SOURCE_NAME]
                 [-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH]
                 [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
-                [-kr] [-kl] [-r [REPLACE [REPLACE ...]]] [-f]
+                [-kr] [-kl] [-r [REPLACE [REPLACE ...]]]
+                [-f] [--no-register]
 ```
 
 ### Usage
 
-Creates a template from the source folder and saves the template in the specified path.
+Creates a template named `StandardGem` from the source folder and saves it in the `default_templates_folder` specified in the O3DE manifest. Also registers the template in the O3DE manifest.
 
 ```cmd
-o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
+o3de.bat create-template -sp C:\MyGems\StandardGem
 ```
 
-{{< todo issue="https://github.com/o3de/o3de.org/issues/806">}} Add more usage examples. {{< /todo >}}
+Creates a template named `StandardGem` from the source folder and saves it in `C:\MyTemplates`, without registering the template.
+
+```cmd
+o3de.bat create-template -sp C:\MyGems\StandardGem -tp C:\MyTemplates\StandardGem --no-register
+```
+
+Creates a template named `StandardGem` from the source folder and saves it in the default templates folder. Additionally, it replaces any part of a file or path in the source folder containing the word `Standard` with the placeholder name `${Name}`, and any appearance of the word `Standard` in the source file content with `${SanitizedCppName}`.
+
+```cmd
+o3de.bat create-template -sp C:\MyGems\TestGem -tp StandardGem -sn Standard
+```
+
+Creates a template named `StandardComponent` from the source folder and saves it in the default templates folder. Additionally, it does the following:
+
+* Replaces any part of a file or path in the source folder containing the word `Standard` with the placeholder name `${Name}`.
+* Replaces any appearance of the word `Standard` in the source file content with `${SanitizedCppName}`.
+* Replaces any appearance of the word `MyGem` with `${GemName}`. This particular example is useful when creating a template where the Gem name serves as a C++ namespace.
+* Replaces the UUID `cd2c4950-7ee3-49b9-b356-51a3b6bb2373` with `${Random_Uuid}`. When the `create-from-template` command encounters `${Random_Uuid}` in a template, it replaces this placeholder with a randomly-generated UUID.
+* Keeps all licensing text in the source files that begins with `{BEGIN_LICENSE}` and ends with `{END_LICENSE}`.
+
+```cmd
+o3de.bat create-template -sp C:\MyComponent -tp StandardComponent -sn Standard -kl -r MyGem ${GemName} cd2c4950-7ee3-49b9-b356-51a3b6bb2373 ${Random_Uuid}
+```
+
+{{< note >}}
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. For example: `-r MyGem '${GemName}'`.
+{{< /note >}}
 
 ### Optional parameters
   
@@ -230,13 +257,17 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
   Shows the help message.
 
+- **`-v`**
+
+  If specified, provides additional logging verbosity.
+
 - **`-sp SOURCE_PATH, --source-path SOURCE_PATH`**
 
   The path to the source folder that you want to use as a template.
 
 - **`-tp TEMPLATE_PATH, --template-path TEMPLATE_PATH`**
 
-  The path to an existing template that you want to create a new template from. The path can be absolute or relative to the default template's path.
+  The path where you want to create the template. The path can be absolute or relative to the `default_templates_folder` specified in the O3DE manifest. If not supplied, the template path is set to the default template path concatenated with `SOURCE_NAME`. If `SOURCE_NAME` is not specified, the last component of `SOURCE_PATH` is used in its place.
 
 - **`-srp SOURCE_RESTRICTED_PATH, --source-restricted-path SOURCE_RESTRICTED_PATH`**
 
@@ -256,7 +287,9 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-sn SOURCE_NAME, --source-name SOURCE_NAME`**
 
-  Substitutes any file and path entries that match the source name--`${Name}` and `${SanitizedCppName}`--in the source-path directory. An example of path substitution: `--source-name Foo<source-path>/Code/Include/FooBus.h` -> `<source-path>/Code/Include/${Name}Bus.h`. An example of file content substitution: `class FooRequests` -> `class ${SanitizedCppName}Requests`.
+  Substitutes any file and path entries that match `SOURCE_NAME` with `${Name}`, and any file content that matches `SOURCE_NAME` with `${SanitizedCppName}`.
+  
+  An example of substitution: `--source-name Foo` replaces the source file `FooBus.h` -> `${Name}Bus.h`, and the source content `class FooRequests` -> `class ${SanitizedCppName}Requests`.
 
 - **`-srprp SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH, --source-restricted-platform-relative-path SOURCE_RESTRICTED_PLATFORM_RELATIVE_PATH`**
 
@@ -268,23 +301,27 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-kr, --keep-restricted-in-template`**
 
-  If true, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If included, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the `template.json` file) in the new template's `template.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
+  If included, keeps all of the lines of license text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. If false, the license text isn't included.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A to B replacement pairs. For example: `--replace ${User} MyUsername ${id} 1723905`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: `${Name}` to \<TemplateName\>, `${NameLower}` to \<templatename\>, `${NameUpper}` to \<TEMPLATENAME\>.
+  Add A to B replacement pairs. For example: `-r MyUsername ${User} 1723905 ${id}`. This replaces `MyUsername` with `${User}`, and `1723905` with `${id}`.
 
   {{< note >}}
-When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `--replace '${User}' MyUsername`.
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. For example: `-r MyUsername '${User}'`.
   {{< /note >}}
 
 - **`-f, --force`**
 
-  Forces the new template directory to override the existing one, if one exists. 
+  Forces the new template directory to override the existing one, if one exists.
+
+- **`--no-register`**
+
+  Prevents registration of the template path in the O3DE manifest.
 
 
 <!-------------------------------------------------------------->
@@ -296,7 +333,7 @@ Creates an instance of a generic template based on the specified template.
 ### Format
 
 ```cmd
-create-from-template [-h] -dp DESTINATION_PATH
+create-from-template [-h] [-v] -dp DESTINATION_PATH
                                     (-tp TEMPLATE_PATH | -tn TEMPLATE_NAME)
                                     [-dn DESTINATION_NAME]
                                     [-drp DESTINATION_RESTRICTED_PATH | -drn DESTINATION_RESTRICTED_NAME]
@@ -304,15 +341,33 @@ create-from-template [-h] -dp DESTINATION_PATH
                                     [-drprp DESTINATION_RESTRICTED_PLATFORM_RELATIVE_PATH]
                                     [-trprp TEMPLATE_RESTRICTED_PLATFORM_RELATIVE_PATH]
                                     [-kr] [-kl] [-r [REPLACE [REPLACE ...]]]
-                                    [-f]
+                                    [-f] [--no-register]
 ```
 
 ### Usage
 
-Instantiates a template based on the specified template and saves it in the specified path.
+Instantiates an object based on the template that is located in the specified template path and saves it in the specified destination path.
 
 ```cmd
-o3de.bat create-from-template --destination-path DESTINATION_PATH --template-path TEMPLATE_PATH
+o3de.bat create-from-template -dp DESTINATION_PATH -tp TEMPLATE_PATH
+```
+
+Instantiates an object based on the template named `DefaultComponent` and saves it in the directory `NewComponent` in the current path. Additionally, it replaces all occurrences of `${GemName}` in the template with `MyGem`.
+
+```cmd
+o3de.bat create-from-template -dp NewComponent -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem
+```
+
+{{< note >}}
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `-r '${GemName}' MyGem`.
+{{< /note >}}
+
+To create the component in an existing directory, such as the `Code` directory of a Gem that's in progress, add the `-f` option to the `create-from-template` command to force the creation of the component files there.
+
+For example, to create a component called `MyTestComponent` in the `MyGem` namespace in the Gem's `Code` directory, do the following:
+
+```cmd
+scripts\o3de.bat create-from-template -dp C:\Gems\MyGem\Code -dn MyTest -tn DefaultComponent -kr -r ${GemName} MyGem -f
 ```
 
 ### Optional parameters
@@ -320,6 +375,10 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 - **`-h, --help`**
 
   Shows the help message.
+
+- **`-v`**
+
+  If specified, provides additional logging verbosity.
 
 - **`-dp DESTINATION_PATH, --destination-path DESTINATION_PATH`**
 
@@ -363,23 +422,27 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 - **`-kr, --keep-restricted-in-instance`**
 
-  If true, creates the restricted platforms in the new template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If specified, creates the restricted platforms in the new template folder. If not specified, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH.
 
 - **`-kl, --keep-license-text`**
 
-  If true, keeps the license text (located in the template's `template.json` file) in the new template's `template.json` file. If false, the license text isn't included. By default, this parameter is false. The license text is all of the lines of text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}.
+  If specified, keeps all license text found in the template files. If not specified, the license text isn't included. License text includes all of the lines of text starting on a line containing {BEGIN_LICENSE} and ending on the line containing {END_LICENSE}.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A to B replacement pairs. For example: `--replace ${User} MyUsername ${id} 1723905`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: `${Name}` to \<DestinationName\>, `${NameLower}` to \<destinationname\>, `${NameUpper}` to \<DESTINATIONNAME\>.
+  Add A to B replacement pairs. For example: `-r ${User} MyUsername ${id} 1723905`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: `${Name}` to \<DestinationName\>, `${NameLower}` to \<destinationname\>, `${NameUpper}` to \<DESTINATIONNAME\>.
 
   {{< note >}}
-When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `--replace '${User}' MyUsername`.
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. For example: `-r '${User}' MyUsername`.
   {{< /note >}}
 
 - **`-f, --force`**
 
-  Overwrites the instantiated template directory, even if it already exists.
+  Overwrites files in the destination directory if they already exist.
+
+- **`--no-register`**
+
+  Prevents registration of the project in the O3DE manifest.
 
 
 <!-------------------------------------------------------------->
@@ -1213,7 +1276,7 @@ o3de.bat register-show --repos
 
 - **`-v, --verbose`**
 
-  If verbose > 0, outputs the contents of the specified files.
+  If specified, outputs the contents of the listed files.
 
 - **`-pp PROJECT_PATH, --project-path PROJECT_PATH`**
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -301,11 +301,11 @@ When using the replace parameter in Windows PowerShell, you must use a single qu
 
 - **`-kr, --keep-restricted-in-template`**
 
-  If included, creates the restricted platforms in the template folder. If false, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH. By default, this parameter is false.
+  If included, creates the restricted platforms in the template folder. By default, creates the restricted files in the restricted folder located at TEMPLATE_RESTRICTED_PATH.
 
 - **`-kl, --keep-license-text`**
 
-  If included, keeps all of the lines of license text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. If false, the license text isn't included.
+  If included, keeps all of the lines of license text, starting at {BEGIN_LICENSE} and ending at {END_LICENSE}. By default, the license text isn't included.
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 

--- a/content/docs/user-guide/project-config/cli-reference.md
+++ b/content/docs/user-guide/project-config/cli-reference.md
@@ -276,10 +276,14 @@ o3de.bat create-template --source-path SOURCE_PATH --template-path TEMPLATE_PATH
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A to B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: `${Name}` to \<TemplateName\>, `${NameLower}` to \<templatename\>, `${NameUpper}` to \<TEMPLATENAME\>.
+  Add A to B replacement pairs. For example: `--replace ${User} MyUsername ${id} 1723905`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<TemplateName\> is the last component of the TEMPLATE_PATH. The following replacement pairs already exist: `${Name}` to \<TemplateName\>, `${NameLower}` to \<templatename\>, `${NameUpper}` to \<TEMPLATENAME\>.
+
+  {{< note >}}
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `--replace '${User}' MyUsername`.
+  {{< /note >}}
 
 - **`-f, --force`**
-         
+
   Forces the new template directory to override the existing one, if one exists. 
 
 
@@ -367,7 +371,11 @@ o3de.bat create-from-template --destination-path DESTINATION_PATH --template-pat
 
 - **`-r [REPLACE [REPLACE ...]], --replace [REPLACE [REPLACE ...]]`**
 
-  Add A to B replacement pairs. For example: `--replace MyUsername ${User} 1723905 ${id}`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: `${Name}` to \<DestinationName\>, `${NameLower}` to \<destinationname\>, `${NameUpper}` to \<DESTINATIONNAME\>.
+  Add A to B replacement pairs. For example: `--replace ${User} MyUsername ${id} 1723905`. This replaces `${User}` with `MyUsername`, and `${id}` with `1723905`. Note: \<DestinationName\> is the last component of the DESTINATION_PATH. The following replacement pairs already exist: `${Name}` to \<DestinationName\>, `${NameLower}` to \<destinationname\>, `${NameUpper}` to \<DESTINATIONNAME\>.
+
+  {{< note >}}
+When using the replace parameter in Windows PowerShell, you must use a single quote around any `$` replacement variables. Example: `--replace '${User}' MyUsername`.
+  {{< /note >}}
 
 - **`-f, --force`**
 


### PR DESCRIPTION
Signed-off-by: William Hayward <wilhayw@amazon.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

- Adds usage examples and clarifications for several O3DE CLI commands.
- Adds a recommended usage of `-kr` parameter ("keep restricted") when creating components from the default component template. This, oddly, _avoids_ the creation and registration of a "restricted" folder in the `<user>/.o3de/Restricted/Templates` directory when instantiating from this template.
- Adds a usage note for Windows PowerShell users who use the o3de script with the `--replace` parameter.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #806 