### PR TITLE
Add editorsv_rhi_override CVAR to Multiplayer testing page

### DIFF
--- a/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/test-in-editor.md
+++ b/content/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/test-in-editor.md
@@ -20,5 +20,6 @@ The Multiplayer Gem exposes a variety of cvars to help configure launching a ser
 | `editorsv_serveraddr` | `string` | The address of the server to connect to. Change this if you have a running server you want the connect to when entering Play Mode. The value is `127.0.0.1` by default. |
 | `editorsv_port` | `uint16_t` | The port that the multiplayer Gem binds to for traffic. |
 | `editorsv_isDedicated` | `bool` | Whether a Server should start up as a host. This setting is used by the Editor to tell the local server it launches to immediately start hosting its Editor connection so the Editor can connect. |
+| `editorsv_rhi_override` | `string` | Override the default rendering hardware interface (rhi) when launching the Editor server. For example, you may be running an Editor using 'dx12', but want to launch a headless server using 'null'. If empty, the server will launch using the same rhi as the Editor. |
 
 Using these features, you can configure the Editor to connect to a compatible remote host if you wanted or a specific server executable. For example, you could configure your profile Editor to connect to a debug server.


### PR DESCRIPTION
The Cvar `editorsv_rhi_override` is currently missing from https://www.o3de.org/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/test-in-editor/ .

This CVar allows you to override the rendering hardware interface (rhi) used to render the Editor server. Its definition (and the description text I used for this update) are defined in [MultiplayerEditorSystemComponent.cpp](https://github.com/o3de/o3de/blob/development/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp#L43).

## Change summary

New CVar name, type, and description now appear in the "Advanced Configuration" Table (see below screenshot):

![image](https://user-images.githubusercontent.com/34254888/170765817-0ff06828-0b02-470c-9835-5334bb504522.png)



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

