### PR TITLE
Fixed "UI Editor Toolbar" documentation page typos and formatting error

### DIFF
--- a/content/docs/user-guide/interactivity/user-interface/editor/toolbar.md
+++ b/content/docs/user-guide/interactivity/user-interface/editor/toolbar.md
@@ -7,7 +7,9 @@ weight: 100
 
 ## Interaction Modes 
 
-The **UI Editor** toolbar features interaction modes. The selected interaction mode determines how you can interact with the UI elements in your canvas.Interaction modes
+The **UI Editor** toolbar features interaction modes. The selected interaction mode determines how you can interact with the UI elements in your canvas.
+
+**Interaction modes**
 
 **Select**
 Select elements in your canvas. In this mode, selecting is the only action that you can use on your UI elements.
@@ -17,7 +19,7 @@ Select and move UI elements. Moving a UI element modifies its offset. In the **M
 You can move UI elements in the following ways:
 + Select an element and drag it to a new position.
 + Select a particular axis (X, Y, or Z) on the axis gizmo and drag the element by only one axis at a time.
-+ Nudge your selected elemented using keyboard arrows.
++ Nudge your selected element using keyboard arrows.
 + Select multiple elements and align them using the [Alignment Tool](#alignment-tool).
 
 **Rotate**
@@ -39,7 +41,7 @@ The alignment tool is a set of buttons on the **UI Editor**'s toolbar.
 The alignment tools are enabled when your interaction mode is **Move** or **Anchor** and you have selected two or more movable elements.
 
 {{< note >}}
-One type of element that you can't moved is one that a parent layout element controls.
+One type of element that you can't move is one that a parent layout element controls.
 {{< /note >}}
 
 With these tools, you can align elements by lining up their:


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary
Fixed issue regarding https://www.o3de.org/docs/user-guide/interactivity/user-interface/editor/toolbar/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1710 issue. 

* Changed Interaction Modes section - `The selected interaction mode determines how you can interact with the UI elements in your canvas.Interaction modes` - `Interaction modes` moved a paragraph lower and bolded.
* Changed Interaction Modes section - `Nudge your selected elemented using keyboard arrows.` - `elemented` to `element`.
* Changed Alignment Tool section - Note: `One type of element that you can’t moved is one that a parent layout element controls.` - `moved` to `move`.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

