### PR TITLE
Multi-Position Audio Component - Updated the component name and fixed letter casing

### DIFF
--- a/content/docs/user-guide/components/reference/audio/multi-position.md
+++ b/content/docs/user-guide/components/reference/audio/multi-position.md
@@ -5,7 +5,7 @@ description: Use the Multi-Position Audio component to play sounds at multiple l
 toc: true
 ---
 
-The Audio Multi-Position Component helps to create sounds that emanate
+The Multi-Position Audio Component helps to create sounds that emanate
 from multiple locations. For example a sound that covers an area, like
 a river, should use this component. Any sounds that have multiple
 instances should also use this component, as it does help to reduce
@@ -19,7 +19,7 @@ resources.
 
 | Name | Description | Default |
 |------|-------------|---------|
-| Entity References | a list of entities whose world positions will be used as the sound's multiple positions. | `<Empty>` |
+| Entity References | A list of entities whose world positions will be used as the sound's multiple positions. | `<Empty>` |
 | Behavior Type | A drop-down selection, the options are 'Separate' or 'Blended'. Separate means that the sound positions will be treated as if they were individual point source sounds. Blended means the positions will be treated as if they are one sound covering an area. | Separate |
 
 ## EBuses


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* Audio Multi-Position Component (https://www.o3de.org/docs/user-guide/components/reference/audio/multi-position/):
   * Changed the "Audio Multi-Position" to "Multi-Position Audio" in the first sentence on the page.
   * Fixed letter casing under the "Properties" section in the description of the "Entity References" property.

These fixes are related to https://github.com/o3de/o3de.org/issues/1068.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?