### PR TITLE
Getting Started with Test Automation - fixing spelling and formatting

### DIFF
--- a/content/docs/user-guide/testing/getting-started/_index.md
+++ b/content/docs/user-guide/testing/getting-started/_index.md
@@ -174,13 +174,13 @@ To verify everything is set up correctly, run the CMake configure command from *
 
 Now that you have configured CMake to create a test library and registered it with CTest, you are ready to write new tests. To simplify your module structure, create new test files inside `o3de/.../<MyModule>/tests/`.
 
-Tests are written using standard [GoogleTest](https://github.com/google/googletest/blob/main/docs/index.md) syntax, which helps you write small functions to test your code. To pull in everything from GoogleTest plus a few convienient tools, add the following statement to your C++ test file:
+Tests are written using standard [GoogleTest](https://github.com/google/googletest/blob/main/docs/index.md) syntax, which helps you write small functions to test your code. To pull in everything from GoogleTest plus a few convenient tools, add the following statement to your C++ test file:
 
 ```cpp
 #include <AzTest/AzTest.h>
 ```
 
-To keep test functions legible at a glance, we recommend using the [Osherove Naming Convention](https://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html) of `UnitOfWork_StateUnderTest_ExpectedBehavior`. This helps when reading a report that includes many individual test case failures. One way to think of this pattern is to summarize the test into `WhatIsExecuted_UniqueSetupStep_MostImportantVerification` so a test failure can be understood based on the name, without always needing to investigate the code inside the test. If you are struggling to summarize the test, this may indicate the test is too complex. Try breaking breaking complex tests into multiple smaller tests. Note that while GoogleTest documentation recommends [not using any underscores](http://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore) in test names, tests will function normally as long as test and fixture names never start or end with an underscore (`_`).
+To keep test functions legible at a glance, we recommend using the [Osherove Naming Convention](https://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html) of `UnitOfWork_StateUnderTest_ExpectedBehavior`. This helps when reading a report that includes many individual test case failures. One way to think of this pattern is to summarize the test into `WhatIsExecuted_UniqueSetupStep_MostImportantVerification` so a test failure can be understood based on the name, without always needing to investigate the code inside the test. If you are struggling to summarize the test, this may indicate the test is too complex. Try breaking complex tests into multiple smaller tests. Note that while GoogleTest documentation recommends [not using any underscores](http://google.github.io/googletest/faq.html#why-should-test-suite-names-and-test-names-not-contain-underscore) in test names, tests will function normally as long as test and fixture names never start or end with an underscore (`_`).
 
 A short example of C++ test structure:
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding https://docs.o3de.org/docs/user-guide/testing/getting-started/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1801 issue. 

* Changed Step 3: Write new tests section  - `To pull in everything from GoogleTest plus a few convienient tools,` - `convienient` to `convenient`.
* Changed Step 3: Write new tests section - `Try breaking breaking complex tests into multiple smaller tests` -  one `breaking` removed.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
