### PR TITLE
Profiler - fixed typo

### DIFF
--- a/content/docs/user-guide/testing/profiler/_index.md
+++ b/content/docs/user-guide/testing/profiler/_index.md
@@ -3,7 +3,7 @@ description: ' Use the O3DE Profiler to capture, save, and analyze network, CPU,
 title: Profiler
 ---
 
-Profiler is a O3DE tool that can capture, save, and analyze network, CPU, and VRAM usage statistics. You can used the saved data to analyze network usage frame by frame, fix problems in the use of network bandwidth, and optimize the performance of your game.
+Profiler is a O3DE tool that can capture, save, and analyze network, CPU, and VRAM usage statistics. You can use the saved data to analyze network usage frame by frame, fix problems in the use of network bandwidth, and optimize the performance of your game.
 
 **Topics**
 + [Creating and Using Annotations](/docs/user-guide/testing/profiler/annotations/)


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding http://localhost:1313/docs/user-guide/testing/profiler/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1803 issue. 

* Changed Profiler section - `You can used the saved data to analyze network usage frame by frame, ` - `used` to `use`.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
