### PR TITLE
Creating and Using Annotations - fixing broken links

### DIFF
--- a/content/docs/user-guide/testing/profiler/annotations.md
+++ b/content/docs/user-guide/testing/profiler/annotations.md
@@ -7,9 +7,9 @@ title: Creating and Using Annotations
 In Profiler, annotations are a convenient way of highlighting per-frame log information from the data captured from your application. After you learn how annotations are used in Profiler, you can modify your application so that they appear in Profiler.
 
 **Topics**
-+ [Using Annotations](#profiler-annotations-using)
-+ [Creating Annotations](#profiler-annotations-creating)
-+ [Viewing Annotations in Trace Messages Profiler](#profiler-annotations-creating-trace-messages-profiler)
++ [Using Annotations](#using-annotations)
++ [Creating Annotations](#creating-annotations)
++ [Viewing Annotations in Trace Messages Profiler](#viewing-annotations-in-trace-messages-profiler)
 
 ## Using Annotations 
 
@@ -23,7 +23,7 @@ Annotations in the O3DE Profiler tool flag frames in your captured data that hav
 
 ![Configure Annotations dialog box](/images/user-guide/profiler-annotations-using-configure-dialog.png)
 
-   The **Configure Annotations** dialog box contains a list of available annotations and their display colors. For information on creating annotations for your application, see [ Creating Annotations](#profiler-annotations-creating).
+   The **Configure Annotations** dialog box contains a list of available annotations and their display colors. For information on creating annotations for your application, see [ Creating Annotations](#creating-annotations).
 
 1. When you select an annotation in the dialog box, a marker and line of the same color appears in the channel display. Note that you might have to scroll horizontally to find the marker.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding https://www.o3de.org/docs/user-guide/testing/profiler/annotations/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1809 issue. 

* Changed Topics section - fixed the https://www.o3de.org/docs/user-guide/testing/profiler/annotations/#profiler-annotations-using link to correctly direct to the Using Annotations section.
 * Changed Topics section - fixed the https://www.o3de.org/docs/user-guide/testing/profiler/annotations/#profiler-annotations-creating link to correctly direct to the Creating Annotations section.
 * Changed Topics section - fixed the https://www.o3de.org/docs/user-guide/testing/profiler/annotations/#profiler-annotations-creating-trace-messages-profiler link to correctly direct to the Viewing Annotations in Trace Messages Profiler section.
 * Changed Using Annotations section - fixed the https://www.o3de.org/docs/user-guide/testing/profiler/annotations/#profiler-annotations-creating link to correctly direct to the Creating Annotations section.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
