### PR TITLE
Asset List Comparison Operations - fixing broken link

### DIFF
--- a/content/docs/user-guide/packaging/asset-bundler/list-operations.md
+++ b/content/docs/user-guide/packaging/asset-bundler/list-operations.md
@@ -8,7 +8,7 @@ weight: 500
 Asset list comparisons are rules provided to the `AssetBundlerBatch.exe` tool to determine which files should be included or excluded from the final bundle asset list. The asset list files have the suffix `.assetlist` and contain a flat list of paths and names of asset files. 
 
 {{< note >}}
-While the comparison operations use terms from set theory, they are not exactly the same as the actual set operations. This is particularly true of the [delta comparison operation](#asset-bundler-list-operations-delta), which includes a file entry in both sets if one of those files has been modified in the second set. Additionally, file pattern matching is not a set operation.
+While the comparison operations use terms from set theory, they are not exactly the same as the actual set operations. This is particularly true of the [delta comparison operation](#asset-list-delta-comparison-operation), which includes a file entry in both sets if one of those files has been modified in the second set. Additionally, file pattern matching is not a set operation.
 {{< /note >}}
 
 ## Asset List Delta Comparison Operation 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding https://docs.o3de.org/docs/user-guide/packaging/asset-bundler/list-operations/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1796 issue. 

* Changed Asset List Comparison Operations section - fixed the [delta comparison operation](https://docs.o3de.org/docs/user-guide/packaging/asset-bundler/list-operations/#asset-bundler-list-operations-delta) link to correctly direct to the Asset List Delta Comparison Operation section.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
