### PR TITLE
Parallel Pattern & Batching Test-Writing - fixing spelling and formatting

### DIFF
--- a/content/docs/user-guide/testing/parallel-pattern/_index.md
+++ b/content/docs/user-guide/testing/parallel-pattern/_index.md
@@ -87,7 +87,7 @@ The recommended structure is the following:
 
 ![Folder Structure](/images/user-guide/testing/parallel-pattern/folder-structure.png)
 
-* **/**  - The root folder of the tests should contain a `CMakeLists.txt` file and the test suites for the feature. A feature must contain one test suite file per type (Smoke, Main, Periodic, and Sandbox). These files will only be run by the external Python interpeter.
+* **/**  - The root folder of the tests should contain a `CMakeLists.txt` file and the test suites for the feature. A feature must contain one test suite file per type (Smoke, Main, Periodic, and Sandbox). These files will only be run by the external Python interpreter.
 
 * **utils/** (Optional) - A `utils` directory provides utilities common to multiple tests for the `TestSuite` files. Utilities for specific tests should be part of their test files.
   
@@ -420,7 +420,7 @@ Certain test modes can be disabled or managed through command-line options:
 ## Best practices
 
 * **Don’t create a level unless necessary**. Use an existing empty level and don’t save the changes when the test is over.
-* **Tests should be be self-contained**. No external tools should determine if the test has passed or failed. Instead, O3DE Editor should do this work. Use the one of the editor's return codes as result of the test, `0x0` for success and `0xF` for failure.
+* **Tests should be self-contained**. No external tools should determine if the test has passed or failed. Instead, O3DE Editor should do this work. Use the one of the editor's return codes as result of the test, `0x0` for success and `0xF` for failure.
 * **Don’t read the O3DE Editor log file directly**. To read O3DE Editor log information, use the `DebugTraceBus` and `Tracer` utilities. The `DebugTraceBus` is able to capture all logged information, without needing to create an I/O dependency on a file.
     
 ```python


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding https://www.o3de.org/docs/user-guide/testing/parallel-pattern/ documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1812 issue. 

* Changed Test structure section - `These files will only be run by the external Python interpeter.` - `interpeter` to `interpreter`.
* Changed Best practices section - `Tests should be be self-contained. ` -  one `be` removed.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
