### PR TITLE
Controlling the Playhead - fixing broken links

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/controlling-the-playhead.md
+++ b/content/docs/user-guide/visualization/cinematics/controlling-the-playhead.md
@@ -14,11 +14,11 @@ The **Play** toolbar has the following controls.
 
 | Toolbar Options | Description |
 | --- | --- |
-|  **Go to start of sequence**  |  Playhead is moved to the **In** marker of your sequence. For more information, see [Setting the In and Out Markers](#setting-the-in-out-markers).  |
+|  **Go to start of sequence**  |  Playhead is moved to the **In** marker of your sequence. For more information, see [Setting the In and Out Markers](#setting-the-in-and-out-markers).  |
 |  **Play**  |  Activates play mode and moves the playhead forward through the sequence timeline. Click the drop-down menu to control the play speed.  The default is **1x** speed. Other options include **2x**, **1/2x**, **1/4x**, and **1/8x**.  |
 |  **Stop**  |  Stops the playhead. Click the drop-down menu to specify the default **Stop** or **Stop with Hard Reset**, which returns the playhead to the start of the sequence.  |
 |  **Pause**  |  During play mode, holds the playhead at the current point in the timeline. When selected again, the sequence resumes playing.  |
-|  **Go to end of sequence**  |  Playhead is moved to the **Out** marker of the sequence.  For more information, see [Setting the In and Out Markers](#setting-the-in-out-markers).  |
+|  **Go to end of sequence**  |  Playhead is moved to the **Out** marker of the sequence.  For more information, see [Setting the In and Out Markers](#setting-the-in-and-out-markers).  |
 |  **Start Animation Recording**  |  Also known as record mode, you can manipulate objects within the level and the animation keys are automatically added to the sequence.  For more information, see [Using Record Mode](/docs/user-guide/visualization/cinematics/using-record-mode/).  |
 |  **Start Auto Recording**  |  When selected, also activates record mode. The playhead automatically moves in the timeline based on the setting specified in the drop-down menu.  The default is **1 sec**. Other options include **1/2 sec**, **1/5 sec**, **1/10 sec**, **1/25** sec, **1/50** sec, and **1/100** sec.  |
 | Loop |  During play mode, when the playhead reaches the **End** marker it returns to the **In** marker of the sequence and continues playing the sequence again.  |


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Controlling the Playhead](https://www.o3de.org/docs/user-guide/visualization/cinematics/controlling-the-playhead/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1820 issue. 

* Changed Go to start of sequence section - fixed the [Setting the In and Out Markers](https://www.o3de.org/docs/user-guide/visualization/cinematics/controlling-the-playhead/#setting-the-in-out-markers) link to correctly direct to the Setting the In and Out Markers section.
* Changed Go to end of sequence section - fixed the [Setting the In and Out Markers](https://www.o3de.org/docs/user-guide/visualization/cinematics/controlling-the-playhead/#setting-the-in-out-markers) link to correctly direct to the Setting the In and Out Markers section.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
