### PR TITLE
Setting Sequence Properties - fixing formatting error

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/sequence-props.md
+++ b/content/docs/user-guide/visualization/cinematics/sequence-props.md
@@ -11,8 +11,6 @@ You can set properties in the Track View to control how the track view sequence 
 
 1. In the **Sequence Properties** dialog box, you can specify the following properties.
 
-![Specify track view sequence properties.](/images/user-guide/cinematics/cinematics-sequence-props.png)
-**Scene Properties**
-
+    ![Specify track view sequence properties.](/images/user-guide/cinematics/cinematics-sequence-props.png)
 
 1. When you are finished, click **OK**.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Setting Sequence Properties](https://www.o3de.org/docs/user-guide/visualization/cinematics/sequence-props/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1822 issue. 

* Changed To set sequence properties section - `Scene Properties` removed and the numbered list increments correctly after the image.




### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
