### PR TITLE
Submit a PR to O3DE Docs - Fixed two bad links

### DIFF
--- a/content/docs/contributing/to-docs/submit-a-pr.md
+++ b/content/docs/contributing/to-docs/submit-a-pr.md
@@ -17,8 +17,8 @@ When you make an edit or create a new topic in the **Open 3D Engine (O3DE)** doc
 Before submitting a PR, ensure your contributions meet the guidelines below:
 
 * Files in the PR are placed in the proper directories. Refer to [O3DE Docs Structure](/docs/contributing/to-docs/o3de-docs-structure).
-* Contributions adhere to the O3DE Documentation style. Refer to [O3DE Documentation Contribution Style Guide](/docs/contributing/to-docs/style-guide).
-* Contributions use O3DE terms correctly. Refer to [O3DE Documentation Terminology](/docs/contributing/to-docs/style-guide).
+* Contributions adhere to the O3DE Documentation style. Refer to [O3DE Documentation Contribution Style Guide](/docs/contributing/to-docs/style-guide/overview).
+* Contributions use O3DE terms correctly. Refer to [O3DE Documentation Terminology](/docs/contributing/to-docs/terminology).
 * All commits in the PR have a proper *DCO sign-off*. Refer to [Commit your changes](#commit-your-changes) below.
 
 * The PR only contains commits and changes you want reviewed for the PR.


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* Submit a PR to O3DE Docs (https://www.o3de.org/docs/contributing/to-docs/submit-a-pr/):
   * Fixed two bad links that redirect to a blank page.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?