### PR TITLE
Update ScriptCanvas Autogen usage

### DIFF
--- a/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-free-function-nodes.md
+++ b/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-free-function-nodes.md
@@ -175,44 +175,29 @@ set(FILES
 )
 ```
 
-### Step 5: Reflect the new node {#reflect-the-new-node}
+### Step 5: Register the new node {#register-the-new-node}
 {{< note >}}
 This step is only required once for the first time custom free function node creation.
 {{< /note >}}
 
-The final step is to register and reflect the new node.
+The final step is to register the new node. To do this, you need to modify your Gem's [Gem module](/docs/user-guide/programming/gems/overview/) or [system component](/docs/user-guide/programming/components/system-components/).
 
-To do this, you need to modify Gem [System Component](/docs/user-guide/programming/components/system-components/).
-In our example, it is named `MyGemSystemComponent.cpp` by default.
-
-1. Include auto-generated registry header file, and invoke `REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION` with sanitized Gem target name. 
-    {{< note >}}
-    Auto-generated registry header file should be the same name declared under `AUTOGEN_RULES` in your Gem's `Code/CMakeLists.txt`. In our example, it is `AutoGenFunctionRegistry.generated.h`.
-    {{< /note >}}
-    {{< note >}}
-    Sanitized Gem target name should contain letters and numbers only. In our example, it is `MyGemStatic` which refers to `MyGem.Static` target.
-    {{< /note >}}
+In your Gem's module or system component, include the auto-generated registry header file, and invoke `REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION` with the sanitized Gem target name.
+{{< note >}}
+Use the same auto-generated registry header file that you declared in Step 1 under `AUTOGEN_RULES` in your Gem's `Code/CMakeLists.txt`. In our example, it is `AutoGenFunctionRegistry.generated.h`.
+{{< /note >}}
+{{< note >}}
+The sanitized Gem target name should contain letters and numbers only. In our example, it is `MyGemStatic` which refers to the `MyGem.Static` target.
+{{< /note >}}
    
-    For example, in `MyGemSystemComponent.cpp`
-  
-    ```cpp
-    #include <AutoGenFunctionRegistry.generated.h>
-    
-    REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION(MyGemStatic)
-    ...
-    ```
+For example, in `MyGemSystemComponent.cpp`
 
-1. Reflect auto-generated registry through Gem system component Reflect function.
+```cpp
+#include <AutoGenFunctionRegistry.generated.h>
 
-    For example, in `MyGemSystemComponent.cpp`
-
-    ```cpp
-    void MyGemSystemComponent::Reflect(AZ::ReflectContext* context)
-    {
-        ScriptCanvas::AutoGenRegistry::Reflect(context);
-        ...
-    }
-    ```
+REGISTER_SCRIPTCANVAS_AUTOGEN_FUNCTION(MyGemStatic)
+...
+```
 
 ## Advanced ScriptCanvasFunction.xml Usage
 This topic explores additional features we support in function XML file.

--- a/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-nodeable-nodes.md
+++ b/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-nodeable-nodes.md
@@ -184,61 +184,30 @@ set(FILES
 )
 ```
 
-## Step 5: Reflect the new node {#reflect-the-new-node}
+## Step 5: Register the new node {#register-the-new-node}
 {{< note >}}
 This step is only required once for the first time nodeable node creation.
 {{< /note >}}
 
-The final step is to register and reflect the new node. To do this, you need to modify your Gem's [Gem module](/docs/user-guide/programming/gems/overview/) and [system component](/docs/user-guide/programming/components/system-components/). Use the **StartingPointInput** Gem from the O3DE source as a reference:
+The final step is to register new node. To do this, you need to modify your Gem's [Gem module](/docs/user-guide/programming/gems/overview/) or [system component](/docs/user-guide/programming/components/system-components/). Use the **StartingPointInput** Gem from the O3DE source as a reference:
 
-1. In your Gem's system component, include the auto-generated registry header file, and invoke `REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE` with the sanitized Gem target name.
-    {{< note >}}
-    Use the same auto-generated registry header file that you declared in Step 1 under `AUTOGEN_RULES` in your Gem's `Code/CMakeLists.txt`. In the **StartingPointInput** example, it is `AutoGenNodeableRegistry.generated.h`.
-    {{< /note >}}
-    {{< note >}}
-    The sanitized Gem target name should contain letters and numbers only. In the **StartingPointInput** example, it is `StartingPointInputStatic` which refers to the `StartingPointInput.Static` target.
-    {{< /note >}}
-   
-    For example, in [`StartingPointInputGem.cpp`](https://github.com/o3de/o3de/blob/development/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp):
-  
-    ```cpp
-    #include <AutoGenNodeableRegistry.generated.h>
-    ...
-    
-    REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE(StartingPointInputStatic);
-    ...
-    ```
+In your Gem's module or system component, include the auto-generated registry header file, and invoke `REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE` with the sanitized Gem target name.
+{{< note >}}
+Use the same auto-generated registry header file that you declared in Step 1 under `AUTOGEN_RULES` in your Gem's `Code/CMakeLists.txt`. In the **StartingPointInput** example, it is `AutoGenNodeableRegistry.generated.h`.
+{{< /note >}}
+{{< note >}}
+The sanitized Gem target name should contain letters and numbers only. In the **StartingPointInput** example, it is `StartingPointInputStatic` which refers to the `StartingPointInput.Static` target.
+{{< /note >}}
 
-1. Also in your Gem's system component, reflect and initialize the auto-generated registry in the component's Reflect function:
+For example, in [`StartingPointInputGem.cpp`](https://github.com/o3de/o3de/blob/development/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp):
 
-    For example, in [`StartingPointInputGem.cpp`](https://github.com/o3de/o3de/blob/development/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp):
+```cpp
+#include <AutoGenNodeableRegistry.generated.h>
+...
 
-    ```cpp
-    void StartingPointInputSystemComponent::Reflect(AZ::ReflectContext* context)
-    {
-        REFLECT_SCRIPTCANVAS_AUTOGEN(StartingPointInputStatic, context);
-        ...
-    }
-    ```
-   
-    ```cpp
-    void StartingPointInputSystemComponent::Init()
-    {
-        INIT_SCRIPTCANVAS_AUTOGEN(StartingPointInputStatic);
-    }   
-    ```
-
-1. Finally, insert the auto-generated nodeable descriptors in the Gem module.
-
-    For example, in [`StartingPointInputGem.cpp`](https://github.com/o3de/o3de/blob/development/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp):
-    ```cpp
-    StartingPointInputModule() : AZ::Module()
-    {
-        ...
-        AZStd::vector<AZ::ComponentDescriptor*> autogenDescriptors(GET_SCRIPTCANVAS_AUTOGEN_COMPONENT_DESCRIPTORS(StartingPointInputStatic));
-        m_descriptors.insert(m_descriptors.end(), autogenDescriptors.begin(), autogenDescriptors.end());
-    }
-    ```
+REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE(StartingPointInputStatic);
+...
+```
 
 ## Advanced ScriptCanvasNodeable.xml usage
 This topic explores additional features that we support in the nodeable XML file.

--- a/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-nodeable-nodes.md
+++ b/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/custom-nodeable-nodes.md
@@ -189,7 +189,7 @@ set(FILES
 This step is only required once for the first time nodeable node creation.
 {{< /note >}}
 
-The final step is to register new node. To do this, you need to modify your Gem's [Gem module](/docs/user-guide/programming/gems/overview/) or [system component](/docs/user-guide/programming/components/system-components/). Use the **StartingPointInput** Gem from the O3DE source as a reference:
+The final step is to register the new node. To do this, you need to modify your Gem's [Gem module](/docs/user-guide/programming/gems/overview/) or [system component](/docs/user-guide/programming/components/system-components/). Use the **StartingPointInput** Gem from the O3DE source as a reference:
 
 In your Gem's module or system component, include the auto-generated registry header file, and invoke `REGISTER_SCRIPTCANVAS_AUTOGEN_NODEABLE` with the sanitized Gem target name.
 {{< note >}}


### PR DESCRIPTION
## Change summary

Because of recent change https://github.com/o3de/o3de/pull/10812, have to update the final step of ScriptCanvas nodeable and custom free function node creation guides.

In general, ScriptCanvas doesn't require customer with extra steps to register their custom nodes. Right now, everything is handled transparently based on self-register pattern.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

Signed-off-by: onecent1101 <liug@amazon.com>
