### PR TITLE
Adding Lighting - fixing empty header

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/adding-lighting-to-scenes.md
+++ b/content/docs/user-guide/visualization/cinematics/adding-lighting-to-scenes.md
@@ -6,8 +6,6 @@ title: Adding Lighting
 
 You can set up a different lighting scenario in a sequence using light components and/or a time of day settings that are only triggered during the sequence. You can add light components to the sequence and then add the tracks that you want to animate. You can then set the [Console Variable Node](/docs/user-guide/visualization/cinematics/track-view/nodes-cvar/) to specify the time of day settings.
 
-##  
-
 ## Cinematic Lighting Best Practices 
 
 See the following recommended guidelines and best practices for cinematics lighting.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding [Adding Lighting](https://www.o3de.org/docs/user-guide/visualization/cinematics/adding-lighting-to-scenes/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1815 issue. 

* Deleted the empty header tag.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
