### PR TITLE
Director (Scene) Node - fixing formatting error

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/track-view/nodes-director.md
+++ b/content/docs/user-guide/visualization/cinematics/track-view/nodes-director.md
@@ -17,7 +17,7 @@ The **Director (Scene)** node includes a camera track that specifies the active 
 
 1. Right-click the **Director** node and click **Add Track**.
 
-![Add the Director node in the Track View to manage your track view sequence.](/images/user-guide/cinematics/cinematics-trackview-nodes-director.png)
+   ![Add the Director node in the Track View to manage your track view sequence.](/images/user-guide/cinematics/cinematics-trackview-nodes-director.png)
 
 1. Select the track and double-click to position the key on its highlighted row in the timeline.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issue regarding [Director (Scene) Node](https://www.o3de.org/docs/user-guide/visualization/cinematics/track-view/nodes-director/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1829 issue. 

* Changed To add a Director node in the Track View section - The numbered list increments correctly after the image.




### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
