### PR TITLE
Event Node - fixing formatting and syntax

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/track-view/nodes-event.md
+++ b/content/docs/user-guide/visualization/cinematics/track-view/nodes-event.md
@@ -14,7 +14,7 @@ You can add an **Event** node to your sequence to trigger and send values to Scr
 
 1. In the **Track Event Name** window, enter a name for the track and choose **OK**.
 
-   This creates a **Track Event** node and a **Track Event** track is automatically to that node.
+   This creates a **Track Event** node and a **Track Event** track is automatically added to that node.
 
    ![Creating track event nodes in a sequence.](/images/user-guide/cinematics/cinematics-track-view-editor-track-event-nodes.png)
 
@@ -22,12 +22,12 @@ You can add an **Event** node to your sequence to trigger and send values to Scr
 
 1. In the node browser, right-click and choose **Edit Events**. This opens the **Track View Events** window.
 
-![Creating a track event for a sequence.](/images/user-guide/cinematics/cinematics-track-view-editor-track-event-nodes-2.png)
+    ![Creating a track event for a sequence.](/images/user-guide/cinematics/cinematics-track-view-editor-track-event-nodes-2.png)
 
 1. In the **Track View Events** window, click **Add** to create an event.
 
 1. Enter an event name and choose **OK**. Your track event appears in the window.
 
-![Enter a name for a track event in your sequence.](/images/user-guide/cinematics/cinematics-track-view-editor-track-event-nodes-3.png)
+    ![Enter a name for a track event in your sequence.](/images/user-guide/cinematics/cinematics-track-view-editor-track-event-nodes-3.png)
 
 1. When you are done, close the window. You can now specify this track event in Script Canvas.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Event Node](https://www.o3de.org/docs/user-guide/visualization/cinematics/track-view/nodes-event/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1830 issue. 

* Changed To add an Event node section - `This creates a Track Event node and a Track Event track is automatically to that node.` - `... Track Event track is automatically to that node.` changed to `...Track Event track is automatically added to that node.`
* Changed To create a Track Event section - The numbered list increments after the images.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
