### PR TITLE
Improvements to left docs navigation

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -145,8 +145,6 @@ $(function() {
 
 // A helper function to show the list of children in the docs-nav.
 function showChildren(e) {
-  $(e).toggleClass("open");
-
   $(e).siblings('ul').each(function()
   {
     $(this).slideToggle(300);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -102,15 +102,18 @@ $(function() {
   $("#docs-nav a").each(function(){
     if($(this).attr("href") == url) {
       $(this).addClass("currentPage");
+
+      // Apply attributes to the parent pages/sections for styling.
       $(this).parentsUntil("#docs-nav", "ul").each(function(){
         $(this).addClass("currentAncestor");
         $(this).siblings('a').each(function()
         {
-          $(this).addClass("currentAncestor").addClass("open");
-          
-        });
-        $(this).parent('li').addClass("currentAncestorCategory");
+          $(this).addClass("currentAncestor").addClass("open");          
+        });                  
+        $(this).parent('li').addClass("currentAncestorCategory");    
       })
+      $(this).parent('li').addClass("currentAncestorCategory");    
+      
     }
   })
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -116,7 +116,6 @@ $(function() {
 });
 
 // Applies to the current page in the docs-nav.
-
 $(function() {
   $("#docs-nav a.currentPage").each(function(e){
 
@@ -129,7 +128,8 @@ $(function() {
     }
     $(this).siblings('.has-children-icon').each(function()
     {
-      $(this).addClass("open");      
+      $(this).addClass("open");
+      $(this).addClass("currentPage");
     });
   })
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -98,17 +98,6 @@ $(function() {
 // Docs navigation
 
 $(function() {
-  $("#docs-nav a.has-children").click(function(e){
-    e.preventDefault();
-    $(this).toggleClass("open");
-    $(this).siblings('ul').each(function()
-    {
-      $(this).slideToggle(300);
-    });
-  })
-});
-
-$(function() {
   const url = window.location.pathname;
   $("#docs-nav a").each(function(){
     if($(this).attr("href") == url) {
@@ -118,12 +107,52 @@ $(function() {
         $(this).siblings('a').each(function()
         {
           $(this).addClass("currentAncestor").addClass("open");
+          
         });
         $(this).parent('li').addClass("currentAncestorCategory");
       })
     }
   })
 });
+
+// Applies to the current page in the docs-nav.
+
+$(function() {
+  $("#docs-nav a.currentPage").each(function(e){
+
+    // Show children pages/sections in the docs-nav, if any.
+    if ($(this).hasClass('has-children')){
+      console.log("yes has children");
+
+      $(this).addClass("open");
+      showChildren(this);
+    }
+    $(this).siblings('.has-children-icon').each(function()
+    {
+      $(this).addClass("open");      
+    });
+  })
+});
+
+// For sections in the docs-nav, this applies to the drop-down icon's click event.
+$(function() {
+  $("#docs-nav a.has-children-icon").click(function(e){
+    console.log("has-children-icon triggered");
+    $(this).toggleClass("open");
+    showChildren(this);
+  })
+});
+
+// A helper function to show the list of children in the docs-nav.
+function showChildren(e) {
+  $(e).toggleClass("open");
+
+  $(e).siblings('ul').each(function()
+  {
+    $(this).slideToggle(300);
+  });
+}
+
 
 $(function() {
   $("body").append("<div id=\"docs-mobile-menu-overlay\" class=\"docs-mobile-menu-overlay\"></div>");

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1507,7 +1507,7 @@ nav.docs-nav
       position: relative
 
       a
-        display: block
+        display: inline-block
         padding: 3px 20px 3px 5px
         color: #333
         &:hover

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1533,8 +1533,10 @@ nav.docs-nav
       a.has-children:hover::after
         border-color: $o3de-blue-highlight    
 
-      a.has-children-icon      
-        padding: 15px
+      a.has-children-icon  
+        display: inline-block
+        height: 50%
+        padding: 10px
         position: absolute  
         right: 0px
         top: 0px
@@ -1550,11 +1552,12 @@ nav.docs-nav
           border-left: 0
           border-top: 0    
         &:hover::after
+          cursor: pointer
           border-color: $o3de-blue-highlight
         
       a.has-children-icon.open
         &:after
-          transform: rotate(45deg) translate(-3px, -3px)
+          transform: rotate(45deg)
         &:hover::after
           border-color: $o3de-blue-highlight
       

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1526,6 +1526,12 @@ nav.docs-nav
         color: $o3de-blue
         &:hover
           color: $o3de-blue-highlight
+        
+      a.currentAncestor.has-children::after
+        border-color: $o3de-blue
+
+      a.has-children:hover::after
+        border-color: $o3de-blue-highlight    
 
       a.has-children-icon      
         padding: 15px
@@ -1542,16 +1548,28 @@ nav.docs-nav
           transform: rotate(-45deg)
           border: 2px solid #333
           border-left: 0
-          border-top: 0
+          border-top: 0    
+        &:hover::after
+          border-color: $o3de-blue-highlight
         
-      a.currentAncestor.has-children::after
-        border-color: $o3de-blue
-
-      a.has-children:hover::after
-        border-color: $o3de-blue-highlight
+      a.has-children-icon.open
+        &:after
+          transform: rotate(45deg) translate(-3px, -3px)
+        &:hover::after
+          border-color: $o3de-blue-highlight
       
-      a.has-children-icon.open::after
-        transform: rotate(45deg) translate(-3px, -3px)
+      a.has-children-icon.currentPage
+        &:after
+          border-color: $o3de-blue
+        &:hover::after
+          border-color: $o3de-blue-highlight
+
+      a.has-children-icon.currentAncestor
+        &:after
+          border-color: $o3de-blue          
+        &:hover::after
+          border-color: $o3de-blue-highlight
+
 
       ul
         display: none

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1534,12 +1534,9 @@ nav.docs-nav
         border-color: $o3de-blue-highlight    
 
       a.has-children-icon  
-        display: inline-block
-        height: 50%
-        padding: 10px
         position: absolute  
         right: 0px
-        top: 0px
+        top: 8px
         &:after
           position: absolute  
           right: 5px
@@ -1557,7 +1554,7 @@ nav.docs-nav
         
       a.has-children-icon.open
         &:after
-          transform: rotate(45deg)
+          transform: rotate(45deg) translate(-3px, -3px)
         &:hover::after
           border-color: $o3de-blue-highlight
       

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1513,7 +1513,7 @@ nav.docs-nav
         &:hover
           color: $o3de-blue-highlight
       
-      a.currentPage:not(.has-children)
+      a.currentPage
         background: rgba(221, 221, 221, .3)
         border-radius: 3px
         color: $o3de-blue
@@ -1527,7 +1527,7 @@ nav.docs-nav
         &:hover
           color: $o3de-blue-highlight
 
-      a.has-children::after
+      a.has-children-icon::after
         content: ''
         width: 10px
         height: 10px
@@ -1546,7 +1546,7 @@ nav.docs-nav
       a.has-children:hover::after
         border-color: $o3de-blue-highlight
       
-      a.has-children.open::after
+      a.has-children-icon.open::after
         transform: rotate(45deg) translate(-3px, -3px)
 
       ul

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1514,7 +1514,6 @@ nav.docs-nav
           color: $o3de-blue-highlight
       
       a.currentPage
-        background: rgba(221, 221, 221, .3)
         border-radius: 3px
         color: $o3de-blue
         font-weight: 600

--- a/assets/sass/custom.sass
+++ b/assets/sass/custom.sass
@@ -1527,18 +1527,22 @@ nav.docs-nav
         &:hover
           color: $o3de-blue-highlight
 
-      a.has-children-icon::after
-        content: ''
-        width: 10px
-        height: 10px
-        position: absolute
-        right: 8px
-        top: 13px
-        transition: transform .5s ease
-        transform: rotate(-45deg)
-        border: 2px solid #333
-        border-left: 0
-        border-top: 0
+      a.has-children-icon      
+        padding: 15px
+        position: absolute  
+        right: 0px
+        top: 0px
+        &:after
+          position: absolute  
+          right: 5px
+          content: ''
+          width: 10px
+          height: 10px
+          transition: transform .5s ease
+          transform: rotate(-45deg)
+          border: 2px solid #333
+          border-left: 0
+          border-top: 0
         
       a.currentAncestor.has-children::after
         border-color: $o3de-blue

--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -3,10 +3,11 @@
     {{ range .Pages }}
         {{ $isHere := in $here .RelPermalink }}
         <li>
-            <a href="{{ .RelPermalink }}" class="docs-link ">
-                {{.LinkTitle}}
+            <a href="{{ .RelPermalink }}" class="docs-link {{ if .Pages }} has-children{{ end }}">
+                    {{.LinkTitle}}
             </a>
-            <a class="{{ if .Pages }} has-children{{ end }}"> </a>
+            
+            <a class="{{ if .Pages }} has-children-icon{{ end }}"> </a>
             {{ if .Pages }}            
                     {{ partial "section-nav-walk.html" . }}
             {{ end }}

--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -1,16 +1,16 @@
 {{ $here   := .RelPermalink }}
-<ul>
-    {{ range .Pages }}
-        {{ $isHere := in $here .RelPermalink }}
-        <li>
-            <a href="{{ .RelPermalink }}" class="docs-link {{ if .Pages }} has-children{{ end }}">
-                    {{.LinkTitle}}
-            </a>
-            
-            <a class="{{ if .Pages }} has-children-icon{{ end }}"> </a>
-            {{ if .Pages }}            
-                    {{ partial "section-nav-walk.html" . }}
-            {{ end }}
-        </li>
-    {{ end }}
-</ul>
+{{ range .Pages }}
+    {{ $isHere := in $here .RelPermalink }}
+    <li>
+        <a href="{{ .RelPermalink }}" class="docs-link {{ if .Pages }} has-children{{ end }}">
+                {{.LinkTitle}}
+        </a>
+        
+        <a class="{{ if .Pages }} has-children-icon{{ end }}"> </a>
+        {{ if .Pages }}
+            <ul>
+                {{ partial "section-nav-walk.html" . }}
+            </ul>
+        {{ end }}
+    </li>
+{{ end }}

--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -1,24 +1,15 @@
 {{ $here   := .RelPermalink }}
-
+<ul>
     {{ range .Pages }}
         {{ $isHere := in $here .RelPermalink }}
         <li>
-            <a href="{{ .RelPermalink }}"
-            class="docs-link{{ if .Pages }} has-children{{ end }}"> 
-                {{.LinkTitle}} 
+            <a href="{{ .RelPermalink }}" class="docs-link ">
+                {{.LinkTitle}}
             </a>
-            {{ if .Pages }}
-                <ul>
-                    {{ if and ( .IsSection ) (ge (len .Content) 1) }}
-                    <li>
-                        <a href="{{ .RelPermalink }}"
-                        class="docs-link">                        
-                            {{ if .Params.sectionPageTitle }} {{.Params.sectionPageTitle}} {{else}} {{.LinkTitle}} {{end}}
-                        </a>
-                    </li>
-                    {{ end }}
+            <a class="{{ if .Pages }} has-children{{ end }}"> </a>
+            {{ if .Pages }}            
                     {{ partial "section-nav-walk.html" . }}
-                </ul>
             {{ end }}
         </li>
     {{ end }}
+</ul>

--- a/layouts/partials/section-nav-walk.html
+++ b/layouts/partials/section-nav-walk.html
@@ -6,7 +6,7 @@
                 {{.LinkTitle}}
         </a>
         
-        <a class="{{ if .Pages }} has-children-icon{{ end }}"> </a>
+        {{ if .Pages }}<a class="has-children-icon"> </a>{{ end }}
         {{ if .Pages }}
             <ul>
                 {{ partial "section-nav-walk.html" . }}


### PR DESCRIPTION

## Change summary

Resolves this issue: https://github.com/o3de/o3de.org/issues/1686

Updated the website to allow the following behaviors in the left-docs-navigation:
- When a user clicks on the section title, they are redirected to that section (`_index.md`) _and_ the section's children pages/sections are displayed. 
- When a user clicks on the "drop-down" icon next to a section, the section's children pages/sections are displayed, _but_ they are not redirected to that section. 

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

