### PR TITLE
Using Animation Curves - fixing formatting errors

### DIFF
--- a/content/docs/user-guide/visualization/cinematics/track-view/editor-animation-curves.md
+++ b/content/docs/user-guide/visualization/cinematics/track-view/editor-animation-curves.md
@@ -44,7 +44,6 @@ See the following tips for working in the **Curve Editor**:
 + To zoom in or out, scroll the mouse wheel
 + To pan the view, click and drag the middle mouse wheel
 + To select multiple spline keys, click and drag to select the keys
-+
 
 **To adjust a spline key**
 
@@ -55,7 +54,6 @@ See the following tips for working in the **Curve Editor**:
   1. Do one of the following:
      + Drag the spline key to a different point on the timeline.
      + Use the toolbar buttons to select a preset: auto, zero, step, or linear.
-+
 
 **To edit multiple elements at once**
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Using Animation Curves](https://www.o3de.org/docs/user-guide/visualization/cinematics/track-view/editor-animation-curves/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1832 issue. 

* Changed To edit elements in a curve section - Deleted an empty bullet point in the list.
* Changed To adjust a spline key section - Deleted an empty bullet point in the list.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #1832 
