### PR TITLE
Finding Nodes in Script Canvas - fixing spelling error

### DIFF
--- a/content/docs/user-guide/scripting/script-canvas/editor-reference/nodes/finding-nodes.md
+++ b/content/docs/user-guide/scripting/script-canvas/editor-reference/nodes/finding-nodes.md
@@ -15,7 +15,7 @@ If you want to find all nodes of the same type on a graph - for example, to chec
 
 1. To scroll to the right, starting at the leftmost node occurrence, press **F8**. The relevant nodes are highlighted with an orange glow.
 
-1. To scroll to the left, starting at the rightmost node occurence, press **F7**.
+1. To scroll to the left, starting at the rightmost node occurrence, press **F7**.
 
 1. To return to the beginning or end of the cycle, press **F7** or **F8** again.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed an issue regarding [Finding Nodes](https://www.o3de.org/docs/user-guide/scripting/script-canvas/editor-reference/nodes/finding-nodes/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1849 issue. 

* Changed To find all instances of a node section - `To scroll to the left, starting at the rightmost node occurence, press F7. ` - `occurence` changed to `occurrence`.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Fiux #1849 