### PR TITLE
Creating Script Canvas Nodes from the Behavior Context - fixing spelling

### DIFF
--- a/content/docs/user-guide/scripting/script-canvas/programmer-guide/behavior-context.md
+++ b/content/docs/user-guide/scripting/script-canvas/programmer-guide/behavior-context.md
@@ -26,7 +26,7 @@ The core Script Canvas code is built as a static library that is linked into the
 
 When you use the behavior context, you do not need to write any code specific to Script Canvas. However, it is important that the way in which your code is reflected to the behavior context remains intuitive and practical in a visual scripting environment.
 
-The combination of the Script Canvas and behavior context archictectures includes the following benefits:
+The combination of the Script Canvas and behavior context architectures includes the following benefits:
 
 + Support for the AZ::Event and EBus event systems enable your scripts to use decoupled, event-driven programming paradigms.
 + Script Canvas can use functionality exposed through the behavior context from any Gem, enabling any Gem to enhance Script Canvas.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed an issue regarding [Creating Nodes from the Behavior Context](https://www.o3de.org/docs/user-guide/scripting/script-canvas/programmer-guide/behavior-context/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1850 issue. 

* Changed Script Canvas architecture section - `The combination of the Script Canvas and behavior context archictectures includes the following benefits: ` - `archictectures` changed to `architectures`.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
