### PR TITLE
Creating Custom Nodes in Script Canvas - fixing spelling

### DIFF
--- a/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/_index.md
+++ b/content/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/_index.md
@@ -5,7 +5,7 @@ description: Learn how to create custom Script Canvas nodes in Open 3D Engine (O
 weight: 200
 ---
 
-Creating custom nodes in Script Canvas offers you maximum control and flexibility with the functionality of the node. You might wish to a create custom node in the following scenarios:
+Creating custom nodes in Script Canvas offers you maximum control and flexibility with the functionality of the node. You might wish to create a custom node in the following scenarios:
 
 * When your node has state, time, or latent results.
 * When creating complex nodes.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed an issue regarding [Creating Custom Nodes](https://www.o3de.org/docs/user-guide/scripting/script-canvas/programmer-guide/custom-nodes/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1853 issue. 

* Changed Creating Custom Nodes in Script Canvas section - `You might wish to a create custom node in the following scenarios:` changed to `You might wish to create a custom node in the following scenarios:`.



### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
