### PR TITLE
Customizing the Entity Icon - fixing formatting

### DIFF
--- a/content/docs/user-guide/editor/entity-inspector-customize-icon.md
+++ b/content/docs/user-guide/editor/entity-inspector-customize-icon.md
@@ -13,6 +13,6 @@ You can also specify your own icon.
 
 1. Choose **Set custom icon**.
 
-!['Set custom icon' menu item](/images/user-guide/component/entity_system/component-working-customize.png)
+   !['Set custom icon' menu item](/images/user-guide/component/entity_system/component-working-customize.png)
 
 1. Select an icon from your game project directory.


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Customizing the Entity Icon](https://www.o3de.org/docs/user-guide/editor/entity-inspector-customize-icon/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1862 issue. 

* Changed To customize an entity icon section - The numbered list increments correctly after the image.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
