### PR TITLE
Audio RTPC Component - Added a table to the Properties section, and bolded names in the EBus table

### DIFF
--- a/content/docs/user-guide/components/reference/audio/rtpc.md
+++ b/content/docs/user-guide/components/reference/audio/rtpc.md
@@ -11,10 +11,9 @@ The **Audio RTPC** component provides basic [Real-Time Parameter Control (RTPC)]
 
 ## Audio RTPC Component Properties
 
-The **Audio RTPC** component has the following property:
-
-**Default Rtpc**
-Enter the name of the audio RTPC to use by default. You can associate any RTPC name with the entity, typically one that is meant to affect a particular trigger.
+| Name | Description | Default |
+|------|-------------|---------|
+| **Default Rtpc** | Enter the name of the audio RTPC to use by default. You can associate any RTPC name with the entity, typically one that is meant to affect a particular trigger. | `<Empty>` |
 
 ## EBus Request Bus Interface
 
@@ -24,5 +23,5 @@ For more information about using the Event Bus (EBus) interface, see [Working wi
 
 | Name | Description | Parameters | Return | Scriptable |
 |------|-------------|------------|--------|------------|
-| SetValue | Sets the value of the default RTPC. | `value` - Float value of the RTPC | None | Yes |
-| SetRtpcValue | Sets the value of the specified RTPC. | `rtpcName` - Name of the RTPC to set; `value` - Float value to set | None | Yes |
+| **SetValue** | Sets the value of the default RTPC. | `value` - Float value of the RTPC | None | Yes |
+| **SetRtpcValue** | Sets the value of the specified RTPC. | `rtpcName` - Name of the RTPC to set; `value` - Float value to set | None | Yes |


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* Audio RTPC Component (https://www.o3de.org/docs/user-guide/components/reference/audio/rtpc/):
   * Adjusted the "Audio RTPC Component Properties" section to contain a table, similar to https://www.o3de.org/docs/user-guide/components/reference/audio/multi-position/#multi-position-audio-properties.
   * Bolded names of the Properties, and EBus section tables.

This Pull Request is submitted as a fix to the https://github.com/o3de/o3de.org/pull/1869.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?