### PR TITLE
Audio Switch Component - Added a table to the properties section and bolded names in the EBus table

### DIFF
--- a/content/docs/user-guide/components/reference/audio/switch.md
+++ b/content/docs/user-guide/components/reference/audio/switch.md
@@ -11,13 +11,10 @@ The **Audio Switch** component provides basic [Audio Translation Layer (ATL)](/d
 
 ## Audio Switch Properties
 
-The Audio Switch component has the following properties:
-
-**Default Switch**
-Enter the name of the audio switch to use by default. You can associate any audio switch with the entity.
-
-**Default State**
-Enter the name of the audio switch state to use by default. Use the [Audio Controls Editor](/docs/user-guide/interactivity/audio/audio-controls-editor) to assign the state to the switch. When this component is activated, the default switch is set to the default state.
+| Name | Description | Default |
+|------|-------------|---------|
+| **Default Switch** | Enter the name of the audio switch to use by default. You can associate any audio switch with the entity. | `<Empty>` |
+| **Default State** | Enter the name of the audio switch state to use by default. Use the [Audio Controls Editor](/docs/user-guide/interactivity/audio/audio-controls-editor) to assign the state to the switch. When this component is activated, the **Default Switch** is set to the **Default State**. | `<Empty>` |
 
 ## EBus Request Bus Interface
 
@@ -27,5 +24,5 @@ For more information about using the Event Bus (EBus) interface, see [Working wi
 
 | Name | Description | Parameters | Return | Scriptable |
 |------|-------------|------------|--------|------------|
-| SetState | Sets the specified state of the default switch. | `stateName` - Name of the state to set  | None | Yes |
-| SetSwitchState | Sets a specified switch to a specified state. | `switchName` - Name of the switch to set; `stateName` - Name of the state to set | None | Yes |
+| **SetState** | Sets the specified state of the default switch. | `stateName` - Name of the state to set  | None | Yes |
+| **SetSwitchState** | Sets a specified switch to a specified state. | `switchName` - Name of the switch to set; `stateName` - Name of the state to set | None | Yes |


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.
    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* Audio Switch Component (https://www.o3de.org/docs/user-guide/components/reference/audio/switch/):
   * Adjusted the "Audio Switch Component Properties" section to contain a table, similar to https://www.o3de.org/docs/user-guide/components/reference/audio/multi-position/#multi-position-audio-properties.
   * Bolded names of the Properties and EBus section tables.

This Pull Request is submitted as a fix to the https://github.com/o3de/o3de.org/pull/1871.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?