### PR TITLE
add previewer popout-overlay shortcode

### DIFF
--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -425,6 +425,7 @@ You can add inline O3DE GUI icons with the `icon` shortcode. Icon `.svg` files a
 | picker.svg | {{< icon "picker.svg" >}} |
 | pin-button.svg | {{< icon "pin-button.svg" >}} |
 | play.svg | {{< icon "play.svg" >}} |
+| popout-overlay.svg | {{< icon "popout-overlay.svg" >}} |
 | prefab.svg | {{< icon "prefab.svg" >}} |
 | prefab-edit.svg | {{< icon "prefab-edit.svg" >}} |
 | processing.svg | {{< icon "processing.svg" >}} |

--- a/static/images/icons/popout-overlay.svg
+++ b/static/images/icons/popout-overlay.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="4" fill="black"/>
+<path d="M19.022 5.99296H12.9085L14.9117 7.98131L11.8995 10.949L14.0214 13.1006L17.0039 10.0884L19.022 12.1064V5.99296Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.0015 3H9V16H22.0015V3ZM20 5H11V14H20V5Z" fill="white"/>
+<path d="M7 12H5V20H13.0031V18H15V22H3V10H7V12Z" fill="white"/>
+</svg>


### PR DESCRIPTION
Add shortcode for a new previewer / popout-overlay.svg used for image and gradient components.

{{< icon "popout-overlay.svg" >}}

Fix #1877 