### PR TITLE
Error Messages in Dialogs - fixing errors

### DIFF
--- a/content/docs/tools-ui/ux-patterns/error/components/dialogs.md
+++ b/content/docs/tools-ui/ux-patterns/error/components/dialogs.md
@@ -17,7 +17,7 @@ toc: true
 
 3. **Icon**: A standard icon and has a size of 48 x 48px. Refer to [Standard Icons](../overview#standard-icons). 
 
-4. **Body**: Contains information regrding the user's task and how to resolve it. 
+4. **Body**: Contains information regarding the user's task and how to resolve it. 
 
 5. **Actions**: The primary and optional secondary call-to-action buttons that resolve or exit the dialog.
 
@@ -49,7 +49,7 @@ Review these specifications when creating a dialog:
 
 * Include a primary button and/or an optional secondary button for the dialog's actions. 
   
-  * Use the primary button for a primary action. Primary buttons are have a blue background, making it more distinct to the user. Write an actionable text on the primary button such as "Save", "Restart", or "Open". 
+  * Use the primary button for a primary action. Primary buttons have a blue background, making it more distinct to the user. Write an actionable text on the primary button such as "Save", "Restart", or "Open". 
 
 * Use the secondary button for alternative options or passive actions such as "Cancel" or "OK".
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Error Messages in Dialogs](https://www.o3de.org/docs/tools-ui/ux-patterns/error/components/dialogs/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1897 issue. 

* Structure of a dialog section - `Contains information regrding the user’s task and how to resolve it.` - `regrding` changed to `regarding`.
* Specifications section - `Primary buttons are have a blue background...` - `are` deleted


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
