### PR TITLE
Error Messages in Inline Notifications - fixing errors

### DIFF
--- a/content/docs/tools-ui/ux-patterns/error/components/inline-notifications.md
+++ b/content/docs/tools-ui/ux-patterns/error/components/inline-notifications.md
@@ -14,7 +14,7 @@ Inline notifications are non-disruptive messages that are confined to a specific
 
 Review these specifications when creating an inline notification:
 
-* Persistantly display inline notifications until the user dismisses them or until the issue is resolved.
+* Persistently display inline notifications until the user dismisses them or until the issue is resolved.
 
 * Write clear and concise messages. One line is recommended.
 
@@ -78,7 +78,7 @@ Inline notifications in component cards are displayed to indicate an error/failu
 
 ### Specifications
 
-* Persistantly display inline notifications in the component cards until the issue is resolved.
+* Persistently display inline notifications in the component cards until the issue is resolved.
 
 * Avoid stacking multiple inline messages horizontally or vertically. Instead, display the messages one after the other as the user resolves each issue.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Error Messages in Inline Notifications](https://www.o3de.org/docs/tools-ui/ux-patterns/error/components/inline-notifications/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1898 issue. 

* Specifications section - `Persistantly display inline notifications until the user dismisses them or until the issue is resolved.` - `Persistantly` changed to `Persistently`.
* Inline notifications in component cards section - `Persistantly display inline notifications in the component cards until the issue is resolved.` - `Persistantly` changed to `Persistently`.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
