### PR TITLE
Error Messages in Toasts - fixing errors

### DIFF
--- a/content/docs/tools-ui/ux-patterns/error/components/toasts.md
+++ b/content/docs/tools-ui/ux-patterns/error/components/toasts.md
@@ -6,7 +6,7 @@ weight: 600
 toc: true
 ---
 
-In O3DE, *toasts* are non-disruptive notifications that are displayed ovre most elements in a page on the bottom-right corner of the window. They are non-distruptive because they can be displayed in the middle of a user's workflow without hindering the user's actions.
+In O3DE, *toasts* are non-disruptive notifications that are displayed over most elements in a page on the bottom-right corner of the window. They are non-distruptive because they can be displayed in the middle of a user's workflow without hindering the user's actions.
 
 The following example demonstrates a toast that appears at the bottom-right corner of the **O3DE Animation Editor** window.
 
@@ -69,7 +69,7 @@ Review these specifications when creating a toast:
 
 Toasts that contain links in the subtitle text must do the following:
 
-* Persistantly display and don't automatically disappear, unlike a standard toast.
+* Persistently display and don't automatically disappear, unlike a standard toast.
 
 * Display a manual close button.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Error Messages in Toasts](https://www.o3de.org/docs/tools-ui/ux-patterns/error/components/toasts/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1899 issue. 

* Error Messages in Toasts section - `In O3DE, toasts are non-disruptive notifications that are displayed ovre most elements...` - `ovre` changed to `over`.
* Toasts with links section - `Persistantly display and don’t automatically disappear, unlike a standard toast.` - `Persistantly` changed to `Persistently`.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
