### PR TITLE
Atom Renderer - fixing errors

### DIFF
--- a/content/docs/atom-guide/_index.md
+++ b/content/docs/atom-guide/_index.md
@@ -9,7 +9,7 @@ guide_img: "/images/atom-guide/guide_img.png"
 primary: false
 ---
 
-Welcome to the Atom Documentation! Atom Renderer is the graphics engine powering **Open 3D Engine (O3DE)**. Check out the video below for a quick overview of some of Atom's features. Then, read on learn more about creating beautiful, high performance graphics with Atom!
+Welcome to the Atom Documentation! Atom Renderer is the graphics engine powering **Open 3D Engine (O3DE)**. Check out the video below for a quick overview of some of Atom's features. Then, read on to learn more about creating beautiful, high performance graphics with Atom!
 
 {{< youtube-width id="GTJ_ie7yHdI" title="Atom Renderer" >}}
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Atom Renderer](https://www.o3de.org/docs/atom-guide/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/1909 issue. 

* Atom Renderer section - `Then, read on learn more about creating beautiful, high performance graphics with Atom!` - `Then, read on learn more` changed to `Then, read on to learn more`.


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
