### PR TITLE
Add documentation on AzNetworking Serialization cvar

### DIFF
--- a/content/docs/user-guide/networking/settings.md
+++ b/content/docs/user-guide/networking/settings.md
@@ -133,7 +133,7 @@ These settings control networking behavior.
 | net_UdpIgnoreWin10054               | If true, will ignore 10054 socket errors on windows.                                                                                | True            |                      |
 | net_UdpRecvBufferSize               | Default UDP socket receive buffer size.                                                                                             | 1 * 1024 * 1024 |                      |
 | net_UdpSendBufferSize               | Default UDP socket send buffer size.                                                                                                | 1 * 1024 * 1024 |                      |
-
+| net_validateSerializedTypes         | Causes an Assert when a TypeValidatingSerializer serialization attempt results in a type or variable name mismatch. | False   | Increases bandwidth utilization to support mismatch detection.   |
 ### Multiplayer layer
 | Setting                             | Description                                                                          | Default | Notes                    |
 |-------------------------------------|--------------------------------------------------------------------------------------|---------|--------------------------|

--- a/content/docs/user-guide/networking/settings.md
+++ b/content/docs/user-guide/networking/settings.md
@@ -134,6 +134,7 @@ These settings control networking behavior.
 | net_UdpRecvBufferSize               | Default UDP socket receive buffer size.                                                                                             | 1 * 1024 * 1024 |                      |
 | net_UdpSendBufferSize               | Default UDP socket send buffer size.                                                                                                | 1 * 1024 * 1024 |                      |
 | net_validateSerializedTypes         | Causes an Assert when a TypeValidatingSerializer serialization attempt results in a type or variable name mismatch. | False   | Increases bandwidth utilization to support mismatch detection.   |
+
 ### Multiplayer layer
 | Setting                             | Description                                                                          | Default | Notes                    |
 |-------------------------------------|--------------------------------------------------------------------------------------|---------|--------------------------|

--- a/content/docs/user-guide/networking/settings.md
+++ b/content/docs/user-guide/networking/settings.md
@@ -133,7 +133,7 @@ These settings control networking behavior.
 | net_UdpIgnoreWin10054               | If true, will ignore 10054 socket errors on windows.                                                                                | True            |                      |
 | net_UdpRecvBufferSize               | Default UDP socket receive buffer size.                                                                                             | 1 * 1024 * 1024 |                      |
 | net_UdpSendBufferSize               | Default UDP socket send buffer size.                                                                                                | 1 * 1024 * 1024 |                      |
-| net_validateSerializedTypes         | Causes an Assert when a TypeValidatingSerializer serialization attempt results in a type or variable name mismatch. | False   | Increases bandwidth utilization to support mismatch detection.   |
+| net_validateSerializedTypes         | Causes an Assert when an attempt at `TypeValidatingSerializer` serialization results in a type or variable name mismatch. | False   | Increases bandwidth utilization to support mismatch detection.   |
 
 ### Multiplayer layer
 | Setting                             | Description                                                                          | Default | Notes                    |


### PR DESCRIPTION
Signed-off-by: puvvadar <puvvadar@amazon.com>

## Change summary

This change adds detail on the cvar `net_validateSerializedTypes`. This cvar is not currently implemented in main but the cvar page is not yet available in development so it was suggested I merge to main in the interim.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

