### PR TITLE
Terrain World Component - Fixed text syntax

### DIFF
--- a/content/docs/user-guide/components/reference/terrain/world.md
+++ b/content/docs/user-guide/components/reference/terrain/world.md
@@ -21,15 +21,15 @@ You must add this component to the *Level* entity, the parent of all entities in
 
 | Property | Description | Values | Default |
 | - | - | - | - |
-| Min Height | The minimum value for the height of terrain. The **Min Height** value must be less than the **max Height** value. | -65536.0 - 65536.0 | `0.0` |
+| Min Height | The minimum value for the height of terrain. The **Min Height** value must be less than the **Max Height** value. | -65536.0 - 65536.0 | `0.0` |
 | Max Height | The maximum value for the worlds bounds. The **Max Height** value must be greater than the **Min Height** value. | -65536.0 - 65536.0 | `1024.0` |
-| Height Query Resolution (m) | The distance between each height sample position, in meters. | 0.1 to Infinity | `1.0` |
-| Surface Data Query Resolution (m) | The distance between each surface data sample position, in meters. | 0.1 to Infinity | `1.0` |
+| Height Query Resolution (m) | The distance between each height sample position, in meters. | 0.1 - Infinity | `1.0` |
+| Surface Data Query Resolution (m) | The distance between each surface data sample position, in meters. | 0.1 - Infinity | `1.0` |
 
 
 ## Usage 
 
-We recommend that you set the **Min Height** and **Max Height** bounds to as small of a range as possible,  to achieve more accurate height values . The terrain renderer uses 16-bit height values, which provides 65536 possible distinct heights. To get the resolution, calculate: (Max Height - Min Height) / 65536. So, if the height range is 1 km, then the resolution is about 1.5 cm. This results in finer height detail. 
+We recommend that you set the **Min Height** and **Max Height** bounds to as small of a range as possible,  to achieve more accurate height values . The terrain renderer uses 16-bit height values, which provides 65536 possible distinct heights. To get the resolution, calculate: (**Max Height** - **Min Height**) / 65536. So, if the height range is 1 km, then the resolution is about 1.5 cm. This results in finer height detail. 
 
 **Height Query Resolution** and **Surface Data Query Resolution** are used to define consistent spacing, centered at the origin, for terrain height and surface queries across the entire world. Different systems that use terrain data, such as physics and rendering, can also use these conceptual grids to make implementation decisions about how to best use the terrain data. By default, the terrain system queries the input data only at points aligned to the grid. This creates a consistent view of the input data. However, you can author or generate input data to the terrain system at any resolution. Since the input data is only used at these resolutions, we recommend that input gradients that have quantized source data, like images, match the appropriate query resolution.
 


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* Terrain World Component (https://www.o3de.org/docs/user-guide/components/reference/terrain/world/):
   * Terrain World Properties - Fixed letter case in the Min Height property description.
   * Terrain World Properties - Changed the "to" to "-" in the Height Query Resolution (m), and Surface Data Query Resolution (m) Values to remain consistent with other similar numeric values.
   * Usage - Bolded a Max Height, and Min Height mention.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?