### PR TITLE
add links to guides to contributing overview

### DIFF
--- a/content/docs/contributing/to-code/overview.md
+++ b/content/docs/contributing/to-code/overview.md
@@ -13,3 +13,5 @@ Looking to contribute new or changed code to **Open 3D Engine (O3DE)**? The link
 | [GitHub Workflow](git-workflow.md) | Learn how to work with Git to start contributing. |
 | [O3DE Fix Validation Issues](validation-errors.md) | How to use the O3DE validation tool. |
 | [O3DE C++ Coding Standards](https://github.com/o3de/sig-core/blob/main/governance/Coding-Standards-and-Style-Guide.md) | Follow the coding standards used throughout O3DE's C++ codebase. |
+| [O3DE Code Review Guidelines](https://github.com/o3de/community/blob/main/guides/o3de-code-review-guidelines.md) | Guidance for change authors and code reviewers when contributing PRs to O3DE. |
+| [O3DE Deprecation Guidelines](https://github.com/o3de/community/blob/main/guides/o3de-deprecation-guidelines.md) | Guidance for if you want to change or remove a feature or API in O3DE. |

--- a/content/docs/contributing/to-code/overview.md
+++ b/content/docs/contributing/to-code/overview.md
@@ -14,4 +14,4 @@ Looking to contribute new or changed code to **Open 3D Engine (O3DE)**? The link
 | [O3DE Fix Validation Issues](validation-errors.md) | How to use the O3DE validation tool. |
 | [O3DE C++ Coding Standards](https://github.com/o3de/sig-core/blob/main/governance/Coding-Standards-and-Style-Guide.md) | Follow the coding standards used throughout O3DE's C++ codebase. |
 | [O3DE Code Review Guidelines](https://github.com/o3de/community/blob/main/guides/o3de-code-review-guidelines.md) | Guidance for change authors and code reviewers when contributing PRs to O3DE. |
-| [O3DE Deprecation Guidelines](https://github.com/o3de/community/blob/main/guides/o3de-deprecation-guidelines.md) | Guidance for if you want to change or remove a feature or API in O3DE. |
+| [O3DE Deprecation Guidelines](https://github.com/o3de/community/blob/main/guides/o3de-deprecation-guidelines.md) | Guidance for changing or removing a feature (and/or API) in O3DE. |


### PR DESCRIPTION
## Change summary

Add links to contribution guides (https://github.com/o3de/community/blob/main/guides/o3de-deprecation-guidelines.md and https://github.com/o3de/community/blob/main/guides/o3de-code-review-guidelines.md) (suggested by @chanmosq)