### PR TITLE
HttpRequestor: Add instructions about creating dependency on gem and deactivting EC2 IMDS

### DIFF
--- a/content/docs/user-guide/gems/reference/network/http-requestor.md
+++ b/content/docs/user-guide/gems/reference/network/http-requestor.md
@@ -39,7 +39,7 @@ void AutomatedTestingSystemComponent::GetRequiredServices(AZ::ComponentDescripto
 
 ### Turn off AWS EC2 Instance Metadata Service calls
 
-The HttpRequestor gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) under-the-hood to provide the Http(s) client. The code is configured to not require any AWS credentials or account information.
+The HttpRequestor Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to provide the Http(s) client. You don't need to provide AWS credentials or account information to use this Gem.
 
 However, if you are not running on AWS EC2 compute its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp#L104) environment variable. This will prevent any reach out the AWS EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. Requests to EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
 

--- a/content/docs/user-guide/gems/reference/network/http-requestor.md
+++ b/content/docs/user-guide/gems/reference/network/http-requestor.md
@@ -11,7 +11,7 @@ The HTTPRequestor Gem provides functionality to make asynchronous HTTP/HTTPS req
 This feature is currently supported only on Windows, it could be expanded to other platforms.
 {{< /note >}}
 
-## Getting Started
+## Getting started
 
 To use the HttpRequestor Gem, it must be enabled in the project. For more information refer to [Adding and Removing Gems in a Project](/docs/user-guide/project-config/add-remove-gems/).
 
@@ -24,6 +24,29 @@ BUILD_DEPENDENCIES
             Gem::HttpRequestor
             3rdParty::AWSNativeSDK::Core
 ```
+
+### Create a dependency on the Gem
+
+If you need to ensure the HttpRequestor Gem is enabled before its use in a component, add a requirement in your component's `GetRequiredServices` method. For example:
+
+```cpp
+void AutomatedTestingSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+{
+   ...
+   required.push_back(AZ_CRC_CE("HttpRequestorService"));
+}
+```
+
+### Turn off AWS EC2 Instance Metadata Service calls
+
+The HttpRequestor gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) under-the-hood to provide the Http(s) client. The code is configured to not require any AWS credentials or account information.
+
+However, if you are not running on AWS EC2 compute its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp#L104) environment variable. This will prevent any reach out the AWS EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. Requests to EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
+
+```
+set AWS_EC2_METADATA_DISABLED=true
+```
+
 
 ## C\+\+ API
 
@@ -151,11 +174,11 @@ HttpRequestor::HttpRequestorRequestBus::Broadcast(
     {
         if (responseCode == Aws::Http::HttpResponseCode::OK)
         {
-            AZ_Printf("HttpRequest Demo",  "Call succeed with %s %d", data.WriteCompact().c_str(), responseCode);
+            AZ_Printf("HttpRequestExample",  "Call succeed with %s %d", data.WriteCompact().c_str(), responseCode);
         }
         else
         {
-            AZ_Printf("HttpRequestDemo", "Request Failed!");
+            AZ_Printf("HttpRequestExample", "Request Failed!");
         }
     });
 ```

--- a/content/docs/user-guide/gems/reference/network/http-requestor.md
+++ b/content/docs/user-guide/gems/reference/network/http-requestor.md
@@ -41,7 +41,7 @@ void AutomatedTestingSystemComponent::GetRequiredServices(AZ::ComponentDescripto
 
 The HttpRequestor Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to provide the Http(s) client. You don't need to provide AWS credentials or account information to use this Gem.
 
-However, if you are not running on AWS EC2 compute its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp#L104) environment variable. This will prevent any reach out the AWS EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. Requests to EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
+However, if your project is not running on Amazon EC2 compute, it's recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. This will prevent any calls to the Amazon EC2 Instance Metadata Service (IMDS) from attempting to retrieve configuration, region, and credential information. Requests to IMDS will fail if you are not using EC2, leading to delays and wasted network resources.
 
 ```
 set AWS_EC2_METADATA_DISABLED=true

--- a/content/docs/user-guide/gems/reference/network/http-requestor.md
+++ b/content/docs/user-guide/gems/reference/network/http-requestor.md
@@ -37,7 +37,7 @@ void AutomatedTestingSystemComponent::GetRequiredServices(AZ::ComponentDescripto
 }
 ```
 
-### Turn off AWS EC2 Instance Metadata Service calls
+### Turn off Amazon EC2 Instance Metadata Service calls
 
 The HttpRequestor Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to provide the Http(s) client. You don't need to provide AWS credentials or account information to use this Gem.
 


### PR DESCRIPTION
Updated version of https://github.com/o3de/o3de.org/pull/1959

* Add documentation around dependency setup, asked for in https://github.com/o3de/o3de.org/issues/1920
     * Retargets for stabilization this PR that originally had changes https://github.com/o3de/o3de.org/pull/1959
* Adds note about preventing calls to EC2 metadata service, as reported in #sig-network chat.
     * Repeats information in https://github.com/o3de/o3de.org/pull/1991 so would be good to standardized language between the two changes (in this case probably need to repeat information as HttpRequestor is used by non AWS users, who will be surprised by the need to set this variable)

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

