### PR TITLE
AWSCore Gem: Add notice about deactivating AWS EC2 IMDS calls

### DIFF
--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -29,8 +29,8 @@ You should now be able to utilize AWS functions in Lua script, Script Canvas, or
 
 ## Prevent calls to Amazon EC2 Instance Metadata Service
 
-The Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
-This will prevent SDK resources from attempting to contact the Amazon EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. 
+AWS Gems use the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Unless your project is running on Amazon EC2 compute, it's recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
+Turning this setting off will prevent SDK resources from needlessly attempting to contact the Amazon EC2 Instance Metadata Service (IMDS) for configuration, region, and credential information, which can result in delays and wasted network resources.
 
 Requests to Amazon EC2 IMDS will fail on non Amazon EC2 compute leading to delays and wasted network resources.
 

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -14,6 +14,7 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
     a. Confirm you have credentials using the command `aws configure list`.
 
 1. Install the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install).
+
     a. Confirm the CDK is setup using the command `cdk --version`.
 
 1. **Build** your O3DE project with the AWS Core Gem (and other AWS Gems you need) enabled.

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -25,12 +25,12 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
 
 You should now be able to utilize AWS functions in Lua script, Script Canvas, or C++ to communicate with your AWS resources. See [Scripting with AWS Core](./scripting/) for scripting examples.
 
-## Prevent calls to AWS EC2 Instance Metadate Service
+## Prevent calls to Amazon EC2 Instance Metadate Service
 
-The Gem uses uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp#L104) environment variable. 
-This will prevent SDK resources attempting to contact the AWS EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. 
+The Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
+This will prevent SDK resources from attempting to contact the Amazon EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. 
 
-Requests to AWS EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
+Requests to Amazon EC2 IMDS will fail on non Amazon EC2 compute leading to delays and wasted network resources.
 
 ```
 # macOS / Linux
@@ -42,10 +42,6 @@ setx AWS_EC2_METADATA_DISABLED true
 # Windows (for just this session)
 set AWS_EC2_METADATA_DISABLED=true
 ```
-
-See the AWS guide on [How to set environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set) for more details.
-
-
 
 ## Project settings
 

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -32,8 +32,6 @@ This will prevent SDK resources attempting to contact the AWS EC2 Instance Metad
 
 Requests to AWS EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
 
-You can [set environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set) locally in the session as follows:
-
 ```
 # macOS / Linux
 export AWS_EC2_METADATA_DISABLED=true
@@ -44,6 +42,10 @@ setx AWS_EC2_METADATA_DISABLED true
 # Windows (for just this session)
 set AWS_EC2_METADATA_DISABLED=true
 ```
+
+See the AWS guide on [How to set environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set) for more details.
+
+
 
 ## Project settings
 

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -32,8 +32,6 @@ You should now be able to utilize AWS functions in Lua script, Script Canvas, or
 AWS Gems use the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Unless your project is running on Amazon EC2 compute, it's recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
 Turning this setting off will prevent SDK resources from needlessly attempting to contact the Amazon EC2 Instance Metadata Service (IMDS) for configuration, region, and credential information, which can result in delays and wasted network resources.
 
-Requests to Amazon EC2 IMDS will fail on non Amazon EC2 compute leading to delays and wasted network resources.
-
 ```
 # macOS / Linux
 export AWS_EC2_METADATA_DISABLED=true

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -10,11 +10,9 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
 1. [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you don't have one.
 
 1. Configure **AWS credentials** following the instructions in [Configuring AWS Credentials for O3DE](./configuring-credentials/).
-
     a. Confirm you have credentials using the command `aws configure list`.
 
 1. Install the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install).
-
     a. Confirm the CDK is setup using the command `cdk --version`.
 
 1. **Build** your O3DE project with the AWS Core Gem (and other AWS Gems you need) enabled.
@@ -26,6 +24,26 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
 1. Associate the resource mapping file with the project. See the next section entitled [Project Settings](#project-settings).
 
 You should now be able to utilize AWS functions in Lua script, Script Canvas, or C++ to communicate with your AWS resources. See [Scripting with AWS Core](./scripting/) for scripting examples.
+
+## Prevent calls to AWS EC2 Instance Metadate Service
+
+The Gem uses uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-core/source/client/ClientConfiguration.cpp#L104) environment variable. 
+This will prevent SDK resources attempting to contact the AWS EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. 
+
+Requests to AWS EC2 IMDS will fail on non EC2 compute leading to delays and wasted network resources.
+
+You can [set environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-set) locally in the session as follows:
+
+```
+# macOS / Linux
+export AWS_EC2_METADATA_DISABLED=true
+
+# Windows (for all sessions)
+setx AWS_EC2_METADATA_DISABLED true
+
+# Windows (for just this session)
+set AWS_EC2_METADATA_DISABLED=true
+```
 
 ## Project settings
 

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -10,6 +10,7 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
 1. [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you don't have one.
 
 1. Configure **AWS credentials** following the instructions in [Configuring AWS Credentials for O3DE](./configuring-credentials/).
+
     a. Confirm you have credentials using the command `aws configure list`.
 
 1. Install the [AWS Cloud Development Kit (CDK)](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html#getting_started_install).

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -29,8 +29,8 @@ You should now be able to utilize AWS functions in Lua script, Script Canvas, or
 
 ## Prevent calls to Amazon EC2 Instance Metadata Service
 
-AWS Gems use the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Unless your project is running on Amazon EC2 compute, it's recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
-Turning this setting off will prevent SDK resources from needlessly attempting to contact the Amazon EC2 Instance Metadata Service (IMDS) for configuration, region, and credential information, which can result in delays and wasted network resources.
+AWS Gems use the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Unless your project is running on Amazon EC2 compute, it's recommended that you turn off Amazon EC2 Instance Metadata Service (IMDS) queries by setting the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable to `true`. 
+Setting this environment variable will prevent SDK resources from needlessly attempting to contact the Amazon EC2 IMDS for configuration, region, and credential information, which can result in delays and wasted network resources.
 
 ```
 # macOS / Linux

--- a/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-core/getting-started.md
@@ -27,7 +27,7 @@ To get started using AWS Gems with AWS services in your O3DE project, complete t
 
 You should now be able to utilize AWS functions in Lua script, Script Canvas, or C++ to communicate with your AWS resources. See [Scripting with AWS Core](./scripting/) for scripting examples.
 
-## Prevent calls to Amazon EC2 Instance Metadate Service
+## Prevent calls to Amazon EC2 Instance Metadata Service
 
 The Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to call AWS resources. Its recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. 
 This will prevent SDK resources from attempting to contact the Amazon EC2 Instance Metadate Service (IMDS), which may occur to retrieve configuration, region and credential information. 


### PR DESCRIPTION
## Change summary

Add notice about deactivating AWS EC2 IMDS calls that may occur when searching for configuration and credential information. On non EC2 compute this will delay calls and waste resources and has to be prevented via an environment variable.

Relates to https://github.com/o3de/o3de.org/pull/1989 

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

