### PR TITLE
Lua Debugger: Add note that Remote tools gem must be active in project

### DIFF
--- a/content/docs/user-guide/scripting/lua/debugging-tutorial.md
+++ b/content/docs/user-guide/scripting/lua/debugging-tutorial.md
@@ -68,11 +68,15 @@ This tutorial shows you how to use O3DE Lua Editor to perform debugging operatio
     
 ## Connect to O3DE Editor
 
-The **Remote Tools Gem** facilitates local connections between O3DE applications. The Remote Tools Gem starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
+The [**Remote Tools Gem**](docs/user-guide/gems/reference/debug/remote-tools) facilitates local connections between O3DE applications. 
 
 {{< note >}}
+The **Remote Tools Gem** must be [enabled in your project](/docs/user-guide/project-config/add-remove-gems/#enabling-or-disabling-gems) for debugging to work.
+
 **Remote Tools Gem** behavior is disabled in release builds.
 {{< /note >}}
+
+The Remote Tools Gem starts automatically when Lua Editor is started and must be running in the background for Lua Editor to find targets it can connect to.  Because the debugging functionality is enabled through network sockets, you must connect Lua Editor to the target that is running the script before you can debug. In this tutorial, you connect to O3DE Editor.
 
 1. In the Lua Editor toolbar, choose **Target: None**, and then choose **Editor(*ID*)** to connect to O3DE Editor.
 


### PR DESCRIPTION
## Change summary

https://github.com/o3de/o3de/issues/12259 reported issues making Lua debugging work, but user did not appear to have Remote Tools Gem active. Adding explicit note that Gem must be active for functionality to work

Updating: https://development--o3deorg.netlify.app/docs/user-guide/scripting/lua/debugging-tutorial/

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>