### PR TITLE
HTTP Requestor Gem reference | guidance and formatting update

### DIFF
--- a/content/docs/user-guide/gems/reference/network/http-requestor.md
+++ b/content/docs/user-guide/gems/reference/network/http-requestor.md
@@ -8,7 +8,7 @@ toc: true
 The HTTPRequestor Gem provides functionality to make asynchronous HTTP/HTTPS requests and return data through a user-provided call back function.
 
 {{< note >}}
-This feature is currently supported only on Windows, it could be expanded to other platforms.
+While this feature is currently supported only on Windows, it could be expanded to other platforms.
 {{< /note >}}
 
 ## Getting started
@@ -17,7 +17,7 @@ To use the HttpRequestor Gem, it must be enabled in the project. For more inform
 
 The `HttpRequestor` Gem uses the AWS C++ SDK. To pick up these dependencies, add the following to the project's CMake file:
 
-```
+```cmake
 BUILD_DEPENDENCIES
         PRIVATE
             ...
@@ -41,20 +41,21 @@ void AutomatedTestingSystemComponent::GetRequiredServices(AZ::ComponentDescripto
 
 The HttpRequestor Gem uses the [AWS C++ SDK](https://github.com/aws/aws-sdk-cpp) to provide the Http(s) client. You don't need to provide AWS credentials or account information to use this Gem.
 
-However, if your project is not running on Amazon EC2 compute, it's recommended that you turn off the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable. This will prevent any calls to the Amazon EC2 Instance Metadata Service (IMDS) from attempting to retrieve configuration, region, and credential information. Requests to IMDS will fail if you are not using EC2, leading to delays and wasted network resources.
+Unless your project is running on Amazon EC2 compute, it's recommended that you turn off Amazon EC2 Instance Metadata Service (IMDS) queries by setting the [AWS_EC2_METADATA_DISABLED](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) environment variable to `true`.
+Setting this environment variable will prevent SDK resources from needlessly attempting to contact the Amazon EC2 IMDS for configuration, region, and credential information, which can result in delays and wasted network resources.
 
-```
+```cmd
 set AWS_EC2_METADATA_DISABLED=true
 ```
 
 
-## C\+\+ API
+## C++ API
 
 {{< note >}}
-This content is in the process of being moved to https://o3de.org/docs/api/gems/httprequestor/class_http_requestor_1_1_http_requestor_requests.html
+This content is in the process of being moved to the [API Reference](https://o3de.org/docs/api/gems/httprequestor/class_http_requestor_1_1_http_requestor_requests.html).
 {{< /note >}}
 
-The HttpRequestor Gem has two sets of APIs: one set for making requests that return json responses and one set for return string (text) responses.
+The HttpRequestor Gem has two sets of APIs: one set for making requests that return JSON responses and one set for return string (text) responses.
 
 ### AddRequest, AddRequestWithHeaders, AddRequestWithHeadersAndBody
 
@@ -62,15 +63,15 @@ Use the `AddRequest`, `AddRequestWithHeaders`, and `AddRequestWithHeadersAndBody
 
 #### Syntax
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddRequest, URI, method, callback)
 ```
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddRequestWithHeaders, URI, method, headers, callback)
 ```
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddRequestWithHeadersAndBody, URI, method, headers, body, callback)
 ```
 
@@ -80,7 +81,7 @@ Each add request method requires the URI, a method and a callback.
 
 | Parameter | Type | Description | 
 | --- | --- | --- | 
-| URI | `AZStd::String` | The fully qualified web address, in the following format: `scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]`  | 
+| URI | `AZStd::String` | The fully qualified web address, in the following format: `scheme:[//[user:password@]host[:port]][/]path[?query][#fragment]`.  | 
 | method | `Aws::Http::HttpMethod` | The method type. The following values are supported: `HTTP_GET`, `HTTP_POST`, `HTTP_DELETE`, `HTTP_PUT`, `HTTP_HEAD`, and `HTTP_PATCH`. | 
 | callback | [see below](#json-request-callback) | This function is called when the HTTP request is completed. The response body and code are present in the callback. | 
 | headers | `HttpRequestor::Headers` | The list of header fields for the HTTP request. | 
@@ -92,7 +93,7 @@ Return: No return value.
 
 This callback is returned for the `AddRequest`, `AddRequestWithHeaders`, and `AddRequestWithHeadersAndBody` methods.
 
-```
+```cpp
 void Callback(const Aws::Utils::Json::JsonValue& json, Aws::Http::HttpResponseCode responseCode);
 ```
 
@@ -112,15 +113,15 @@ Use the `AddTextRequest`, `AddTextRequestWithHeaders`, and `AddTextRequestWithHe
 
 #### Syntax
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddTextRequest, URI, method, callback)
 ```
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddTextRequestWithHeaders, URI, method, headers, callback)
 ```
 
-```
+```cpp
 HttpRequestor::HttpRequestorRequestBus::Broadcast(&HttpRequestor::HttpRequestorRequests::AddTextRequestWithHeadersAndBody, URI, method, headers, body, callback)
 ```
 
@@ -143,7 +144,7 @@ Each add text request method requires the URI, a method and a callback.
 
 This callback is returned for the `AddTextRequest`, `AddTextRequestWithHeaders` and `AddTextRequestWithHeadersAndBody` methods.
 
-```
+```cpp
 void Callback(const AZStd::string& response, Aws::Http::HttpResponseCode responseCode);
 ```
 
@@ -159,9 +160,9 @@ void Callback(const AZStd::string& response, Aws::Http::HttpResponseCode respons
 
 ## Example
 
-The following example shows calling a HttpBin to get the origin ip address:
+The following example shows calling a HttpBin to get the origin IP address:
 
-```
+```cpp
 #include <aws/core/http/HttpResponse.h>
 #include <HttpRequestor/HttpRequestorBus.h>
 #include <HttpRequestor/HttpTypes.h>


### PR DESCRIPTION
Signed-off-by: Willow Hayward <17654918+willihay@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

- Revise wording on use of AWS_EC2_METADATA_DISABLED environment variable.
- Formatting improvements.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

@netlify /docs/user-guide/gems/reference/network/http-requestor