### PR TITLE
Changes for Material Types and Shaders documentation

### DIFF
--- a/content/docs/learning-guide/tutorials/rendering/get-started-materialtypes-and-shaders.md
+++ b/content/docs/learning-guide/tutorials/rendering/get-started-materialtypes-and-shaders.md
@@ -5,7 +5,8 @@ description: "Create a new material type and shader in the Atom renderer."
 toc: true
 ---
 
-In this tutorial, you will create a new material type with a simple, unlit color shader.  This tutorial covers the following key concepts:
+In this tutorial, you will create a new material type with a simple, unlit color shader. This tutorial covers the following key concepts:
+
 - Files needed for creating materials and shaders.
 - Basic shader programming concepts in **AZSL**, including Shader Resource Groups.
 - Creating shader asset files.
@@ -13,21 +14,18 @@ In this tutorial, you will create a new material type with a simple, unlit color
 - Debugging shaders with **Asset Processor**.
 
 ## 1. Set up the files
-The process of developing a combination of shaders and materials that create an appearance for a surface is called *look development*. For Atom renderer, this process requires several interdependent files including the following: 
-- `.azsl`: This file contains AZSL shader code. The AZSL shader code includes  Shader Resource Groups, shader inputs and outputs, and shader programs.
+
+The process of developing a combination of shaders and materials that create an appearance for a surface is called _look development_. For Atom renderer, this process requires several interdependent files including the following:
+
+- `.azsl`: This file contains AZSL shader code. The AZSL shader code includes Shader Resource Groups, shader inputs and outputs, and shader programs.
 - `.shader`: This file contains data that describes the shader asset and is structured in JSON format. It references the `.azsl` file and configures the **AZSLc** shader compiler.
 - `.materialtype`: This file contains material type data, and is structured in JSON format. A material type references one or more `.shader` files to create an appearance, defines properties for the material type, and links the material type properties to variables in the referenced shaders.
-- `.material`: This file contains material data and is structured in JSON format. Materials must be created from a material type. Materials inherit the material type's properties and shaders. These properties' values are set in the `.material` file, describing the look of the material. Materials can be created using the Material Editor. 
+- `.material`: This file contains material data and is structured in JSON format. Materials must be created from a material type. Materials inherit the material type's properties and shaders. These properties' values are set in the `.material` file, describing the look of the material. Materials can be created using the Material Editor.
 
 **Asset Processor** compiles run-time assets from these files. When a new asset file is saved to disk, or an existing asset file is modified, **Asset Processor** automatically detects the change and processes the files. For **Asset Processor** to detect new or updated files, the files must exist in a subdirectory of your project, or in a directory **Asset Processor** is monitoring. For this tutorial, use a project subdirectory named `Materials`.
 
-{{< note >}}
-To specify a directory outside of your project for **Asset Processor** to monitor, you can edit the `AssetProcessorPlatformConfig.ini` located in the root of your project directory.
-
-Assets such as shaders and materials can be distributed in Gems. Check the Gems included with your project for additional material and shader asset files.
-{{< /note >}}
-
 In the `Materials` subdirectory of your project, create the following files:
+
 - `MyUnlitColor.azsl`
 - `MyUnlitColor.shader`
 - `MyUnlitColor.materialtype`
@@ -37,119 +35,134 @@ The `.material` file is created using **Material Editor** later in the tutorial.
 {{< /note >}}
 
 ## 2. Author AZSL Shader Code (.azsl)
+
 First, you are going to write AZSL shader code in the `MyUnlitColor.azsl` file. The AZSL shader contains the following components:
+
 - #include directives
 - Shader Resource Groups (SRGs)
 - Vertex and fragment shader inputs and outputs
 - Vertex and fragment shader programs
 
 #### Includes
-At the very top of the file are a set of `#include` directives. A shader program can use shared Shader Resource Groups (SRGs) and reusable AZSL code, which are contained in .srgi and .azsli files. 
+
+At the very top of the file are a set of `#include` directives. A shader program can use shared Shader Resource Groups (SRGs) and reusable AZSL code, which are contained in .srgi and .azsli files.
 
 For this tutorial, you need the following #include directives:
 
-* `viewsrg.srgi`: Defines a shared view SRG.
-* `DefaultObjectSrg.azsli`: Defines an object SRG.
-* `ForwardPassOutput.azsli`: Defines a ForwardPassOutput struct. 
-* `SrgSemantics.azsl`: Defines SRG semantics. Anytime you want to define an SRG, the SRG must inherit from an SRG semantic. 
+- `viewsrg.srgi`: Defines a shared view SRG.
+- `DefaultObjectSrg.azsli`: Defines an object SRG.
+- `ForwardPassOutput.azsli`: Defines a ForwardPassOutput struct.
+- `SrgSemantics.azsl`: Defines SRG semantics. Anytime you want to define an SRG, the SRG must inherit from an SRG semantic.
 
 To use #include directives, add the following code in the `MyUnlitColor.azsl` file:
 
-```glsl
+```cpp
 #include <viewsrg.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/PBR/ForwardPassOutput.azsli>
 #include <Atom/Features/SrgSemantics.azsli>
 ```
 
-Next, you will learn about these referenced SRGs: what they are, how they are used throughout your shader code, and how to define a new SRG. 
+Next, you will learn about these referenced SRGs: what they are, how they are used throughout your shader code, and how to define a new SRG.
 
 #### Shader Resource Groups
+
 Throughout a shader program, you need to store, use, and pass constant data. In AZSL, this is handled through Shader Resource Groups (SRGs). SRGs contain shader resources and uniforms that can be shared throughout the system. SRGs are bound to a specific frequency (such as per frame view, per object, per material, and more). They are designed to be shared across multiple shaders, so a single material type can only define one material SRG.
 
-In this tutorial, MyUnlitColor.azsl uses the following SRGs:  
+In this tutorial, MyUnlitColor.azsl uses the following SRGs:
 
-* ViewSrg:  This is provided by _viewsrg.srgi_. ViewSrg contains data related to the camera changes (such as view, projection, inverse viewProjection matrices, and culling frustum). 
-* ObjectSrg:  This is provided by _DefaultObjectSrg.azsli_. ObjectSrg contains data that is specific for the object or geometry being rendered (such as the object's position).
-* MaterialSrg:  This is defined in this _.azsl_ file and contains data that is specific to the material type.
+- ViewSrg: This is provided by _viewsrg.srgi_. ViewSrg contains data related to the camera changes (such as view, projection, inverse viewProjection matrices, and culling frustum).
+- ObjectSrg: This is provided by _DefaultObjectSrg.azsli_. ObjectSrg contains data that is specific for the object or geometry being rendered (such as the object's position).
+- MaterialSrg: This is defined in this _.azsl_ file and contains data that is specific to the material type.
 
 #### Defining a Material SRG
-Next, you need to define a material SRG to store data that needs to be updated at a per-material frequency. A material SRG must inherit an `SRG_PerMaterial` semantic. `SRG_PerMaterial` contains data specific to the material. In this tutorial, you want to configure a single color of the material, so the material SRG must contain a variable to hold the color value. 
 
-As shown in the following code, define an SRG, `UnlitColorSrg` that inherits from `SRG_PerMaterial`. Then, define variable `m_unlitColor` that will hold a color value. 
+Next, you need to define a material SRG to store data that needs to be updated at a per-material frequency. A material SRG must inherit an `SRG_PerMaterial` semantic. `SRG_PerMaterial` contains data specific to the material. In this tutorial, you want to configure a single color of the material, so the material SRG must contain a variable to hold the color value.
 
-```hlsl
+As shown in the following code, define an SRG, `UnlitColorSrg` that inherits from `SRG_PerMaterial`. Then, define variable `m_unlitColor` that will hold a color value.
+
+```cpp
 ShaderResourceGroup UnlitColorSrg : SRG_PerMaterial
 {
     float3 m_unlitColor;
 }
 ```
+
 {{< note >}}
 The `MyUnlitColor.materialtype` file must establish a connection between `m_unlitColor` and the color property. You will do this later in the tutorial.
 {{< /note >}}
 
-Next, you're going to write the vertex and fragment shaders that use these SRGs. 
+Next, you're going to write the vertex and fragment shaders that use these SRGs.
 
 #### Defining Vertex and Fragment Shaders
-In this step 
-Shaders are only one part of the render pipeline – they must have inputs and outputs to pass constant data and communicate with the rest of the pipeline. Writing shader programs in AZSL follows similar practices as in HLSL (see [Microsoft DirectX HLSL documentation](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl)). 
 
-Shader inputs and outputs can be defined via input/output variables or via a structure containing them. 
+In this step
+Shaders are only one part of the render pipeline – they must have inputs and outputs to pass constant data and communicate with the rest of the pipeline. Writing shader programs in AZSL follows similar practices as in HLSL (see [Microsoft DirectX HLSL documentation](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl)).
+
+Shader inputs and outputs can be defined via input/output variables or via a structure containing them.
 
 Vertex Shader
-: To set up the vertex shader, define the input and output data of the vertex shader and the vertex shader program. 
+: To set up the vertex shader, define the input and output data of the vertex shader and the vertex shader program.
 
-The vertex shader inputs and outputs are defined inside the structs `VertexInput` and `VertexShaderOutput`. The type of input and output is indicated by HLSL semantics (see Microsoft DirectX HLSL - Semantics](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics) documentation). 
+The vertex shader inputs and outputs are defined inside the structs `VertexInput` and `VertexOutput`. The type of input and output is indicated by HLSL semantics (see Microsoft DirectX HLSL - Semantics](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics) documentation).
 
 In this vertex shader program, you need the geometry's position. You can set up vertex input and output using the following code:
 
-```hlsl
+```cpp
 struct VertexInput
 {
     float3 m_position : POSITION;
 };
 
-struct VertexShaderOutput
+struct VertexOutput
 {
     float4 m_position : SV_Position;
 };
 ```
-The vertex shader program entry point is defined in the function `MainVS`. In this tutorial, you are creating a simple vertex shader that transforms the object's position from model space to clip space by applying a series of matrix transformations. 
 
-Your vertex shader program should look like this: 
-```hlsl
-VertexShaderOutput MainVS(VertexInput IN)
+The vertex shader program entry point is defined in the function `MainVS`. In this tutorial, you are creating a simple vertex shader that transforms the object's position from model space to clip space by applying a series of matrix transformations.
+
+Your vertex shader program should look like this:
+
+```cpp
+VertexOutput MainVS(VertexInput input)
 {
-    VertexShaderOutput OUT;
-    float3 worldPosition = mul(ObjectSrg::GetWorldMatrix(), float4(IN.m_position, 1)).xyz;
-    OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));        
-    return OUT;
+    VertexOutput ouput;
+    const float4x4 worldMatrix = ObjectSrg::GetWorldMatrix();
+
+    float3 worldPosition = mul(worldMatrix, float4(input.m_position, 1.0)).xyz;
+    ouput.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));
+
+    return ouput;
 }
 ```
-Fragment Shader
-: Next, set up the fragment input and output, and the fragment shader program. 
 
-The fragment shader program entry point is defined in the function `MainPS`. It takes `VertexShaderOutput` as input. The resulting fragment shader outputs are stored in the `ForwardPassOutput` struct (included in `ForwardPassOutput.azsli`).
+Fragment Shader
+: Next, set up the fragment input and output, and the fragment shader program.
+
+The fragment shader program entry point is defined in the function `MainPS`. It takes `VertexOutput` as input. The resulting fragment shader outputs are stored in the `ForwardPassOutput` struct (included in `ForwardPassOutput.azsli`).
 
 Since this is an unlit single shader color, you only need to set the value for diffuse color and disable specular lighting.
 
-Your fragment shader program should look like this: 
-```hlsl
-ForwardPassOutput MainPS(VertexShaderOutput IN)
+Your fragment shader program should look like this:
+
+```cpp
+ForwardPassOutput MainPS(VertexOutput input)
 {
-    ForwardPassOutput OUT;
+    ForwardPassOutput ouput;
 
-    // standard ForwardPassOutput G-buffer layout
-    OUT.m_diffuseColor = float4(UnlitColorSrg::m_unlitColor, -1.0); // Subsurface scattering is disabled
-    OUT.m_specularColor = float4(0.0, 0.0, 0.0, 0.0);   // Disable specular lighting
+    ouput.m_diffuseColor = float4(UnlitColorSrg::m_unlitColor, -1.0);
+    ouput.m_specularColor = float4(0.0, 0.0, 0.0, 0.0);
 
-    return OUT;
+    return ouput;
 }
 ```
 
 #### MyUnlitColor.azsl
+
 Here is the complete `MyUnlitColor.azsl` file:
-```hlsl
+
+```cpp
 
 #include <viewsrg.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
@@ -166,17 +179,20 @@ struct VertexInput
     float3 m_position : POSITION;
 };
 
-struct VertexShaderOutput
+struct VertexOutput
 {
-    float4 m_position : SV_Position;    
+    float4 m_position : SV_Position;
 };
 
-VertexShaderOutput MainVS(VertexInput IN)
+VertexOutput MainVS(VertexInput input)
 {
-    VertexShaderOutput OUT;
-    float3 worldPosition = mul(ObjectSrg::GetWorldMatrix(), float4(IN.m_position, 1)).xyz;
-    OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));        
-    return OUT;
+    VertexOutput ouput;
+    const float4x4 worldMatrix = ObjectSrg::GetWorldMatrix();
+
+    float3 worldPosition = mul(worldMatrix, float4(input.m_position, 1.0)).xyz;
+    ouput.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));
+
+    return ouput;
 }
 
 struct PixelOutput
@@ -184,20 +200,22 @@ struct PixelOutput
     float4 m_color : SV_Target0;
 };
 
-ForwardPassOutput MainPS(VertexShaderOutput IN)
+ForwardPassOutput MainPS(VertexOutput input)
 {
-    ForwardPassOutput OUT;
+    ForwardPassOutput ouput;
 
     // standard ForwardPassOutput G-buffer layout
-    OUT.m_diffuseColor = float4(UnlitColorSrg::m_unlitColor, -1.0); // Subsurface scattering is disabled
-    OUT.m_specularColor = float4(0.0, 0.0, 0.0, 0.0);   // Disable specular lighting
+    ouput.m_diffuseColor = float4(UnlitColorSrg::m_unlitColor, -1.0); // Subsurface scattering is disabled
+    ouput.m_specularColor = float4(0.0, 0.0, 0.0, 0.0);   // Disable specular lighting
 
-    return OUT;
+    return ouput;
 }
 ```
 
 ## 3. Author Shader Asset Data (.shader)
+
 The `.shader` file defines metadata to configure the shader compiler for the referenced `.azsl` source file, and specifies how the render pipeline should use the shader. The `.shader` file is responsible for the following:
+
 - Referencing the `.azsl` source file.
 - Configuring depth, stencil, and blend states.
 - Specifying shader compiler hints.
@@ -205,83 +223,77 @@ The `.shader` file defines metadata to configure the shader compiler for the ref
 - Specifying where in the render queue this shader should be drawn.
 
 #### Components of .shader
+
 The configuration in `.shader` is broken down into the following properties:
 
 Source
 : This shader references the `.azsl` source file `MyUnlitColor.azsl`.
 
 DepthStencilState
-: The `CompareFunc` property sets the comparison operator to `GreaterEqual` in order to discard pixels that have depth values that are lower than the current value in the depth buffer. This is necessary because Atom implements reverse depth buffers and uses a separate depth pre-pass that runs before the lighting pass. 
+: The `CompareFunc` property sets the comparison operator to `GreaterEqual` in order to discard pixels that have depth values that are lower than the current value in the depth buffer. This is necessary because Atom implements reverse depth buffers and uses a separate depth pre-pass that runs before the lighting pass.
 
 BlendState
 : Disable the blend state.
 
 CompilerHints
-: Set compiler hints for AZSLc. 
+: Set compiler hints for AZSLc.
 
 Entry Points
 : By default, any functions that start or end with `VS` or `PS` (corresponding to vertex and fragment shaders) are recognized by the asset builder as shader entry points. To explicitly identify the shader's entry points, specify the function's name and the type of shader program.
 
-- The vertex shader's entry point is at the MainVS function. 
-- The fragment shader's entry point is at the MainPS function. 
+- The vertex shader's entry point is at the MainVS function.
+- The fragment shader's entry point is at the MainPS function.
 
 DrawList
-: Specify the name of the draw list where draw items using this shader should be queued for rendering. Generally, the name should match the draw list name in a `.pass`. 
+: Specify the name of the draw list where draw items using this shader should be queued for rendering. Generally, the name should match the draw list name in a `.pass`.
 
 #### MyUnlitColor.shader
+
 Here is the complete MyUnlitColor.shader file:
+
 ```json
-
 {
-    "Source" : "MyUnlitColor.azsl",
+  "Source": "MyUnlitColor.azsl",
 
-    "DepthStencilState" :
-    {
-        "Depth" :
-        {
-            "Enable" : true,
-            "CompareFunc" : "GreaterEqual"
-        }
-    },
+  "DepthStencilState": {
+    "Depth": {
+      "Enable": true,
+      "CompareFunc": "GreaterEqual"
+    }
+  },
 
-    "BlendState" : {
-        "Enable" : false
-    },
+  "DrawList": "forward",
 
-    "CompilerHints" : { 
-        "DxcDisableOptimizations" : false
-    },
-
-    "ProgramSettings":
-    {
-      "EntryPoints":
-      [
-        {
-          "name": "MainVS",
-          "type": "Vertex"
-        },
-        {
-          "name": "MainPS",
-          "type": "Fragment"
-        }
-      ]
-    },
-
-    "DrawList" : "forward"      
+  "ProgramSettings": {
+    "EntryPoints": [
+      {
+        "name": "MainVS",
+        "type": "Vertex"
+      },
+      {
+        "name": "MainPS",
+        "type": "Fragment"
+      }
+    ]
+  }
 }
 ```
 
 ## 4. Author Material Type Data (.materialtype)
+
 The `MyUnlitColor.materialtype` file contains the material type data in JSON format. Material types are responsible for the following:
+
 - Linking to shaders.
 - Defining property groups
 - Defining material properties for property groups.
 
 #### Linking to Shaders
-Linking to shaders in a `.materialtype` defines which shader(s) the material type will use to compute the appearance of the surface. It also exposes the variables of the shader(s) to the material type, so they can be linked to material properties. In this tutorial, the `color` property is connected to the variable `m_unlitColor`, which is defined inside `MyUnlitColor.azsl` and referenced by the `MyUnlitColor.shader` file. 
 
-For this tutorial, the MyUnlitColor material type links to a few shaders: 
-- `MyUnlitColor.shader`: This is the the shader you created earlier in this tutorial. The color property is connected to the variable `m_unlitColor`, which is defined inside `MyUnlitColor.azsl` and referenced by the `MyUnlitColor.shader` file. 
+Linking to shaders in a `.materialtype` defines which shader(s) the material type will use to compute the appearance of the surface. It also exposes the variables of the shader(s) to the material type, so they can be linked to material properties. In this tutorial, the `color` property is connected to the variable `m_unlitColor`, which is defined inside `MyUnlitColor.azsl` and referenced by the `MyUnlitColor.shader` file.
+
+For this tutorial, the MyUnlitColor material type links to a few shaders:
+
+- `MyUnlitColor.shader`: This is the the shader you created earlier in this tutorial. The color property is connected to the variable `m_unlitColor`, which is defined inside `MyUnlitColor.azsl` and referenced by the `MyUnlitColor.shader` file.
 - `DepthPass.shader`: This shader is needed to write to the depth buffer.
 - `Shadowmap.shader`: This shader enables the object to cast a shadow.
 
@@ -290,8 +302,10 @@ For this tutorial, the MyUnlitColor material type links to a few shaders:
 {{< /note >}}
 
 This results in the following example:
+
 ```json
-"shaders": [
+    "shaders":
+    [
         {
             "file": "./MyUnlitColor.shader"
         },
@@ -301,23 +315,25 @@ This results in the following example:
         {
             "file": "Shaders/Shadow/Shadowmap.shader"
         }
-]	
+    ]
 ```
 
-
 #### Defining Material Properties
-In a `.materialtype` file, material properties are defined in groups of properties within the `propertyLayout` container. The groups container arranges the properties into collapsible groups displayed in the **Inspector** of **Material Editor**. Each property has several attributes including an id, name, type, default value, and a link to a variable in one of the shaders referenced by the `.materialtype` file. 
 
-For this tutorial, we only have one material property: color. To define the color property in the propertyLayout container: 
-1. Define a `settings` property group in the `groups` container. 
+In a `.materialtype` file, material properties are defined in groups of properties within the `propertyLayout` container. The groups container arranges the properties into collapsible groups displayed in the **Inspector** of **Material Editor**. Each property has several attributes including an id, name, type, default value, and a link to a variable in one of the shaders referenced by the `.materialtype` file.
+
+For this tutorial, we only have one material property: color. To define the color property in the propertyLayout container:
+
+1. Define a `settings` property group in the `groups` container.
 2. Define a `settings` property group in the `properties` container to hold details about the properties that belong to the settings `property` group.
 3. Define the `color` property within the `settings` property group inside `properties`.
 
 This results in the following example:
+
 ```json
 
     "propertyLayout": {
-        "version": 3,
+        "version": 1,
         "groups": [
             {
                 "id": "settings",
@@ -327,12 +343,12 @@ This results in the following example:
         "properties": {
             "settings": [
                 {
-                    "id": "color",						// Unique, C-style identifier 		
+                    "id": "color",						// Unique, C-style identifier
                     "displayName": "Color",				// Name (appears in the Material Editor)
                     "type": "Color",					// Data type
                     "defaultValue": [ 0.5, 0.0, 0.5 ],	// Default value (depends on data type)
                     "connection": {						// Establish a connection between the property and a variable in the shader.
-                        "type": "ShaderInput",			// - Any changes made to this 'color' property serialize to the 'm_unlitColor' 
+                        "type": "ShaderInput",			// - Any changes made to this 'color' property serialize to the 'm_unlitColor'
                         "id": "m_unlitColor"            // - variable in the UnlitSingleColor shader.
                     }
                 }
@@ -343,56 +359,60 @@ This results in the following example:
 ```
 
 To recap, the above example accomplishes a couple of things:
+
 - Defines the material properties.
 - Creates a connection to the variables used by the shader source code (`.azsl`).
-- Sets up the metadata that configures how the material properties appear in the **Inspector** in **Material Editor**. 
+- Sets up the metadata that configures how the material properties appear in the **Inspector** in **Material Editor**.
 
 #### MyUnlitColor.materialtype
+
 Here is the complete `MyUnlitColor.materialtype` file:
+
 ```json
 {
-    "description": "Renders a model unlit with a single suface color value.",
-        "shaders": [
-        {
-            "file": "./MyUnlitColor.shader"
-        },
-        {
-            "file": "Shaders/Depth/DepthPass.shader"
-        },
-        {
-            "file": "Shaders/Shadow/Shadowmap.shader"
-        }
-    ],
-    "propertyLayout": {
-        "version": 3,
-        "groups": [
-            {
-                "id": "settings",
-                "displayName": "Settings"
-            }
-        ],
-        "properties": {
-            "settings": [
-                {
-                    "id": "color",						
-                    "displayName": "Color",
-                    "type": "Color",
-                    "defaultValue": [ 0.5, 0.0, 0.5 ],
-                    "connection": {
-                        "type": "ShaderInput",
-                        "id": "m_unlitColor"
-                    }
-                }
-            ]
-        }
+  "description": "Renders a model unlit with a single suface color value.",
+  "shaders": [
+    {
+      "file": "./MyUnlitColor.shader"
+    },
+    {
+      "file": "Shaders/Depth/DepthPass.shader"
+    },
+    {
+      "file": "Shaders/Shadow/Shadowmap.shader"
     }
+  ],
+  "propertyLayout": {
+    "version": 3,
+    "groups": [
+      {
+        "id": "settings",
+        "displayName": "Settings"
+      }
+    ],
+    "properties": {
+      "settings": [
+        {
+          "id": "color",
+          "displayName": "Color",
+          "type": "Color",
+          "defaultValue": [0.5, 0.0, 0.5],
+          "connection": {
+            "type": "ShaderInput",
+            "id": "m_unlitColor"
+          }
+        }
+      ]
+    }
+  }
 }
 ```
 
 ## 5. Compile and debug with the Asset Processor
-At this point, we've finished writing the files `MyUnlitColor.materialtype`, `MyUnlitColor.shader`, and `MyUnlitColor.azsl`. Now, we are going to make sure they compile successfully. 
 
-**Asset Processor** is responsible for compiling and debugging `.material`, `.materialtype,` `.shader`, and `.azsl` files (among many other assets). **Asset Processor** automatically launches when **Material Editor** is open and runs in the background in the system tray. You can also launch **Asset Processor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.  
+At this point, we've finished writing the files `MyUnlitColor.materialtype`, `MyUnlitColor.shader`, and `MyUnlitColor.azsl`. Now, we are going to make sure they compile successfully.
+
+**Asset Processor** is responsible for compiling and debugging `.material`, `.materialtype,` `.shader`, and `.azsl` files (among many other assets). **Asset Processor** automatically launches when **Material Editor** is open and runs in the background in the system tray. You can also launch **Asset Processor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.
 
 **Asset Processor** monitors your project's subdirectories and automatically compiles and debugs assets when it detects new or updated files.
 
@@ -401,22 +421,26 @@ If **Asset Processor** encounters an error, it displays a message above the syst
 If a job displays an error or warning, select the job in the **Asset Status** list and view the log in the **Event Log Details** list below. The event log will contain verbose information you can use to solve any errors or warnings emitted when specific assets are processed.
 
 ## 6. Create a material using the Material Editor
-At this point, all of our files should compile successfully. Now, you are going to create a material based on the MyUnlitColor material type. 
 
-To create a new material using **Material Editor**: 
-1. Launch **Material Editor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.  
+At this point, all of our files should compile successfully. Now, you are going to create a material based on the MyUnlitColor material type.
+
+To create a new material using **Material Editor**:
+
+1. Launch **Material Editor** from the directory for your build config such as `<build>/bin/profile/` or `<install>/bin/<platform>/profile/Default`.
 2. From the **File** menu in **Material Editor**, select **New**, or press **Ctrl+N** to create a new material.
 3. In the **Create New Material** dialog, select **MyUnlitColor** in the **Material Type** list.
 4. Choose the folder icon below **Select Material Filename**. Ensure the file browser has your project's `Materials` directory selected and name the material `MyUnlitColor.material`. Choose **OK** to close both the file browser and the **Create New Material** dialog.
 5. The new material is automatically selected in **Asset Browser** and its settings group and color property are available in **Material Editor's** **Inspector**.
 6. Change the material color by specifying a comma separated list of RGB values in the **Color** property field, or choose the color swatch to open the color picker.
-7. Save changes to the material by choosing **Save** from the **File** menu or by pressing **Ctrl+S**. 
+7. Save changes to the material by choosing **Save** from the **File** menu or by pressing **Ctrl+S**.
 
 ![Creating a material from MyUnlitColor material type](/images/learning-guide/tutorials/rendering/unlit-color-material.jpg)
 
-That's it! You created an AZSL shader, a new material type, and a material. 
+That's it! You created an AZSL shader, a new material type, and a material.
 
 ## Dive Deeper
+
 Check out the following pages to learn more about materials and shaders in Atom.
-- [Shader System and AZSL Reference](/docs/atom-guide/dev-guide/shaders/): Learn about the Shader System, including the AZSL language. 
-- [Material System](/docs/atom-guide/dev-guide/materials/): Learn about the technical details underlying the material system in Atom. 
+
+- [Shader System and AZSL Reference](/docs/atom-guide/dev-guide/shaders/): Learn about the Shader System, including the AZSL language.
+- [Material System](/docs/atom-guide/dev-guide/materials/): Learn about the technical details underlying the material system in Atom.

--- a/content/docs/user-guide/networking/settings.md
+++ b/content/docs/user-guide/networking/settings.md
@@ -9,14 +9,15 @@ linktitle: Network Settings
 This page documents [console variables](/docs/user-guide/appendix/cvars/) and other settings that can control Networking and Multiplayer behavior.
 
 ## Networking commands
-The following [console functor](/docs/user-guide/programming/az-console/#console-functors-cfuncs) commands should be used to control the connection of clients to servers for networked games or simulations. 
+
+The following [console functor](/docs/user-guide/programming/az-console/#console-functors-cfuncs) commands should be used to control the connection of clients to servers for networked games or simulations.
 
 | Setting                | Description                                                                                                                                | Parameters                                                                       | Notes                                                                                     |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | host                   | Opens a multiplayer connection as a host for other clients to connect to.                                                                  |                                                                                  |                                                                                           |
-| connect                | Opens a multiplayer connection to a host.                                                                                                  | *(Optional)* IP address and port, separated by ':'. For example, `0.0.0.0:1234`. | Defaults to `cl_serveraddr`:`cl_serverport`.                                              |
+| connect                | Opens a multiplayer connection to a host.                                                                                                  | _(Optional)_ IP address and port, separated by ':'. For example, `0.0.0.0:1234`. | Defaults to `cl_serveraddr`:`cl_serverport`.                                              |
 | disconnect             | Disconnects any open multiplayer connections.                                                                                              |                                                                                  |                                                                                           |
-| LoadLevel              | Unloads the current level and loads a new one with the given asset name. <br> Used to setup the initial level for the game or simiulation. | *(Required)* Path to a level file.                                               | Command is not specific to network or multiplayer but used for all games and simulations. | 
+| LoadLevel              | Unloads the current level and loads a new one with the given asset name. <br> Used to setup the initial level for the game or simiulation. | _(Required)_ Path to a level file.                                               | Command is not specific to network or multiplayer but used for all games and simulations. |
 | sv_launch_local_client | Launches a local client and connects to this host server.                                                                                  |                                                                                  | Only works if currently hosting.                                                          |
 
 These console commands can be executed dynamically via the [console command line](/docs/user-guide/editor/console/) or placed within a console command configuration file, usually with the `.cfg` suffix. Commands will be executed in the order written.
@@ -37,178 +38,187 @@ connect
 Console commands in configuration files can be passed to client and server launchers using the `console-command-file` option, for example `MultiplayerSample.ServerLauncher.exe --console-command-file=launch_server.cfg`.
 
 ## Client settings
+
 The following [console variables](/docs/user-guide/appendix/cvars/) control client behavior.
 
-| Setting                | Description                                                                                                                                                                             | Default   | Notes |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-------|
-| cl_clientport          | The port to bind to for game traffic when connecting to a remote host, a value of 0 will select any available port.                                                                     | 0         |       |
-| cl_serveraddr          | The address of the remote server or host to connect to.                                                                                                                                 | LocalHost |       |
-| cl_serverport          | The port of the remote host to connect to for game traffic.                                                                                                                             | 33450     | 
-| cl_InputRateMs         | Rate at which to sample and process client inputs.                                                                                                                                      | 33 ms     ||
-| cl_MaxRewindHistoryMs  | Maximum number of milliseconds to keep for server correction rewind and replay.                                                                                                         | 2000 ms   |
-| cl_renderTickBlendBase | The base used for blending between network updates, 0.1 will be quite linear, 0.2 or 0.3 will slow down quicker and may be better suited to connections with highly variable latency. | 0.15      ||
+| Setting                | Description                                                                                                                                                                           | Default   | Notes |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----- |
+| cl_clientport          | The port to bind to for game traffic when connecting to a remote host, a value of 0 will select any available port.                                                                   | 0         |       |
+| cl_serveraddr          | The address of the remote server or host to connect to.                                                                                                                               | LocalHost |       |
+| cl_serverport          | The port of the remote host to connect to for game traffic.                                                                                                                           | 33450     |
+| cl_InputRateMs         | Rate at which to sample and process client inputs.                                                                                                                                    | 33 ms     |       |
+| cl_MaxRewindHistoryMs  | Maximum number of milliseconds to keep for server correction rewind and replay.                                                                                                       | 2000 ms   |
+| cl_renderTickBlendBase | The base used for blending between network updates, 0.1 will be quite linear, 0.2 or 0.3 will slow down quicker and may be better suited to connections with highly variable latency. | 0.15      |       |
 
 ### Client to server connection settings
-| Setting                                        | Description                                                                                                                                     | Default    | Notes |
-|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------------|-------|
+
+| Setting                                        | Description                                                                                                                                 | Default    | Notes |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----- |
 | cl_ClientEntityReplicatorPendingRemovalTimeMs  | How long to wait prior to removing an entity for the client through a change in the replication window, entity deletes are still immediate. | 10000 ms   |       |
-| cl_DefaultNetworkEntityActivationTimeSliceMs   | Max Ms to use to activate entities coming from the network, 0 means instantiate everything.                                                     | 0 ms       ||
-| cl_ClientMaxRemoteEntitiesPendingCreationCount | Maximum number of entities that we have sent to the client, but have not had a confirmation back from the client.                               | 4294967295 ||
+| cl_DefaultNetworkEntityActivationTimeSliceMs   | Max Ms to use to activate entities coming from the network, 0 means instantiate everything.                                                 | 0 ms       |       |
+| cl_ClientMaxRemoteEntitiesPendingCreationCount | Maximum number of entities that we have sent to the client, but have not had a confirmation back from the client.                           | 4294967295 |       |
 
 ### Debug settings
+
 | Setting                        | Description                                                                                       | Default | Notes                   |
-|--------------------------------|---------------------------------------------------------------------------------------------------|---------|-------------------------|
+| ------------------------------ | ------------------------------------------------------------------------------------------------- | ------- | ----------------------- |
 | cl_DebugHackTimeMultiplier     | Scalar value used to simulate clock hacking cheats for validating bank time system and anticheat. | 1.0     | Non-release builds      |
 | cl_EnableDesyncDebugging       | If enabled, debug logs will contain verbose information on detected state desyncs.                | True    | Non-release builds      |
 | cl_DesyncDebugging_AuditInputs | If true, adds inputs to audit trail.                                                              | False   | Non-release builds      |
 | cl_PredictiveStateHistorySize  | Controls how many inputs of predictive state should be retained for debugging desyncs.            | 120     | Non-release builds only |
 
-
 ## Server settings
 
 The following [console variables](/docs/user-guide/appendix/cvars/) control server behavior.
 
-| Setting                 | Description                                                                     | Default | Notes                |
-|-------------------------|---------------------------------------------------------------------------------|---------|----------------------|
-| sv_map                  | The map the server should load.                                                 | None    |                      |
-| sv_port                 | The port that Multiplayer Gem will bind to for game traffic.                    | 33450   |                      |
+| Setting                 | Description                                                                          | Default | Notes                |
+| ----------------------- | ------------------------------------------------------------------------------------ | ------- | -------------------- |
+| sv_map                  | The map the server should load.                                                      | None    |                      |
+| sv_port                 | The port that Multiplayer Gem will bind to for game traffic.                         | 33450   |                      |
 | sv_portRange            | The range of ports the host will incrementally attempt to bind to when initializing. | 999     |                      |
-| sv_protocol             | This flag controls whether we use TCP or UDP for game networking.               | Udp     ||
-| sv_DedicatedCPUPercent  | Target CPU usage when running as a dedicated server.                            | 0       | Disabled by default. |
-| sv_DedicatedCPUVariance | How much the CPU can vary from `sv_DedicatedCPUPercent`.                        | 10      |                      |
-| sv_DedicatedMaxRate     | Maximum update rate when running as a dedicated server.                         | 30      |                      |
-| sv_isDedicated          | Whether the host command creates an independent or client hosted server.        | True    |                      |
-| sv_isTransient          | Whether a dedicated server shuts down if all existing connections disconnect.   | True    ||
-| sv_serverSendRateMs     | Minimum number of milliseconds between each network update.                     | 50 ms   || 
+| sv_protocol             | This flag controls whether we use TCP or UDP for game networking.                    | Udp     |                      |
+| sv_DedicatedCPUPercent  | Target CPU usage when running as a dedicated server.                                 | 0       | Disabled by default. |
+| sv_DedicatedCPUVariance | How much the CPU can vary from `sv_DedicatedCPUPercent`.                             | 10      |                      |
+| sv_DedicatedMaxRate     | Maximum update rate when running as a dedicated server.                              | 30      |                      |
+| sv_isDedicated          | Whether the host command creates an independent or client hosted server.             | True    |                      |
+| sv_isTransient          | Whether a dedicated server shuts down if all existing connections disconnect.        | True    |                      |
+| sv_serverSendRateMs     | Minimum number of milliseconds between each network update.                          | 50 ms   |                      |
 
 ### Server to client connection settings
-| Setting                                                | Description                                                                                                                                     | Default    | Notes |
-|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------------|-------|
-| sv_ClientEntityReplicatorPendingRemovalTimeMs          | How long to wait prior to removing an entity for the client through a change in the replication window, entity deletes are still immediate. | 10000 ms   ||
-| sv_ClientMaxRemoteEntitiesPendingCreationCount         | Maximum number of entities that we have sent to the client, but have not had a confirmation back from the client.                               | 4294967295 ||
-| sv_ClientMaxRemoteEntitiesPendingCreationCountPostInit | Maximum number of entities that we will send to clients after gameplay has begun.                                                               | 4294967295 ||
+
+| Setting                                                | Description                                                                                                                                 | Default    | Notes |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----- |
+| sv_ClientEntityReplicatorPendingRemovalTimeMs          | How long to wait prior to removing an entity for the client through a change in the replication window, entity deletes are still immediate. | 10000 ms   |       |
+| sv_ClientMaxRemoteEntitiesPendingCreationCount         | Maximum number of entities that we have sent to the client, but have not had a confirmation back from the client.                           | 4294967295 |       |
+| sv_ClientMaxRemoteEntitiesPendingCreationCountPostInit | Maximum number of entities that we will send to clients after gameplay has begun.                                                           | 4294967295 |       |
 
 ### Replication window settings
+
 | Setting                            | Description                                                                                | Default | Notes |
-|------------------------------------|--------------------------------------------------------------------------------------------|---------|-------|
-| sv_ReplicateServerProxies          | Enable sending of ServerProxy entities to clients.                                         | True    ||
-| sv_MaxEntitiesToTrackReplication   | The default max number of entities to track for replication.                               | 512     ||
-| sv_MinEntitiesToReplicate          | The default min number of entities to replicate to a client connection.                    | 128     ||
-| sv_MaxEntitiesToReplicate          | The default max number of entities to replicate to a client connection.                    | 256     ||
+| ---------------------------------- | ------------------------------------------------------------------------------------------ | ------- | ----- |
+| sv_ReplicateServerProxies          | Enable sending of ServerProxy entities to clients.                                         | True    |       |
+| sv_MaxEntitiesToTrackReplication   | The default max number of entities to track for replication.                               | 512     |       |
+| sv_MinEntitiesToReplicate          | The default min number of entities to replicate to a client connection.                    | 128     |       |
+| sv_MaxEntitiesToReplicate          | The default max number of entities to replicate to a client connection.                    | 256     |       |
 | sv_PacketsToIntegrateQos           | The number of packets to accumulate before updating connection quality of service metrics. | 1000    |       |
-| sv_BadConnectionThreshold          | The loss percentage beyond which we consider our network bad.                              | 0.25    ||
-| sv_ClientReplicationWindowUpdateMs | Rate for replication window updates.                                                       | 300 ms  ||               
-| sv_ClientAwarenessRadius           | The maximum distance entities can be from the client and still be relevant.                | 500.0   ||
+| sv_BadConnectionThreshold          | The loss percentage beyond which we consider our network bad.                              | 0.25    |       |
+| sv_ClientReplicationWindowUpdateMs | Rate for replication window updates.                                                       | 300 ms  |       |
+| sv_ClientAwarenessRadius           | The maximum distance entities can be from the client and still be relevant.                | 500.0   |       |
 
 ### Rewind settings
+
 | Setting                        | Description                                                                      | Default | Notes |
-|--------------------------------|----------------------------------------------------------------------------------|---------|-------|
+| ------------------------------ | -------------------------------------------------------------------------------- | ------- | ----- |
 | sv_RewindVolumeExtrudeDistance | The amount to increase rewind volume checks to account for fast moving entities. | 50      |       |
 
 ### Editor server settings
+
 These settings control how a server will be launched during the "play-in-editor" (CTRL+G) mode.
-
-| Setting                            | Description                                                                                                                                                                                                                                                                                                              | Default   | Notes                                                                                                                                            |
-|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| editorsv_isDedicated               | Whether to init as a server expecting data from an Editor. Do not modify unless you're sure of what you're doing.                                                                                                                                                                                                        | False     ||
-| editorsv_port                      | The server port the Editor will connect to when entering play-mode.                                                                                                                                                                                                                                                      | 33450     | Only valid when `editorsv_enabled` is true.                                                                                                      | 
-| editorsv_serveraddr                | The address of the server the Editor will connect to when entering play-mode.                                                                                                                                                                                                                                            | LocalHost | Only valid when `editorsv_enabled` is true.                                                                                                      |
-| editorsv_process                   | The file path to your project’s ServerLauncher. If `editorsv_enabled` and `editorsv_launch` is true, the Editor will attempt to launch its own server when entering game mode. By default it looks for the ServerLauncher executable inside the same folder where Editor lives; `editorsv_process` overrides that path. | ""        |                                                                                                                                                  |
-| editorsv_rhi_override              | If `editorsv_launch` is true, the server will use the same render hardware interface (rhi) that the editor is using. For example, if the editor is using DX12, then the new server will be launched using DX12. `editorsv_rhi_override` can be used to override the rhi.                                                 | ""        | If you don't need to see the launched server's graphics then set `editorsv_rhi_override=null`, the null renderer.                                |
-| editorsv_enabled                   | If true the Editor will attempt to connect to a Multiplayer server upon entering game mode.                                                                                                                                                                                                                              | False     ||
-| editorsv_hidden                    | If true the Editor will automatically launch a server upon entering game mode. Set `editorsv_hidden` to true if you want the launched server to be started as a background process without any visible window.                                                                                                           | False     |                                                                                                                                                  |  
-| editorsv_launch                    | If true the Editor will automatically launch its own server upon entering game mode.                                                                                                                                                                                                                                     | True      | Only applies if `editorsv_enabled` is also true. If starting your own editor-server remember to set `editorsv_isDedicated` to true on the server |
-| editorsv_connectionMessageFontSize |                                                                                                                                                                                                                                                                                                                          | 0.7       |                                                                                                                                                  |
-
+#editorsv #editorsv\_
+| Setting | Description | Default | Notes |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| editorsv_isDedicated | Whether to init as a server expecting data from an Editor. Do not modify unless you're sure of what you're doing. | False | |
+| editorsv_port | The server port the Editor will connect to when entering play-mode. | 33450 | Only valid when `editorsv_enabled` is true. |
+| editorsv_serveraddr | The address of the server the Editor will connect to when entering play-mode. | LocalHost | Only valid when `editorsv_enabled` is true. |
+| editorsv_process | The file path to your project’s ServerLauncher. If `editorsv_enabled` and `editorsv_launch` is true, the Editor will attempt to launch its own server when entering game mode. By default it looks for the ServerLauncher executable inside the same folder where Editor lives; `editorsv_process` overrides that path. | "" | |
+| editorsv_rhi_override | If `editorsv_launch` is true, the server will use the same render hardware interface (rhi) that the editor is using. For example, if the editor is using DX12, then the new server will be launched using DX12. `editorsv_rhi_override` can be used to override the rhi. | "" | If you don't need to see the launched server's graphics then set `editorsv_rhi_override=null`, the null renderer. |
+| editorsv_enabled | If true the Editor will attempt to connect to a Multiplayer server upon entering game mode. | False | |
+| editorsv_hidden | If true the Editor will automatically launch a server upon entering game mode. Set `editorsv_hidden` to true if you want the launched server to be started as a background process without any visible window. | False | |
+| editorsv_launch | If true the Editor will automatically launch its own server upon entering game mode. | True | Only applies if `editorsv_enabled` is also true. If starting your own editor-server remember to set `editorsv_isDedicated` to true on the server |
+| editorsv_connectionMessageFontSize | | 0.7 | |
 
 ### Dual client server settings
+
 These settings control behavior on both the client and server.
 
-| Setting                                             | Description                                                                             | Default | Notes |
-|-----------------------------------------------------|-----------------------------------------------------------------------------------------|---------|-------|
-| bg_RewindDebugDraw                                  | If true enables debug draw of rewind operations.                                        | False   |       |
-| bg_replicationWindowImmediateAddRemove              | Update replication windows immediately on visibility Add/Removes.                       | True    |       |
-| bg_multiplayerDebugDraw                             | Enables debug draw for the Multiplayer Gem.                                             | False   |       |
-| bg_replicationWindowImmediateAddRemove              | Update replication windows immediately on visibility Add/Removes.                       | True    |       |
-| bg_RewindPositionTolerance                          | Don't sync the NVIDIA PhysX entity if the square of delta position is less than this value.    | 0.001  ||
-| bg_AssertNetBindOnDeactivationWithoutMarkForRemoval |                                                                                         | False   ||
-| bg_hierarchyEntityMaxLimit                          |                                                                                         | 16      || 
-| bg_DrawArticulatedHitVolumes                        | Enables debug draw of articulated hit volumes.                                          | False   ||
-| bg_DrawDebugHitVolumeLifetime                       | The lifetime for hit volume draw-debug shapes.                                          | 0.0     ||
-| bg_RewindOrientationTolerance                       | Don't sync the NVIDIA PhysX entity if the square of delta orientation is less than this value. | 0.001   ||
-
+| Setting                                             | Description                                                                                    | Default | Notes |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------- | ----- |
+| bg_RewindDebugDraw                                  | If true enables debug draw of rewind operations.                                               | False   |       |
+| bg_replicationWindowImmediateAddRemove              | Update replication windows immediately on visibility Add/Removes.                              | True    |       |
+| bg_multiplayerDebugDraw                             | Enables debug draw for the Multiplayer Gem.                                                    | False   |       |
+| bg_replicationWindowImmediateAddRemove              | Update replication windows immediately on visibility Add/Removes.                              | True    |       |
+| bg_RewindPositionTolerance                          | Don't sync the NVIDIA PhysX entity if the square of delta position is less than this value.    | 0.001   |       |
+| bg_AssertNetBindOnDeactivationWithoutMarkForRemoval |                                                                                                | False   |       |
+| bg_hierarchyEntityMaxLimit                          |                                                                                                | 16      |       |
+| bg_DrawArticulatedHitVolumes                        | Enables debug draw of articulated hit volumes.                                                 | False   |       |
+| bg_DrawDebugHitVolumeLifetime                       | The lifetime for hit volume draw-debug shapes.                                                 | 0.0     |       |
+| bg_RewindOrientationTolerance                       | Don't sync the NVIDIA PhysX entity if the square of delta orientation is less than this value. | 0.001   |       |
 
 ## Networking settings
+
 These settings control networking behavior.
 
 ### AzNetworking layer
-| Setting                             | Description                                                                                                                         | Default         | Notes                |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-----------------|----------------------|
-| net_maxPacketTrackTimeMs            | Maximum time to track any particular packet ID before giving up.                                                                     | 2000            |                      |
-| net_rttIncreaseOnPacketLoss         | Scalar amount to increase round trip time estimates by on packet loss.                                                              | 1.2             |                      |
-| net_TcpCompressor                   | TCP compressor to use. WARNING: Similar to encryption this needs to be set once and only once before creating the network interface.  | None            |                      |
-| net_TcpUseEncryption                | Enable encryption on TCP-based connections.                                                                                         | False           |                      |
-| net_UseDtlsCookies                  | Enables DTLS cookie exchange during the connection handshake.                                                                       | False           |                      |
-| net_UdpMaxUnackedPacketCount        | Maximum packets to receive before forcing a heartbeat packet for acking.                                                            | 10              |                      |
-| net_UdpFragmentTimeoutMs            | Milliseconds to retain chunks of incomplete unreliable fragmented packets before timing them out.                                   | 5000 ms         |                      |
-| net_UdpCompressor                   | UDP compressor to use. WARNING: Similar to encryption this needs to be set once and only once before creating the network interface. | None            |                      |
-| net_MinPacketTimeoutMs              | Minimum time to wait before timing out an unacked packet.                                                                           | 200 ms          |                      |
-| net_UdpDefaultTimeoutMs             | Time in milliseconds before we timeout an idle UDP connection.                                                                      | 10 * 1000 ms    |                      |
-| net_UdpPacketTimeSliceMs            | The number of milliseconds to allow for packet processing.                                                                          | 8 ms            |                      |
-| net_UdpTimeoutConnections           | Should code hold timeout UDP connections.                                                                                           | True            |                      |
-| net_UdpUseEncryption                | Enable encryption on UDP-based connections.                                                                                         | False           |                      |
-| net_RttFudgeScalar                  | Scalar value to multiply computed RTT by to determine an optimal packet timeout threshold.                                          | 2.0             |                      |
-| net_MaxTimeoutsPerFrame             | Maximum number of packet timeouts to allow to process in a single frame.                                                            | 1000            |                      |
-| net_FragmentedHeaderOverhead        | A fudge overhead value to take out of fragmented packet payloads.                                                                   | 32              |                      |
-| net_SslInflationOverhead            | A SSL fudge overhead value to take out of fragmented packet payloads.                                                               | 32              |                      |
-| net_UdpUnackedHeartbeats            | The number of heartbeats to attempt to send to keep a connection alive before giving up.                                            | 5               |                      |
-| net_UdpMaxReadTimeMs                | The amount of time to allow the reader thread to read data off registered sockets.                                                  | 10 ms           |                      |
-| net_MaxReliablePacketsInWindow      | The maximum number of reliable packets to allow to be queued up before triggering a disconnect.                                     | 16384           |                      |
-| net_UdpIgnoreWin10054               | If true, will ignore 10054 socket errors on windows.                                                                                | True            |                      |
-| net_UdpRecvBufferSize               | Default UDP socket receive buffer size.                                                                                             | 1 * 1024 * 1024 |                      |
-| net_UdpSendBufferSize               | Default UDP socket send buffer size.                                                                                                | 1 * 1024 * 1024 |                      |
-| net_validateSerializedTypes         | Causes an Assert when an attempt at `TypeValidatingSerializer` serialization results in a type or variable name mismatch. | False   | Increases bandwidth utilization to support mismatch detection.   |
+
+| Setting                        | Description                                                                                                                          | Default         | Notes                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | -------------------------------------------------------------- |
+| net_maxPacketTrackTimeMs       | Maximum time to track any particular packet ID before giving up.                                                                     | 2000            |                                                                |
+| net_rttIncreaseOnPacketLoss    | Scalar amount to increase round trip time estimates by on packet loss.                                                               | 1.2             |                                                                |
+| net_TcpCompressor              | TCP compressor to use. WARNING: Similar to encryption this needs to be set once and only once before creating the network interface. | None            |                                                                |
+| net_TcpUseEncryption           | Enable encryption on TCP-based connections.                                                                                          | False           |                                                                |
+| net_UseDtlsCookies             | Enables DTLS cookie exchange during the connection handshake.                                                                        | False           |                                                                |
+| net_UdpMaxUnackedPacketCount   | Maximum packets to receive before forcing a heartbeat packet for acking.                                                             | 10              |                                                                |
+| net_UdpFragmentTimeoutMs       | Milliseconds to retain chunks of incomplete unreliable fragmented packets before timing them out.                                    | 5000 ms         |                                                                |
+| net_UdpCompressor              | UDP compressor to use. WARNING: Similar to encryption this needs to be set once and only once before creating the network interface. | None            |                                                                |
+| net_MinPacketTimeoutMs         | Minimum time to wait before timing out an unacked packet.                                                                            | 200 ms          |                                                                |
+| net_UdpDefaultTimeoutMs        | Time in milliseconds before we timeout an idle UDP connection.                                                                       | 10 \* 1000 ms   |                                                                |
+| net_UdpPacketTimeSliceMs       | The number of milliseconds to allow for packet processing.                                                                           | 8 ms            |                                                                |
+| net_UdpTimeoutConnections      | Should code hold timeout UDP connections.                                                                                            | True            |                                                                |
+| net_UdpUseEncryption           | Enable encryption on UDP-based connections.                                                                                          | False           |                                                                |
+| net_RttFudgeScalar             | Scalar value to multiply computed RTT by to determine an optimal packet timeout threshold.                                           | 2.0             |                                                                |
+| net_MaxTimeoutsPerFrame        | Maximum number of packet timeouts to allow to process in a single frame.                                                             | 1000            |                                                                |
+| net_FragmentedHeaderOverhead   | A fudge overhead value to take out of fragmented packet payloads.                                                                    | 32              |                                                                |
+| net_SslInflationOverhead       | A SSL fudge overhead value to take out of fragmented packet payloads.                                                                | 32              |                                                                |
+| net_UdpUnackedHeartbeats       | The number of heartbeats to attempt to send to keep a connection alive before giving up.                                             | 5               |                                                                |
+| net_UdpMaxReadTimeMs           | The amount of time to allow the reader thread to read data off registered sockets.                                                   | 10 ms           |                                                                |
+| net_MaxReliablePacketsInWindow | The maximum number of reliable packets to allow to be queued up before triggering a disconnect.                                      | 16384           |                                                                |
+| net_UdpIgnoreWin10054          | If true, will ignore 10054 socket errors on windows.                                                                                 | True            |                                                                |
+| net_UdpRecvBufferSize          | Default UDP socket receive buffer size.                                                                                              | 1 _ 1024 _ 1024 |                                                                |
+| net_UdpSendBufferSize          | Default UDP socket send buffer size.                                                                                                 | 1 _ 1024 _ 1024 |                                                                |
+| net_validateSerializedTypes    | Causes an Assert when an attempt at `TypeValidatingSerializer` serialization results in a type or variable name mismatch.            | False           | Increases bandwidth utilization to support mismatch detection. |
 
 ### Multiplayer layer
+
 | Setting                             | Description                                                                          | Default | Notes                    |
-|-------------------------------------|--------------------------------------------------------------------------------------|---------|--------------------------|
+| ----------------------------------- | ------------------------------------------------------------------------------------ | ------- | ------------------------ |
 | net_EntityReplicatorRecordsMax      | Number of allowed outstanding entity records.                                        | 45      | Requires Multiplayer Gem |
 | net_DefaultEntityMigrationTimeoutMs | Time to wait for a new authority to attach to an entity before we delete the entity. | 1000 ms | Requires Multiplayer Gem |
 | net_EntityReplicatorRecordsMax      | Number of allowed outstanding entity records.                                        | 45      | Requires Multiplayer Gem |
-| net_DebugEntities_ShowBandwidth     | Display bandwidth information.                                                       | False   ||
-| net_DebutAuditTrail_HistorySize     | Size of audit history.                                                               | 20      ||
-| net_DebugEntities_WarnAboveKbps     |                                                                                      | 10.f    ||
-| net_DebugEntities_BelowWarningColor |                                                                                      | Grey    ||
-| net_DebugEntities_WarningColor      |                                                                                      | Red     ||
-| net_DebugEntities_ShowAboveKbps     |                                                                                      | 1.f     ||
-
-
+| net_DebugEntities_ShowBandwidth     | Display bandwidth information.                                                       | False   |                          |
+| net_DebutAuditTrail_HistorySize     | Size of audit history.                                                               | 20      |                          |
+| net_DebugEntities_WarnAboveKbps     |                                                                                      | 10.f    |                          |
+| net_DebugEntities_BelowWarningColor |                                                                                      | Grey    |                          |
+| net_DebugEntities_WarningColor      |                                                                                      | Red     |                          |
+| net_DebugEntities_ShowAboveKbps     |                                                                                      | 1.f     |                          |
 
 ### TLS/DTLS certificate settings
-| Setting                        | Description                                                                                                          | Default                     | Notes | 
-|--------------------------------|----------------------------------------------------------------------------------------------------------------------|-----------------------------|-------|
-| net_SslCertCiphers             | The cipher suite to use when using cert based key exchange.                                                          | ECDHE-RSA-AES256-GCM-SHA384 ||
-| net_SslExternalCertificateFile | The filename of the EXTERNAL (server to client) certificate chain in PEM format.                                     | ""                          ||
-| net_SslExternalContextPassword | The password required for the EXTERNAL (server to client) private certificate.                                       | ""                          ||
-| net_SslExternalPrivateKeyFile  | The filename of the EXTERNAL (server to client) private key file in PEM format.                                      | ""                          ||
-| net_SslInternalCertificateFile | The filename of the INTERNAL (server to server only) certificate chain in PEM format.                                | ""                          ||
-| net_SslInternalContextPassword | The password required for the INTERNAL (server to server only) private certificate.                                 | ""                          ||
-| net_SslInternalPrivateKeyFile  | The filename of the INTERNAL (server to server only) private key file in PEM format.                                 | ""                          ||
-| net_RotateCookieTimer          | Number of milliseconds to wait before generating a new DTLS cookie for handshaking.                                  | 50 ms                       ||
-| net_SslAllowSelfSigned         | If enabled, self-signed certs will not cause a validation error if they are otherwise considered trusted.            | True                        ||
-| net_SslEnablePinning           | If enabled, the public certificates on the local and remote endpoints will be compared to ensure they match exactly. | True                        ||
-| net_SslValidateExpiry          | If enabled, expiration dates on the certificate will be checked for validity.                                        | True                        ||
-| net_SslMaxCertDepth            | The maximum depth allowed for cert chaining validation.                                                              | 3                           ||
+
+| Setting                        | Description                                                                                                          | Default                     | Notes |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- | --------------------------- | ----- |
+| net_SslCertCiphers             | The cipher suite to use when using cert based key exchange.                                                          | ECDHE-RSA-AES256-GCM-SHA384 |       |
+| net_SslExternalCertificateFile | The filename of the EXTERNAL (server to client) certificate chain in PEM format.                                     | ""                          |       |
+| net_SslExternalContextPassword | The password required for the EXTERNAL (server to client) private certificate.                                       | ""                          |       |
+| net_SslExternalPrivateKeyFile  | The filename of the EXTERNAL (server to client) private key file in PEM format.                                      | ""                          |       |
+| net_SslInternalCertificateFile | The filename of the INTERNAL (server to server only) certificate chain in PEM format.                                | ""                          |       |
+| net_SslInternalContextPassword | The password required for the INTERNAL (server to server only) private certificate.                                  | ""                          |       |
+| net_SslInternalPrivateKeyFile  | The filename of the INTERNAL (server to server only) private key file in PEM format.                                 | ""                          |       |
+| net_RotateCookieTimer          | Number of milliseconds to wait before generating a new DTLS cookie for handshaking.                                  | 50 ms                       |       |
+| net_SslAllowSelfSigned         | If enabled, self-signed certs will not cause a validation error if they are otherwise considered trusted.            | True                        |       |
+| net_SslEnablePinning           | If enabled, the public certificates on the local and remote endpoints will be compared to ensure they match exactly. | True                        |       |
+| net_SslValidateExpiry          | If enabled, expiration dates on the certificate will be checked for validity.                                        | True                        |       |
+| net_SslMaxCertDepth            | The maximum depth allowed for cert chaining validation.                                                              | 3                           |       |
 
 ### Debug settings
-| Setting                            | Description                                                 | Default | Notes                    | 
-|------------------------------------|-------------------------------------------------------------|---------|--------------------------|
+
+| Setting                            | Description                                                 | Default | Notes                    |
+| ---------------------------------- | ----------------------------------------------------------- | ------- | ------------------------ |
 | net_DebugCheckNetworkEntityManager | Enables extra debug checks inside the NetworkEntityManager. | False   | Requires Multiplayer Gem |
 
 ### Other useful settings
+
 The following settings can be passed as command line arguments to control server performance.
 
 | Setting      | Description                                                                                                              |
-|--------------|--------------------------------------------------------------------------------------------------------------------------|
+| ------------ | ------------------------------------------------------------------------------------------------------------------------ |
 | rhi          | Add `-rhi=null` to the server launcher args to turn on null renderer to avoid rendering costs.                           |
 | NullRenderer | Add `-NullRenderer` to the server launcher args to turn off RPI ticking to save on performance when using null renderer. |


### PR DESCRIPTION
Fixed some tables that allow the search engine on the website to be able to find sessions of the documentation. Also, removed reference that is no longer needed to make the tutorial working in regards to,  AssetProcessorPlatformConfig.ini file. ShaderVertexOutput is called ShaderOutput in the code.