### PR TITLE
PostFX Layer Component - Fixed a typo

### DIFF
--- a/content/docs/user-guide/components/reference/atom/postfx-layer.md
+++ b/content/docs/user-guide/components/reference/atom/postfx-layer.md
@@ -35,7 +35,7 @@ Each PostFX Layer component must be assigned to a Layer Category. Each Layer Cat
 
 To update the preset Layer Category list:
 
-1. Open Asset Editor form the **Tools** menu.
+1. Open Asset Editor from the **Tools** menu.
 
 1. In Asset Editor, go to **File** &rarr; **Open**.
 


### PR DESCRIPTION
Signed-off-by: Artur Zięba <86952082+LB-ArturZieba@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* PostFX Layer Component (https://www.o3de.org/docs/user-guide/components/reference/atom/postfx-layer/):
   * Fixed a typo in the *Using Layer Categories* section.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?