### PR TITLE
Bump Hugo version to latest.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@ command = "make production-build"
 
 [build.environment]
 HUGO_VERSION = "0.105.0"
+GO_VERSION = "1.18"
 
 [context.deploy-preview]
 command = "make preview-build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.75.1"
+HUGO_VERSION = "0.105.0"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
Updates Hugo version to latest for Netlify builds. This PR is also being used to test staging and deployment to see how we may resolve https://github.com/o3de/o3de.org/issues/2034.