### PR TITLE
Updated the Terrain Height Gradient List documentation

### DIFF
--- a/content/docs/user-guide/components/reference/terrain/height_gradient_list.md
+++ b/content/docs/user-guide/components/reference/terrain/height_gradient_list.md
@@ -6,6 +6,8 @@ description: Use the Terrain Height Gradient List component in your Open 3D Engi
 
 The **Terrain Height Gradient List** provides height data for the terrain system from a list of one or more gradients. The range of heights is adjusted by scaling the height of the [Axis Aligned Box Shape](/docs/user-guide/components/reference/shape/axis-aligned-box-shape) component on the same entity.
 
+The [Terrain Layer Spawner](/docs/user-guide/components/reference/terrain/layer_spawner) that exists on the same Entity will query the **Terrain Height Gradient List** via the `TerrainAreaHeightRequestBus`. If the list contains multiple gradients, the highest point per position queried will be used from each gradient.
+
 ## Provider
 
 [Terrain Gem](/docs/user-guide/gems/reference/environment/terrain)
@@ -13,6 +15,8 @@ The **Terrain Height Gradient List** provides height data for the terrain system
 ## Dependencies
 
 [Axis Aligned Box Shape](/docs/user-guide/components/reference/shape/axis-aligned-box-shape)
+
+[Terrain Layer Spawner](/docs/user-guide/components/reference/terrain/layer_spawner)
 
 ## Terrain Height Gradient List properties
 
@@ -29,3 +33,4 @@ Use the following request functions with the `TerrainAreaHeightRequestBus` EBus 
 | Request Name | Description | Parameter | Return | Scriptable |
 |-|-|-|-|-|
 | `GetHeight` | Returns a Vector3 of the Query Position with the Z-value updated to the terrain's height at the query position.  Also returns a boolean value indicating if terrain exists at the Query Position. | Query Position: Vector3 | Terrain Height: Vector3, Terrain Exists: Boolean | No |
+| `GetHeights` | Takes in a list of Vector3s as input and returns the Vector3s with Z-value updated to the terrain's height at the query position.  Also updates the list of boolean values indicating if terrain exists at each Query Position. | Query Positions: List of Vector3 | Terrain Height: List of Vector3, Terrain Exists: List of Boolean | No |


### PR DESCRIPTION
## Change summary

Updated the Terrain Height Gradient List documentation:
- Extended description by explaining how the `Terrain Layer Spawner` uses it and how it handles multiple gradients
- Added dependency on `Terrain Layer Spawner`
- Added documentation on `GetHeights` API that was added to the `TerrainAreaHeightRequestBus`

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

Signed-off-by: Chris Galvan <chgalvan@amazon.com>