### PR TITLE
Trim extra whitespace from hyperlinks 

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,4 +7,4 @@
 {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
 {{- if .Page.GetPage $url.Path }}{{ $link = printf "%s%s" (.Page.GetPage $url.Path).RelPermalink $fragment }}{{ end }}{{ end -}}
 {{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}{{ if $isRemote }} <sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}</a>
+<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}{{ if $isRemote }} <sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}{{- "" -}}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -7,4 +7,4 @@
 {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
 {{- if .Page.GetPage $url.Path }}{{ $link = printf "%s%s" (.Page.GetPage $url.Path).RelPermalink $fragment }}{{ end }}{{ end -}}
 {{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}{{ if $isRemote }} <sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}{{- "" -}}</a>
+<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{- .Text | safeHTML -}}{{ if $isRemote }} <sup><i class="fas fa-external-link-alt"></i></sup>{{ end }}</a>{{- "" -}}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -9,7 +9,7 @@
 <li>
    <a href="{{ .p1.RelPermalink }}">
     {{ .p1.LinkTitle | markdownify }}
-  </a> / 
+  </a>/ 
 </li>
 {{ end }}
 

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -9,7 +9,7 @@
 <li>
    <a href="{{ .p1.RelPermalink }}">
     {{ .p1.LinkTitle | markdownify }}
-  </a>/ 
+  </a>{{- "/" -}} 
 </li>
 {{ end }}
 


### PR DESCRIPTION
## Change summary

- Add shortcode to link template to trim whitespace from links.
- Removed a space from the breadcrumb navigation template that looks odd.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #1295 
