### PR TITLE
Remove drafts from serve and preview-build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ yarn:
 
 serve: yarn
 	hugo server \
-		--buildDrafts \
 		--buildFuture \
 		--disableFastRender
 
@@ -14,7 +13,6 @@ production-build:
 preview-build:
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
-		--buildDrafts \
 		--buildFuture \
 		--minify \
 		--disableKinds="robotsTXT"


### PR DESCRIPTION
## Change summary

Drafts will no longer be built automatically with the `Serve/Server` or `PreviewBuild` (used for Deploy Previews) commands.

You can enable drafts locally with : `hugo serve -D`

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

