### PR TITLE
Add support for TeX MathML input

### DIFF
--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -544,3 +544,17 @@ Embed Youtube videos in your page by using the `youtube-width` shortcode. The `y
     Output:
 
     {{< youtube-width id="CQmjAxr7LZs" title="What is O3DE?" width="100%" >}}
+
+## Embedding mathematical formulas in TeX and MathML
+
+You can embed mathematical formulas using TeX and MathML input formats, for more information on the MathJax version 3.0 display engine, please refer to the MathJax [documentation](https://docs.mathjax.org/en/latest/index.html).
+
+**Example Usage**
+
+```markdown
+$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
+```
+
+**Example Output**
+
+$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -5,3 +5,4 @@
 <script src="https://cdn.jsdelivr.net/npm/ua-parser-js@0.7.25/src/ua-parser.js" integrity="sha256-zkQSSL5rBWlvCbIoTPQikbYHhOeeiTJy9YX9LXLvFBk=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js" integrity="sha256-DFDZACuFeAqEKv/7Vnu1Tt5ALa58bcWZegGGFNgET8g=" crossorigin="anonymous"></script>
 <script src="{{ $app.RelPermalink }}" type="module" integrity="{{ $app.Data.Integrity }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Change summary

- Add MathJax 3.0 to Hugo template enabling TeX and MathML input.
- Include sample TeX input to smoketest.md

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

