### PR TITLE
"Create a Custom Tool Gem in Python" - Added missing QLineEdit import

### DIFF
--- a/content/docs/learning-guide/tutorials/extend-the-editor/shape-example-py.md
+++ b/content/docs/learning-guide/tutorials/extend-the-editor/shape-example-py.md
@@ -126,7 +126,7 @@ import azlmbr.math as math
 
 from PySide2.QtCore import Qt
 from PySide2.QtGui import QDoubleValidator
-from PySide2.QtWidgets import QCheckBox, QComboBox, QDialog, QFormLayout, QGridLayout, QGroupBox, QLabel,  QPushButton, QVBoxLayout, QWidget
+from PySide2.QtWidgets import QCheckBox, QComboBox, QDialog, QFormLayout, QGridLayout, QGroupBox, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
 ```
 
 ## Dialogs, Widgets, and layouts


### PR DESCRIPTION
Signed-off-by: Tomasz Serwański <86953108+LB-TomaszSerwanski@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

* "Create a Custom Tool Gem in Python" tutorial (https://www.o3de.org/docs/learning-guide/tutorials/extend-the-editor/shape-example-py/):
  * Added a missing import (QLineEdit) - this is required in the "Create an input field" section of the tutorial.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

