### PR TITLE
Wrong command fixed

### DIFF
--- a/content/docs/user-guide/build/distributable-engine.md
+++ b/content/docs/user-guide/build/distributable-engine.md
@@ -121,7 +121,7 @@ If you have an existing project to update rather than creating a new one, the us
 Use the `o3de` script to re-register your project with the install build. This will be used to create the distributable build for your project.
    
 ```cmd
-scripts\o3de.bat register --pp W:\MyProject
+scripts\o3de.bat register -pp W:\MyProject
 ```
 
 The `engine` field of the `project.json` file will now be the name of the engine that was set as `LY_ENGINE_VERSION_NAME` during configuration.


### PR DESCRIPTION
https://github.com/o3de/o3de.org/issues/2085 
Fixed the wrong command from ```scripts\o3de.bat register --pp W:\MyProject``` to ``` scripts\o3de.bat register -pp W:\MyProject```

Signed-off-by: Shrinath Pawar <97937070+ShrinathPawar@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

