### PR TITLE
Prevent _all_ indexing of deployed staging sites.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ yarn.lock
 # IDE / editor files
 .vscode
 .DS_Store
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,10 @@ HUGO_VERSION = "0.105.0"
 GO_VERSION = "1.18"
 
 [context.deploy-preview]
+[[headers]]
+  for = "/*"
+[headers.values]
+  X-Robots-Tag = "none"
 command = "make preview-build"
 
 [context.branch-deploy]


### PR DESCRIPTION
Hopefully this will reduce web crawler traffic by informing it to not only `noindex`, but also `nofollow` (presumably preventing repeated access of _many_ deploy pages without actually indexing anything from them.)