### PR TITLE
Update links to docs.o3de.org subdomain

### DIFF
--- a/content/docs/release-notes/22-10-0/feature-state.md
+++ b/content/docs/release-notes/22-10-0/feature-state.md
@@ -151,7 +151,7 @@ For an up-to-date feature grid and full notes, open the [Feature State Form](htt
 
 | Module | Feature | Functional | Content | Code/API | Performance | Platform | Github Link | Doc Link |
 | :-- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| Deferred Fog | 🟢 Complete | 🟡 Partial | 🟢 Complete | 🟢 Stable | 🟢 Optimized | All  | | [Link](https://docs.o3de.org/docs/user-guide/components/reference/atom/deferred-fog/) |
+| Deferred Fog | 🟢 Complete | 🟡 Partial | 🟢 Complete | 🟢 Stable | 🟢 Optimized | All  | | [Link](https://o3de.org/docs/user-guide/components/reference/atom/deferred-fog/) |
 | Tonemapping | 🟢 Complete | 🟢 Complete | 🟢 Complete | 🟢 Stable | 🟡 Needs Optimization | All  | | [Link](https://www.o3de.org/docs/atom-guide/atom-sample-viewer/graphics-feature-samples/#tonemapping) |
 | Direct Lighting / Area Lights | 🟢 Complete | 🟢 Complete | ⭕ Not Required | 🟢 Stable | 🟡 Needs Optimization | All  | | [Link](https://www.o3de.org/docs/user-guide/components/reference/atom/light/) |
 | Meshes | 🟡 Active | 🟡 Partial | 🟢 Complete | 🟢 Stable | 🟡 Needs Optimization | All  | | [Link](https://www.o3de.org/docs/atom-guide/features/#meshes) |
@@ -212,7 +212,7 @@ For an up-to-date feature grid and full notes, open the [Feature State Form](htt
 | Multiplayer component API | 🟢 Complete | 🟡 Partial | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | |
 | Local Prediction | 🟢 Complete | 🟡 Partial | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | |
 | Server Side Rollback | 🟢 Complete | 🟡 Partial | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | |
-| Play in Editor Mode | 🟡 Active | 🟢 Complete | 🟠 Partial | ❌ Unproven | 🟡 Needs Optimization | | | [Link](https://docs.o3de.org/docs/user-guide/networking/multiplayer/test-in-editor/) |
+| Play in Editor Mode | 🟡 Active | 🟢 Complete | 🟠 Partial | ❌ Unproven | 🟡 Needs Optimization | | | [Link](https://o3de.org/docs/user-guide/networking/multiplayer/test-in-editor/) |
 | Hosting/Joining a Game | 🟡 Active | 🟡 Partial | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | |
 | Network property support | 🟢 Complete | 🟢 Complete | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | [Link](https://www.o3de.org/docs/user-guide/networking/aznetworking/autopackets/) |
 | RPC support | 🟡 Active | 🟡 Partial | ⭕ Not Required | ❌ Unproven | 🟡 Needs Optimization | | | |

--- a/content/docs/release-notes/archive/22-05-0/_index.md
+++ b/content/docs/release-notes/archive/22-05-0/_index.md
@@ -12,7 +12,7 @@ toc: true
 
 First of all: Open 3D Engine has a new logo!
 
-This release also sees the introduction of User Defined Properties (UDP), a way to read metadata from source assets into the Asset Processor. UDP can be assigned in content creation tools to store custom properties about hierarchy nodes such as mesh, light, animation nodes, etc., to power asset generation workflows for O3DE. For more information, read our [blog post on UDP](https://docs.o3de.org/blog/posts/blog-udp/).
+This release also sees the introduction of User Defined Properties (UDP), a way to read metadata from source assets into the Asset Processor. UDP can be assigned in content creation tools to store custom properties about hierarchy nodes such as mesh, light, animation nodes, etc., to power asset generation workflows for O3DE. For more information, read our [blog post on UDP](https://o3de.org/blog/posts/blog-udp/).
 
 We've also included an experimental Gem in this release for motion matching. Motion matching is a data-driven animation technique that synthesizes motions based on existing animation data and the current actor and input contexts. The example Gem includes a character prefab, controllable using a gamepad. Find more details on the supported features and how things work internally in the [Motion Matching Gem code](https://github.com/o3de/o3de/tree/development/Gems/MotionMatching) in our GitHub repository.
 


### PR DESCRIPTION
## Change summary

Docs.o3de.org was removed as a subdomain, thanks @OBWANDO!

- Updated 3 links that pointed to the old subdomain.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #2110 