### PR TITLE
Make search form always use relative path

### DIFF
--- a/layouts/partials/search-results.html
+++ b/layouts/partials/search-results.html
@@ -26,7 +26,7 @@
           // You can customize your searchable fields using any .Page parameters
           "title": "{{ .Title  }}",
           "content": {{ .Content | plainify }}, // Strip out HTML tags
-          "url": "{{ .Permalink }}"
+          "url": "{{ .RelPermalink }}"
       },
       {{ end }}
     }

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,5 +1,5 @@
 <form id="search"
-    action='{{ with .GetPage "/search" }}{{.Permalink}}{{end}}' method="get" class="d-flex align-items-center justify-content-center pl-2">
+    action="/search" method="get" class="d-flex align-items-center justify-content-center pl-2">
     <div class="search-input-view hide-content">
         <label hidden for="search-input">Search site</label>
         <input type="text" id="search-input" class="form-control form-control-sm" name="query"

--- a/layouts/partials/section-nav.html
+++ b/layouts/partials/section-nav.html
@@ -11,7 +11,7 @@
 </p>
 
 <form id="search"
-    action='{{ with .GetPage "/search" }}{{.Permalink}}{{end}}' method="get" class="align-items-center justify-content-center">
+    action="/search" method="get" class="align-items-center justify-content-center">
     <div class="search-input-view">
         <label hidden for="search-input">Search site</label>
         <img src="/img/home/Search_dark.svg" class="search-icon"/>


### PR DESCRIPTION
## Change summary

Change the search form to use the local `/search` path instead of only using `o3de.org` or `localhost`. This allows the deployed preview site search to operate on the deployed version, instead of being redirected to `o3de.org/search`.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Signed-off-by: Chris Galvan <chgalvan@amazon.com>