### PR TITLE
Fix references to the obsolete bootstrap.cfg file

### DIFF
--- a/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
+++ b/content/docs/atom-guide/dev-guide/passes/authoring-passes.md
@@ -17,7 +17,7 @@ Before you begin authoring passes, it's important to understand the Pass System 
 ### Root Pass
 At the basis of the pass system is a **root pass**, which begins the tree of nested child passes. Each pass is registered within its parent pass to establish the overall context of the passes. A pass can be either a render pass or a sub-root with nested child passes. 
 
-One of the key passes is `MainPipeline.pass`, which is the parent pass that defines the rendering logic for the pipeline. You can change Atom's default pipeline pass in the asset file `MainRenderPipeline.azasset`. Furthermore, if you want to change Atom's default pipeline asset, edit the `m_defaultPipelineAssetPath` parameter in the file `bootstrap.cfg`.
+One of the key passes is `MainPipeline.pass`, which is the parent pass that defines the rendering logic for the pipeline. You can change Atom's default pipeline pass in the asset file `MainRenderPipeline.azasset`.
 
 ### Pass Registry
 The **pass registry** contains the registry of all possible pass templates. In order to use a pass template, it must be included in the pass registry. Note that the pass registry can contain pass templates that are never used. You can add a pass templates into the pass registry file `PassTemplates.azasset` by including the name of the pass template and a path to the `.pass` file through the `Name` and `Path` properties.

--- a/content/docs/contributing/to-docs/style-guide/format.md
+++ b/content/docs/contributing/to-docs/style-guide/format.md
@@ -457,7 +457,7 @@ All paths should be platform agnostic and use `/` path separators. When using re
 
 Do | Don't
 :--| :-----
-Open the project's `bootstrap.cfg` file. | Open the project's bootstrap.cfg file.
+Open the project's `project.json` file. | Open the project's project.json file.
 ... in the `/<project>/levels` directory. | ... in the /\<project\>/levels directory.
 Open the `/<project>/game.cfg` file. | Open the /\<project\>/game.cfg file.
 


### PR DESCRIPTION
Signed-off-by: Willow Hayward <17654918+willihay@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Remove or fix references to the obsolete bootstrap.cfg file, replacing with bootstrap.setreg where appropriate.
Note that the topic on FileIO will need another pass to correct outdated information. This has been captured in an earlier issue, https://github.com/o3de/o3de.org/issues/1399.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

