### PR TITLE
Fix CODEOWNERS - Prefix paths with '/' to indicate the root directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,76 +1,76 @@
 # Ownership owners
-.github/CODEOWNERS @o3de/sig-docs-community-maintainers
+/.github/CODEOWNERS @o3de/sig-docs-community-maintainers
 
 # Community content
-content/blog/* @o3de/sig-docs-community-reviewers 
-content/community/* @o3de/sig-docs-community-reviewers 
-content/contribute/* @o3de/sig-docs-community-reviewers 
-content/docs/contributing/* @o3de/sig-docs-community-reviewers 
-static/images/blog/* @o3de/sig-docs-community-reviewers 
-static/images/community/* @o3de/sig-docs-community-reviewers 
-static/images/contribute/* @o3de/sig-docs-community-reviewers 
-static/images/contributing/* @o3de/sig-docs-community-reviewers 
-static/images/shared/* @o3de/sig-docs-community-reviewers 
-layouts/blog/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers 
-layouts/community/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/contribute/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/blog/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/community/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/contribute/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/blog-display.html @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/css.html @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-CONTRIBUTING @o3de/sig-docs-community-reviewers
-README.md @o3de/sig-docs-community-reviewers
+/content/blog/* @o3de/sig-docs-community-reviewers 
+/content/community/* @o3de/sig-docs-community-reviewers 
+/content/contribute/* @o3de/sig-docs-community-reviewers 
+/content/docs/contributing/* @o3de/sig-docs-community-reviewers 
+/static/images/blog/* @o3de/sig-docs-community-reviewers 
+/static/images/community/* @o3de/sig-docs-community-reviewers 
+/static/images/contribute/* @o3de/sig-docs-community-reviewers 
+/static/images/contributing/* @o3de/sig-docs-community-reviewers 
+/static/images/shared/* @o3de/sig-docs-community-reviewers 
+/layouts/blog/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers 
+/layouts/community/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/contribute/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/blog/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/community/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/contribute/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/blog-display.html @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/css.html @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/CONTRIBUTING @o3de/sig-docs-community-reviewers
+/README.md @o3de/sig-docs-community-reviewers
 
 # Release content
-content/docs/release-notes/* @o3de/sig-docs-community-maintainers @o3de/sig-release-maintainers
-static/images/release-notes/* @o3de/sig-docs-community-maintainers @o3de/sig-release-maintainers
+/content/docs/release-notes/* @o3de/sig-docs-community-maintainers @o3de/sig-release-maintainers
+/static/images/release-notes/* @o3de/sig-docs-community-maintainers @o3de/sig-release-maintainers
 
 # Docs content
-content/docs/* @o3de/sig-docs-community-reviewers
-content/smoketest.md @o3de/sig-docs-community-reviewers
-static/docs/* @o3de/sig-docs-community-reviewers
-static/_redirects @o3de/sig-docs-community-reviewers
-static/images/api-reference/* @o3de/sig-docs-community-reviewers
-static/images/atom-guide/* @o3de/sig-docs-community-reviewers
-static/images/community/* @o3de/sig-docs-community-reviewers
-static/images/contribute/* @o3de/sig-docs-community-reviewers
-static/images/contributing/* @o3de/sig-docs-community-reviewers
-static/images/learning-guide/* @o3de/sig-docs-community-reviewers
-static/images/shared/* @o3de/sig-docs-community-reviewers
-static/images/tools-ui/* @o3de/sig-docs-community-reviewers
-static/images/user-guide/* @o3de/sig-docs-community-reviewers
-static/images/welcome-guide/* @o3de/sig-docs-community-reviewers
-static/images/icons/* @o3de/sig-docs-community-reviewers
-layouts/shortcodes/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/docs/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
-layouts/partials/docs* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/content/docs/* @o3de/sig-docs-community-reviewers
+/content/smoketest.md @o3de/sig-docs-community-reviewers
+/static/docs/* @o3de/sig-docs-community-reviewers
+/static/_redirects @o3de/sig-docs-community-reviewers
+/static/images/api-reference/* @o3de/sig-docs-community-reviewers
+/static/images/atom-guide/* @o3de/sig-docs-community-reviewers
+/static/images/community/* @o3de/sig-docs-community-reviewers
+/static/images/contribute/* @o3de/sig-docs-community-reviewers
+/static/images/contributing/* @o3de/sig-docs-community-reviewers
+/static/images/learning-guide/* @o3de/sig-docs-community-reviewers
+/static/images/shared/* @o3de/sig-docs-community-reviewers
+/static/images/tools-ui/* @o3de/sig-docs-community-reviewers
+/static/images/user-guide/* @o3de/sig-docs-community-reviewers
+/static/images/welcome-guide/* @o3de/sig-docs-community-reviewers
+/static/images/icons/* @o3de/sig-docs-community-reviewers
+/layouts/shortcodes/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/docs/* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
+/layouts/partials/docs* @o3de/sig-docs-community-reviewers @o3de/sig-docs-community-site-reviewers
 
 # Web content
-assets/* @o3de/sig-docs-community-site-reviewers
-layouts/* @o3de/sig-docs-community-site-reviewers
-content/search/* @o3de/sig-docs-community-site-reviewers
-static/js/* @o3de/sig-docs-community-site-reviewers
-config.toml @o3de/sig-docs-community-site-reviewers
-Makefile @o3de/sig-docs-community-site-reviewers
-package.json @o3de/sig-docs-community-site-reviewers
+/assets/* @o3de/sig-docs-community-site-reviewers
+/layouts/* @o3de/sig-docs-community-site-reviewers
+/content/search/* @o3de/sig-docs-community-site-reviewers
+/static/js/* @o3de/sig-docs-community-site-reviewers
+/config.toml @o3de/sig-docs-community-site-reviewers
+/Makefile @o3de/sig-docs-community-site-reviewers
+/package.json @o3de/sig-docs-community-site-reviewers
 
 # Foundation-owned materials
-content/download/* @o3de/lf
-content/_index.md @o3de/lf
-LICENSE-* @o3de/lf
-_index.md @o3de/lf
-netlify.toml @o3de/lf
-static/apple-touch-icon-114x114.png @o3de/lf
-static/apple-touch-icon-120x120.png @o3de/lf
-static/apple-touch-icon-144x144.png @o3de/lf
-static/apple-touch-icon-152x152.png @o3de/lf
-static/apple-touch-icon-180x180.png @o3de/lf
-static/apple-touch-icon-57x57.png @o3de/lf
-static/apple-touch-icon-72x72.png @o3de/lf
-static/apple-touch-icon-76x76.png @o3de/lf
-static/apple-touch-icon.png @o3de/lf
-static/favicon.ico @o3de/lf
-static/img/* @o3de/lf
-static/images/events/* @o3de/lf
-static/images/home/* @o3de/lf
+/content/download/* @o3de/lf
+/content/_index.md @o3de/lf
+/LICENSE-* @o3de/lf
+/_index.md @o3de/lf
+/netlify.toml @o3de/lf
+/static/apple-touch-icon-114x114.png @o3de/lf
+/static/apple-touch-icon-120x120.png @o3de/lf
+/static/apple-touch-icon-144x144.png @o3de/lf
+/static/apple-touch-icon-152x152.png @o3de/lf
+/static/apple-touch-icon-180x180.png @o3de/lf
+/static/apple-touch-icon-57x57.png @o3de/lf
+/static/apple-touch-icon-72x72.png @o3de/lf
+/static/apple-touch-icon-76x76.png @o3de/lf
+/static/apple-touch-icon.png @o3de/lf
+/static/favicon.ico @o3de/lf
+/static/img/* @o3de/lf
+/static/images/events/* @o3de/lf
+/static/images/home/* @o3de/lf


### PR DESCRIPTION

We need to adjust the paths to indicate the root directory. This should help fix a current issue where the rule `_index.md @o3de/lf` applies only to the _index.md file that's located at the root folder, and not on all _index.md files. This PR has that issue: https://github.com/o3de/o3de.org/pull/2140

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

