### PR TITLE
Multiplayer Client/Server Split Documentation

### DIFF
--- a/content/docs/user-guide/networking/multiplayer/_index.md
+++ b/content/docs/user-guide/networking/multiplayer/_index.md
@@ -26,6 +26,7 @@ The Multiplayer Gem supports the following:
 | [Configuring a Project](configuration) | How to add and enable the O3DE Multiplayer Gem in a project. |
 | [Running Multiplayer Projects](running) | How to run projects that use the O3DE Multiplayer Gem. |
 | [Multiplayer Auto-components](autocomponents) | How to automatically create components for use with the Multiplayer Gem using the AzAutoGen system. |
+| [Separating Client and Server](split) | How to separate client and server logic and build dependencies.
 | [Testing Multiplayer Projects in the Editor](test-in-editor) | How to automatically launch local servers or connect to a remote persistent server when working on a multiplayer project in the **O3DE Editor**. |
 | [Network Entity Hierarchies](hierarchy) | How to group network entities into hierarchies that process their input together. |
 | [Spawning Players](spawning) | How to spawn an entity for a connecting player to control. |

--- a/content/docs/user-guide/networking/multiplayer/_index.md
+++ b/content/docs/user-guide/networking/multiplayer/_index.md
@@ -26,7 +26,7 @@ The Multiplayer Gem supports the following:
 | [Configuring a Project](configuration) | How to add and enable the O3DE Multiplayer Gem in a project. |
 | [Running Multiplayer Projects](running) | How to run projects that use the O3DE Multiplayer Gem. |
 | [Multiplayer Auto-components](autocomponents) | How to automatically create components for use with the Multiplayer Gem using the AzAutoGen system. |
-| [Separating Client and Server](split) | How to separate client and server logic and build dependencies.
+| [Separating Client and Server](code_separation) | How to separate client and server logic and build dependencies.
 | [Testing Multiplayer Projects in the Editor](test-in-editor) | How to automatically launch local servers or connect to a remote persistent server when working on a multiplayer project in the **O3DE Editor**. |
 | [Network Entity Hierarchies](hierarchy) | How to group network entities into hierarchies that process their input together. |
 | [Spawning Players](spawning) | How to spawn an entity for a connecting player to control. |

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -8,9 +8,9 @@ weight: 450
 The **Multiplayer Gem** supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.
 
 The splitting functionality produces multiple build types:
-* GameLauncher is a client only launcher
-* ServerLauncher is a server only launcher suitable for Dedicated Servers
-* UnifiedLauncher provides both and is suitable for Client Hosted Servers which are clients that can simultaneously host and participate in a multiplayer session
+* _GameLauncher_ is a client-only launcher.
+* _ServerLauncher_ is a server-only launcher suitable for dedicated servers.
+* _UnifiedLauncher_ provides both functionalities, and is suitable for _client-hosted servers_, which are clients that can simultaneously host and participate in a multiplayer session.
 
 This functionality is implemented through a variety of build mechanisms and it's important to understand these mechanisms in any Gem or project using the Multiplayer Gem.
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -128,7 +128,7 @@ Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses
                 Gem::Multiplayer.Common.Static
     )
 ```
-### Conditional Compilation
+### Conditional compilation
 
 MultiplayerComponents are subject to conditional compilation. This is done using the macros `AZ_TRAIT_CLIENT` and `AZ_TRAIT_SERVER`. Client specific logic should be wrapped in the former while Server specific logic should be wrapped in the latter. The motivation for this approach is to allow target specific logic in MultiplayerComponents without requiring target specific files (i.e. a ServerComponent and ClientComponent with or without a BaseComponent).
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -5,7 +5,7 @@ linkTitle: Separating Client and Server
 weight: 450
 ---
 
-The Multiplayer Gem supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.
+The **Multiplayer Gem** supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.
 
 The splitting functionality produces multiple build types:
 * GameLauncher is a client only launcher

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -193,7 +193,7 @@ The following CMake example is abbreviated.
 
 ### AutoComponents
 
-AutoComponents make use of `AZ_TRAIT_SERVER` and `AZ_TRAIT_CLIENT`. Depending on the specification of elements of a component, they will conditionally exclude logic. For example, given an RPC that is invoked on the Client and handled on the Server, the invocation signal will be wrapped in `AZ_TRAIT_CLIENT` while the handler will be wrapped in `AZ_TRAIT_SERVER`. Classes inheriting from AutoComponents will need to honor these usages in order to compile correctly.
+AutoComponents make use of `AZ_TRAIT_SERVER` and `AZ_TRAIT_CLIENT`. Depending on the specification of elements of a component, they will conditionally exclude logic. For example, given an RPC that is invoked on the client and handled on the server, the invocation signal will be wrapped in `AZ_TRAIT_CLIENT` while the handler will be wrapped in `AZ_TRAIT_SERVER`. Classes inheriting from AutoComponents will need to honor these usages in order to compile correctly.
 
 Consider the following RPC:
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -30,7 +30,7 @@ The split by cmake files leads us to four Multiplayer targets:
 1. Common - A target containing multiplayer_files.cmake
 2. Client - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients
 3. Server - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Servers
-4. Unified - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients and Servers
+4. Unified - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for both Clients and Servers
 
 When including the Multiplayer Gem it is important to understand the needs of said usage. If the usage requires split logic, it is recommended to create Client, Server and Unified targets which each use Multiplayer.Client, Server and Unified respectively. If it does not, Multiplayer.Common is sufficient.
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -9,7 +9,7 @@ The Multiplayer Gem supports code separation at build time, to create code that 
 The splitting functionality produces multiple build types:
 * GameLauncher is a client only launcher
 * ServerLauncher is a server only launcher suitable for Dedicated Servers
-* UnifiedLauncher provides both and is suitable for Client Hosted Servers
+* UnifiedLauncher provides both and is suitable for Client Hosted Servers which are clients that can simultaneously host and participate in a multiplayer session
 
 This functionality is implemented through a variety of build mechanisms and it's important to understand these mechanisms in any Gem or project using the Multiplayer Gem.
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -130,7 +130,7 @@ Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses
 ```
 ### Conditional compilation
 
-MultiplayerComponents are subject to conditional compilation. This is done using the macros `AZ_TRAIT_CLIENT` and `AZ_TRAIT_SERVER`. Client specific logic should be wrapped in the former while Server specific logic should be wrapped in the latter. The motivation for this approach is to allow target specific logic in MultiplayerComponents without requiring target specific files (i.e. a ServerComponent and ClientComponent with or without a BaseComponent).
+MultiplayerComponents are subject to conditional compilation. This is done using the macros `AZ_TRAIT_CLIENT` and `AZ_TRAIT_SERVER`. Client-specific logic should be wrapped in the former, while server-specific logic should be wrapped in the latter. The motivation for this approach is to allow target specific logic in MultiplayerComponents without requiring target specific files (i.e. a ServerComponent and ClientComponent with or without a BaseComponent).
 
 In the Multiplayer Gem's cmake, observe that each target enables or disables these traits based on the target. In example, Server enables `AZ_TRAIT_SERVER` while disabling `AZ_TRAIT_CLIENT`. Usage of these targets will bring the macro definitions with them.
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -14,7 +14,7 @@ The splitting functionality produces multiple build types:
 
 This functionality is implemented through a variety of build mechanisms and it's important to understand these mechanisms in any Gem or project using the Multiplayer Gem.
 
-## Splitting Up Client and Server logic
+## Splitting client and server logic
 
 The Multiplayer Gem contains code files that can be divided into two categories:
 1. Files that are fully required on all launcher types.

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -2,6 +2,7 @@
 title: Separating Multiplayer Logic into Client and Server Launchers
 description: Build Open 3D Engine launchers with the Multiplayer Gem specifically targeting Clients, Servers or both.
 linkTitle: Separating Client and Server
+weight: 450
 ---
 
 The Multiplayer Gem supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -132,7 +132,7 @@ Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses
 
 MultiplayerComponents are subject to conditional compilation. This is done using the macros `AZ_TRAIT_CLIENT` and `AZ_TRAIT_SERVER`. Client-specific logic should be wrapped in the former, while server-specific logic should be wrapped in the latter. The motivation for this approach is to allow target specific logic in MultiplayerComponents without requiring target specific files (i.e. a ServerComponent and ClientComponent with or without a BaseComponent).
 
-In the Multiplayer Gem's cmake, observe that each target enables or disables these traits based on the target. In example, Server enables `AZ_TRAIT_SERVER` while disabling `AZ_TRAIT_CLIENT`. Usage of these targets will bring the macro definitions with them.
+In the Multiplayer Gem's cmake, observe that each target enables or disables these traits based on the target. For example, Server enables `AZ_TRAIT_SERVER` while disabling `AZ_TRAIT_CLIENT`. Usage of these targets will bring the macro definitions with them.
 
 {{< note >}}
 The following CMake example is abbreviated.

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -135,7 +135,7 @@ MultiplayerComponents are subject to conditional compilation. This is done using
 In the Multiplayer Gem's cmake, observe that each target enables or disables these traits based on the target. In example, Server enables `AZ_TRAIT_SERVER` while disabling `AZ_TRAIT_CLIENT`. Usage of these targets will bring the macro definitions with them.
 
 {{< note >}}
-The following CMake example is abbreviated
+The following CMake example is abbreviated.
 {{< /note >}}
 
 ```cmake

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -112,7 +112,7 @@ The following CMake examples are abbreviated.
     )
 ```
 
-Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses Multiplayer.Common
+Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses `Multiplayer.Common`.
 
 ```cmake
     ly_add_target(

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -33,7 +33,7 @@ The split by cmake files leads us to four Multiplayer targets:
 3. Server - A target containing `multiplayer_files.cmake` plus `multiplayer_split_files.cmake` conditionally compiled for servers.
 4. Unified - A target containing `multiplayer_files.cmake` plus `multiplayer_split_files.cmake` conditionally compiled for both clients and servers.
 
-When including the Multiplayer Gem it is important to understand the needs of said usage. If the usage requires split logic, it is recommended to create Client, Server and Unified targets which each use Multiplayer.Client, Server and Unified respectively. If it does not, Multiplayer.Common is sufficient.
+When including the Multiplayer Gem it is important to understand the needs of your usage. If the usage requires split logic, it is recommended to create Client, Server, and Unified targets which specify `Multiplayer.Client`, `Multiplayer.Server `, and `Multiplayer.Unified` dependencies, respectively. If your usage does not require split logic, then `Multiplayer.Common` is sufficient.
 
 As an example, [MultiplayerSample](https://github.com/o3de/o3de-multiplayersample) uses and builds upon MultiplayerComponents in the Multiplayer Gem. It therefore defines its own respective Client, Server and Unified targets. 
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -1,5 +1,5 @@
 ---
-title: Client and Server Launchers with the Multiplayer Gem
+title: Separating Multiplayer Logic into Client and Server Launchers
 description: Build Open 3D Engine launchers with the Multiplayer Gem specifically targeting Clients, Servers or both.
 linkTitle: Separating Client and Server
 ---

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -28,10 +28,10 @@ These file lists are maintained in `multiplayer_files.cmake` and `multiplayer_sp
 
 The split by cmake files leads us to four Multiplayer targets:
 
-1. Common - A target containing multiplayer_files.cmake
-2. Client - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients
-3. Server - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Servers
-4. Unified - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for both Clients and Servers
+1. Common - A target containing `multiplayer_files.cmake`.
+2. Client - A target containing `multiplayer_files.cmake` plus `multiplayer_split_files.cmake` conditionally compiled for clients.
+3. Server - A target containing `multiplayer_files.cmake` plus `multiplayer_split_files.cmake` conditionally compiled for servers.
+4. Unified - A target containing `multiplayer_files.cmake` plus `multiplayer_split_files.cmake` conditionally compiled for both clients and servers.
 
 When including the Multiplayer Gem it is important to understand the needs of said usage. If the usage requires split logic, it is recommended to create Client, Server and Unified targets which each use Multiplayer.Client, Server and Unified respectively. If it does not, Multiplayer.Common is sufficient.
 

--- a/content/docs/user-guide/networking/multiplayer/code_separation.md
+++ b/content/docs/user-guide/networking/multiplayer/code_separation.md
@@ -38,7 +38,7 @@ When including the Multiplayer Gem it is important to understand the needs of yo
 As an example, [MultiplayerSample](https://github.com/o3de/o3de-multiplayersample) uses and builds upon MultiplayerComponents in the Multiplayer Gem. It therefore defines its own respective Client, Server and Unified targets. 
 
 {{< note >}}
-The following CMake examples are abbreviated
+The following CMake examples are abbreviated.
 {{< /note >}}
 
 ```cmake

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -6,6 +6,7 @@ linkTitle: Separating Client and Server
 
 The Multiplayer Gem supports builds that contain only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. 
 
+The splitting functionality produces multiple build types.
 * GameLauncher is a client only launcher
 * ServerLauncher is a server only launcher suitable for Dedicated Servers
 * UnifiedLauncher provides both and is suitable for Client Hosted Servers
@@ -33,7 +34,7 @@ The split by cmake files leads us to four Multiplayer targets.
 
 When including the Multiplayer Gem it is important to understand the needs of said usage. If the usage requires split logic, it is recommended to create Client, Server and Unified targets which each use Multiplayer.Client, Server and Unified respectively. If it does not, Multiplayer.Common is sufficient.
 
-As an example, MultiplayerSample uses and builds upon MultiplayerComponents in the Multiplayer Gem. It therefore defines its own respective Client, Server and Unified targets. 
+As an example, [MultiplayerSample](https://github.com/o3de/o3de-multiplayersample) uses and builds upon MultiplayerComponents in the Multiplayer Gem. It therefore defines its own respective Client, Server and Unified targets. 
 
 {{< note >}}
 The following CMake examples are abbreviated

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -1,0 +1,208 @@
+---
+title: Client and Server Launchers with the Multiplayer Gem
+description: Build Open 3D Engine launchers with the Multiplayer Gem specifically targeting Clients, Servers or both.
+linkTitle: Separating Client and Server
+---
+
+The Multiplayer Gem supports builds that contain only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. 
+
+* GameLauncher is a client only launcher
+* ServerLauncher is a server only launcher suitable for Dedicated Servers
+* UnifiedLauncher provides both and is suitable for Client Hosted Servers
+
+This functionality is implemented through a variety of build mechanisms and it's important to understand these mechanisms in any Gem or project using the Multiplayer Gem.
+
+## Splitting Up Client and Server logic
+
+The Multiplayer Gem contains code files that can be divided into two categories.
+1. Files that are fully required on all launcher types.
+2. Files that have parts conditionally compiled out depending on launcher type and their dependents.
+
+These file lists are maintained in multiplayer_files.cmake and multiplayer_split_files.cmake respectively.
+
+multiplayer_files.cmake generally contains core datatypes, base and core classes. multiplayer_split_files.cmake contains AutoComponent based MultiplayerComponents and types dependent on them.
+
+### CMake setup
+
+The split by cmake files leads us to four Multiplayer targets.
+
+1. Common - A target containing multiplayer_files.cmake
+2. Client - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients
+3. Server - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Servers
+4. Unified - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients and Servers
+
+When including the Multiplayer Gem it is important to understand the needs of said usage. If the usage requires split logic, it is recommended to create Client, Server and Unified targets which each use Multiplayer.Client, Server and Unified respectively. If it does not, Multiplayer.Common is sufficient.
+
+As an example, MultiplayerSample uses and builds upon MultiplayerComponents in the Multiplayer Gem. It therefore defines its own respective Client, Server and Unified targets. 
+
+{{< note >}}
+The following CMake examples are abbreviated
+{{< /note >}}
+
+```cmake
+    ly_add_target(
+        NAME MultiplayerSample.Client.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayersample_autogen_files.cmake
+            multiplayersample_files.cmake
+            ${pal_dir}/multiplayersample_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::DebugDraw
+                Gem::PhysX
+                Gem::Multiplayer
+            PRIVATE
+                Gem::Multiplayer.Client.Static
+                Gem::PhysX.Static
+                Gem::DebugDraw.Static
+                Gem::ImGui.Static
+        AUTOGEN_RULES
+            *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
+            *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
+            *.AutoComponent.xml,AutoComponentTypes_Header.jinja,$path/AutoComponentTypes.h
+            *.AutoComponent.xml,AutoComponentTypes_Source.jinja,$path/AutoComponentTypes.cpp
+    )
+
+    ly_add_target(
+        NAME MultiplayerSample.Server.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayersample_autogen_files.cmake
+            multiplayersample_files.cmake
+            ${pal_dir}/multiplayersample_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::PhysX
+                Gem::Multiplayer
+            PRIVATE
+                Gem::Multiplayer.Server.Static
+                Gem::PhysX.Static
+        AUTOGEN_RULES
+            *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
+            *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
+            *.AutoComponent.xml,AutoComponentTypes_Header.jinja,$path/AutoComponentTypes.h
+            *.AutoComponent.xml,AutoComponentTypes_Source.jinja,$path/AutoComponentTypes.cpp
+    )
+
+    ly_add_target(
+        NAME MultiplayerSample.Unified.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayersample_autogen_files.cmake
+            multiplayersample_files.cmake
+            ${pal_dir}/multiplayersample_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::DebugDraw
+                Gem::PhysX
+                Gem::Multiplayer
+            PRIVATE
+                Gem::Multiplayer.Unified.Static
+                Gem::PhysX.Static
+                Gem::DebugDraw.Static
+                Gem::ImGui.Static
+        AUTOGEN_RULES
+            *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
+            *.AutoComponent.xml,AutoComponent_Source.jinja,$path/$fileprefix.AutoComponent.cpp
+            *.AutoComponent.xml,AutoComponentTypes_Header.jinja,$path/AutoComponentTypes.h
+            *.AutoComponent.xml,AutoComponentTypes_Source.jinja,$path/AutoComponentTypes.cpp
+    )
+```
+
+Meanwhile, Multiplayer_ScriptCanvas only requires core datatypes so it only uses Multiplayer.Common
+
+```cmake
+    ly_add_target(
+        NAME ${gem_name}.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            scriptcanvas_multiplayer_files.cmake
+            scriptcanvas_autogen_files.cmake
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::ScriptCanvas
+            PRIVATE
+                Gem::Multiplayer.Common.Static
+    )
+```
+### Conditional Compilation
+
+MultiplayerComponents are subject to conditional compilation. This is done using the macros `AZ_TRAIT_CLIENT` and `AZ_TRAIT_SERVER`. Client specific logic should be wrapped in the former while Server specific logic should be wrapped in the latter. The motivation for this approach is to allow target specific logic in MultiplayerComponents without requiring target specific files (i.e. a ServerComponent and ClientComponent with or without a BaseComponent).
+
+In the Multiplayer Gem's cmake, observe that each target enables or disables these traits based on the target. In example, Server enables `AZ_TRAIT_SERVER` while disabling `AZ_TRAIT_CLIENT`. Usage of these targets will bring the macro definitions with them.
+
+{{< note >}}
+The following CMake example is abbreviated
+{{< /note >}}
+
+```cmake
+    ly_add_target(
+        NAME Multiplayer.Client.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayer_split_files.cmake
+        COMPILE_DEFINITIONS
+            PUBLIC
+                AZ_TRAIT_CLIENT=1
+                AZ_TRAIT_SERVER=0
+        BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzCore
+                AZ::AzFramework
+                AZ::AzNetworking
+            PRIVATE
+                Gem::Multiplayer.Common.Static
+    )
+
+    ly_add_target(
+        NAME Multiplayer.Server.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayer_split_files.cmake
+        COMPILE_DEFINITIONS
+            PUBLIC
+                AZ_TRAIT_CLIENT=0
+                AZ_TRAIT_SERVER=1
+        BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzCore
+                AZ::AzFramework
+                AZ::AzNetworking
+            PRIVATE
+                Gem::Multiplayer.Common.Static
+    )
+```
+
+### AutoComponents
+
+AutoComponents make use of `AZ_TRAIT_SERVER` and `AZ_TRAIT_CLIENT`. Depending on the specification of elements of a component, they will conditionally exclude logic. For example, given an RPC that is invoked on the Client and handled on the Server, the invocation signal will be wrapped in `AZ_TRAIT_CLIENT` while the handler will be wrapped in `AZ_TRAIT_SERVER`. Classes inheriting from AutoComponents will need to honor these usages in order to compile correctly.
+
+Consider the following RPC:
+
+```xml
+    <RemoteProcedure Name="SendClientInput" InvokeFrom="Autonomous" HandleOn="Authority" IsPublic="true" IsReliable="false" GenerateEventBindings="false" Description="Client to server move / input RPC">
+        <Param Type="Multiplayer::NetworkInputArray" Name="inputArray"  />
+        <Param Type="AZ::HashValue32" Name="stateHash" />
+    </RemoteProcedure>
+```
+
+This generates the following AutoComponent signatures:
+
+```cpp
+    //! SendClientInput Invocation
+    //! Client to server move / input RPC
+    //! HandleOn Authority
+    #if AZ_TRAIT_CLIENT
+    void SendClientInput(const Multiplayer::NetworkInputArray& inputArray, const AZ::HashValue32& stateHash);
+    #endif
+
+    #if AZ_TRAIT_SERVER
+    //! SendClientInput Handler
+    //! Client to server move / input RPC
+    //! HandleOn Authority
+    virtual void HandleSendClientInput(AzNetworking::IConnection* invokingConnection, const Multiplayer::NetworkInputArray& inputArray, const AZ::HashValue32& stateHash) {}
+    #endif
+```
+
+A component inheriting from this AutoComponent that overrides HandleSendClientInput would need to similarly wrap it in `AZ_TRAIT_SERVER` as well.

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -21,7 +21,7 @@ The Multiplayer Gem contains code files that can be divided into two categories.
 
 These file lists are maintained in multiplayer_files.cmake and multiplayer_split_files.cmake respectively.
 
-multiplayer_files.cmake generally contains core datatypes, base and core classes. multiplayer_split_files.cmake contains AutoComponent based MultiplayerComponents and types dependent on them.
+`multiplayer_files.cmake` generally contains core datatypes, base and core classes. `multiplayer_split_files.cmake` contains AutoComponent based MultiplayerComponents and types dependent on them.
 
 ### CMake setup
 

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -6,7 +6,7 @@ linkTitle: Separating Client and Server
 
 The Multiplayer Gem supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.
 
-The splitting functionality produces multiple build types.
+The splitting functionality produces multiple build types:
 * GameLauncher is a client only launcher
 * ServerLauncher is a server only launcher suitable for Dedicated Servers
 * UnifiedLauncher provides both and is suitable for Client Hosted Servers

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -4,7 +4,7 @@ description: Build Open 3D Engine launchers with the Multiplayer Gem specificall
 linkTitle: Separating Client and Server
 ---
 
-The Multiplayer Gem supports builds that contain only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. 
+The Multiplayer Gem supports builds that contain only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, a publicly released game client that doesn't ship with server logic can make hacking the simulation more difficult.
 
 The splitting functionality produces multiple build types.
 * GameLauncher is a client only launcher

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -19,7 +19,7 @@ The Multiplayer Gem contains code files that can be divided into two categories:
 1. Files that are fully required on all launcher types.
 2. Files that have parts conditionally compiled out depending on launcher type and their dependents.
 
-These file lists are maintained in multiplayer_files.cmake and multiplayer_split_files.cmake respectively.
+These file lists are maintained in `multiplayer_files.cmake` and `multiplayer_split_files.cmake` respectively.
 
 `multiplayer_files.cmake` generally contains core datatypes, base and core classes. `multiplayer_split_files.cmake` contains AutoComponent based MultiplayerComponents and types dependent on them.
 

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -15,7 +15,7 @@ This functionality is implemented through a variety of build mechanisms and it's
 
 ## Splitting Up Client and Server logic
 
-The Multiplayer Gem contains code files that can be divided into two categories.
+The Multiplayer Gem contains code files that can be divided into two categories:
 1. Files that are fully required on all launcher types.
 2. Files that have parts conditionally compiled out depending on launcher type and their dependents.
 

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -171,6 +171,23 @@ The following CMake example is abbreviated
                 AZ::AzNetworking
                 Gem::Multiplayer.Common.Static
     )
+
+    ly_add_target(
+        NAME Multiplayer.Unified.Static STATIC
+        NAMESPACE Gem
+        FILES_CMAKE
+            multiplayer_split_files.cmake
+        COMPILE_DEFINITIONS
+            PUBLIC
+                AZ_TRAIT_CLIENT=1
+                AZ_TRAIT_SERVER=1
+        BUILD_DEPENDENCIES
+            PUBLIC
+                AZ::AzCore
+                AZ::AzFramework
+                AZ::AzNetworking
+                Gem::Multiplayer.Common.Static
+    )
 ```
 
 ### AutoComponents

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -25,7 +25,7 @@ multiplayer_files.cmake generally contains core datatypes, base and core classes
 
 ### CMake setup
 
-The split by cmake files leads us to four Multiplayer targets.
+The split by cmake files leads us to four Multiplayer targets:
 
 1. Common - A target containing multiplayer_files.cmake
 2. Client - A target containing multiplayer_files.cmake plus multiplayer_split_files.cmake conditionally compiled for Clients

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -151,7 +151,6 @@ The following CMake example is abbreviated
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::AzNetworking
-            PRIVATE
                 Gem::Multiplayer.Common.Static
     )
 
@@ -169,7 +168,6 @@ The following CMake example is abbreviated
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::AzNetworking
-            PRIVATE
                 Gem::Multiplayer.Common.Static
     )
 ```

--- a/content/docs/user-guide/networking/multiplayer/split.md
+++ b/content/docs/user-guide/networking/multiplayer/split.md
@@ -4,7 +4,7 @@ description: Build Open 3D Engine launchers with the Multiplayer Gem specificall
 linkTitle: Separating Client and Server
 ---
 
-The Multiplayer Gem supports builds that contain only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, a publicly released game client that doesn't ship with server logic can make hacking the simulation more difficult.
+The Multiplayer Gem supports code separation at build time, to create code that contains only client logic, only server logic, or both client and server logic. This allows users to create executables of smaller size by excluding unnecessary logic and dependencies. It also allows hiding potentially sensitive logic unique to one executable from the other. For example, ensuring that a free-to-play client executable never includes any server logic code will reduce the chances of hacking or abuse.
 
 The splitting functionality produces multiple build types.
 * GameLauncher is a client only launcher


### PR DESCRIPTION
## Change summary

This change provides documentation for the Multiplayer Gem's Client/Server split feature, implemented in https://github.com/o3de/o3de/pull/12344. This change is in draft until the related feature is ready for submission.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

