### PR TITLE
Add support for Mermaid.js diagram tool in blogs and docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,7 @@ unsafe = true
 
 [params]
 font_awesome_version = "5.12.0"
+mermaid_version = ["9.2.2", "sha384-W/RuUCsZGwf4MwkS0K4JdFzoA0RgiA6foiYzRo68rW5DNPfq+5Dr0uGKY1zecHEA"]
 description = "Open 3D Engine (O3DE) is a modular, open source, cross-platform 3D engine built to power anything from AAA games to cinema-quality 3D worlds to high-fidelity simulations. No fees or commercial obligations. Apache 2.0-licensed. Managed by The Linux Foundation."
 favicon = "favicon.ico"
 repositoryUrl = "https://github.com/o3de/o3de.org"

--- a/content/smoketest.md
+++ b/content/smoketest.md
@@ -558,3 +558,59 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 **Example Output**
 
 $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
+
+## Embedding Mermaid diagrams
+
+**Example UML Class Diagram**
+
+````
+```mermaid
+classDiagram
+    Animal <|-- Duck
+    Animal <|-- Fish
+    Animal <|-- Zebra
+    Animal : +int age
+    Animal : +String gender
+    Animal: +isMammal()
+    Animal: +mate()
+    class Duck{
+        +String beakColor
+        +swim()
+        +quack()
+    }
+    class Fish{
+        -int sizeInFeet
+        -canEat()
+    }
+    class Zebra{
+        +bool is_wild
+        +run()
+    }
+```
+````
+
+**Example Output**
+
+```mermaid
+classDiagram
+    Animal <|-- Duck
+    Animal <|-- Fish
+    Animal <|-- Zebra
+    Animal : +int age
+    Animal : +String gender
+    Animal: +isMammal()
+    Animal: +mate()
+    class Duck{
+        +String beakColor
+        +swim()
+        +quack()
+    }
+    class Fish{
+        -int sizeInFeet
+        -canEat()
+    }
+    class Zebra{
+        +bool is_wild
+        +run()
+    }
+```

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<div class="mermaid">
+    {{- .Inner | safeHTML }}
+</div>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+{{ $mermaidVersion := site.Params.mermaid_version }}
   <div class="container">
       <section class="row">
         <section class="col col-8">
@@ -7,6 +8,13 @@
           <div class="content">
             {{ . }}
           </div>
+          {{ end }}
+
+          {{ if .Page.Store.Get "hasMermaid" }}
+            <script src="https://cdn.jsdelivr.net/npm/mermaid@{{ index $mermaidVersion 0 }}/dist/mermaid.min.js" integrity="{{ index $mermaidVersion 1 }}" crossorigin="anonymous"></script>
+            <script>
+              mermaid.initialize({ startOnLoad: true });
+            </script>
           {{ end }}
         </section>
       </section>

--- a/layouts/partials/blog/content.html
+++ b/layouts/partials/blog/content.html
@@ -1,3 +1,4 @@
+{{ $mermaidVersion := site.Params.mermaid_version }}
 {{ $posts := where site.RegularPages "Section" "blog" }}
 <div class="container">
   <div class="columns">
@@ -5,6 +6,14 @@
       <div class="">
         {{ .Content }}
       </div>
+
+      {{ if .Page.Store.Get "hasMermaid" }}
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@{{ index $mermaidVersion 0 }}/dist/mermaid.min.js" integrity="{{ index $mermaidVersion 1 }}" crossorigin="anonymous"></script>
+        <script>
+            mermaid.initialize({ startOnLoad: true });
+        </script>
+      {{ end }}
+      
       <a class="btn btn-primary back-to-blog" href="/blog">
         <span>
           Back to blogs

--- a/layouts/partials/docs/content.html
+++ b/layouts/partials/docs/content.html
@@ -1,5 +1,13 @@
+{{ $mermaidVersion := site.Params.mermaid_version }}
 {{ with .Content }}
 <div class="content">
   {{ . }}
 </div>
+{{ end }}
+
+{{ if .Page.Store.Get "hasMermaid" }}
+<script src="https://cdn.jsdelivr.net/npm/mermaid@{{ index $mermaidVersion 0 }}/dist/mermaid.min.js" integrity="{{ index $mermaidVersion 1 }}" crossorigin="anonymous"></script>
+<script>
+  mermaid.initialize({ startOnLoad: true });
+</script>
 {{ end }}


### PR DESCRIPTION
Signed-off-by: Willow Hayward <17654918+willihay@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

- Added support for Mermaid.js diagram tool in blogs and docs content.
- Mermaid version and SRI integrity check defined in site config.

Here's a screenshot of the smoketest (since smoke test is no longer built in deploy preview):

![image](https://user-images.githubusercontent.com/17654918/207462711-b3137014-86da-420d-a5c1-633833afa48e.png)

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

