### PR TITLE
Issue1789 brokenpackagedebuglink

### DIFF
--- a/content/docs/user-guide/packaging/windows-release-builds.md
+++ b/content/docs/user-guide/packaging/windows-release-builds.md
@@ -127,7 +127,7 @@ To process your project's assets, do one of the following:
 
 Verify that Asset Processor successfully processed your assets by checking their status. Asset Processor can process your assets with or without warning or error, or they can fail to process. Warnings and errors indicate that your asset may need your attention, but they don't impede the ability to create a project game release layout. On the other hand, it's critical that you resolve any assets that were not processed due to failure.
 
-For help with debugging failures, refer to [Debugging](#debugging).
+For help with troubleshooting failures, refer to [Troubleshooting Packaging in O3DE](/docs/user-guide/packaging/troubleshooting/).
 
 
 ## Create a project game release layout


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Fixed a broken link in the [Creating a Project Game Release Layout for Windows](https://www.o3de.org/docs/user-guide/packaging/windows-release-builds/) page. It linked to a debugging section of the same page that no longer exists because it was previously moved to its own page. Fixes #1789.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

