### PR TITLE
updated the Python docs about EditorComponentAPIBus

### DIFF
--- a/content/docs/user-guide/editor/editor-automation.md
+++ b/content/docs/user-guide/editor/editor-automation.md
@@ -255,10 +255,15 @@ weight: 600
  # output: (list of strings) of type names
  'FindComponentTypeNames'
  
- # Returns the full list of names for all components that can be created with the EditorComponent API
- # input: N/A
+ # Returns the full list of names for all game components that can be created with the EditorComponent API
+ # input: entity.EntityType().Game
  # output: (list of strings) of the known component type names
- 'BuildComponentTypeNameList'
+ 'BuildComponentTypeNameListByEntityType'
+
+ # Returns the full list of names for all level components that can be created with the EditorComponent API
+ # input: entity.EntityType().Level
+ # output: (list of strings) of the known component type names
+ 'BuildComponentTypeNameListByEntityType'
  ```
  
  **Example usage**:
@@ -266,9 +271,12 @@ weight: 600
  ```python
  import azlmbr.bus as bus
  
- # Generate list of component type names
- componentList = azlmbr.editor.EditorComponentAPIBus(bus.Broadcast, 'BuildComponentTypeNameList')
+ # Generate list of game component type names
+ componentList = editor.EditorComponentAPIBus(bus.Broadcast, 'BuildComponentTypeNameListByEntityType', entity.EntityType().Game)
  
+ # Generate list of level component type names
+ componentList = editor.EditorComponentAPIBus(bus.Broadcast, 'BuildComponentTypeNameListByEntityType', entity.EntityType().Level)
+
  # Get component types for 'Mesh' and 'Comment'
  typeIdList = azlmbr.editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeIds', ["Mesh", "Comment"])
  


### PR DESCRIPTION
## Change summary

The 'BuildComponentTypeNameList' was the old event name 'BuildComponentTypeNameListByEntityType' is the new event name

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

