### PR TITLE
Remove 'textures' page because it's documented somewhere else already

### DIFF
--- a/content/docs/atom-guide/look-dev/_index.md
+++ b/content/docs/atom-guide/look-dev/_index.md
@@ -11,7 +11,6 @@ This section contains the information about creative tools and concepts for look
 | Topic                        | Description |
 |--------------------------------------|---------|
 | [Materials](materials/) | Learn about PBR materials, how to create materials, and the Material Editor in Atom. |
-| [Textures](textures/) | Learn about how textures are supported and processed in Atom. |
 | [Shading](shaders/) | Learn about shading in Atom. |
 | [Color Management](color-management/) | Learn about the color space conversion workflow used in Atom. |
 | [Tutorials](/docs/learning-guide/tutorials/rendering/) | A collection of tutorials about rendering and look development in O3DE, located in the Learning Guide. |

--- a/content/docs/atom-guide/look-dev/textures/_index.md
+++ b/content/docs/atom-guide/look-dev/textures/_index.md
@@ -1,9 +1,0 @@
----
-title: "Textures"
-description: "Learn about how textures are supported and processed in Atom Renderer."
-toc: true
-weight: 300
----  
-
-{{< todo issue="https://github.com/o3de/o3de.org/issues/1563" >}}
-{{< /todo >}}


### PR DESCRIPTION
Signed-off-by: chanmosq <75444793+chanmosq@users.noreply.github.com>

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

