### PR TITLE
Specify Hugo minimum version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are working on the documentation or interested in seeing a specific branc
 
 To build the O3DE website locally, you need the items below.
 - `o3de.org` repository
-- **Hugo (extended version)**, a static site generator that builds the website.
+- **Hugo (extended version 0.93 or later)**, a static site generator that builds the website.
 - **npm** (or another package manager) to install the **bootstrap** package, which Hugo needs for styling.
 
 ### Download the repository
@@ -25,7 +25,7 @@ You can download this repository or clone it onto your local machine. Cloning th
 ### Setup Hugo, npm, and dependencies
 1. To install **Hugo (extended version)**, follow the instructions for your machine in the [Hugo documentation](https://gohugo.io/getting-started/installing). 
    
-    *Note: You must install the **extended version** of Hugo.*
+    *Note: You must install the **extended version** of Hugo, version 0.93 or later. If downloading a prebuilt binary, make sure the filename starts with `hugo_extended`.*
 
 2. To install **npm**, follow the instructions in the [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) documentation. Installing npm also installs **Node.js**.
 
@@ -89,7 +89,39 @@ You can now view the O3DE website on your local machine! Find the O3DE documenta
 
 ## Troubleshooting
 
-### Issue
+### Issue: Module not compatible
+
+Running `hugo server` outputs the following warning:
+
+```cmd
+WARN ... Module "project" is not compatible with this Hugo version; run "hugo mod graph" for more information.
+```
+
+#### Description
+
+This indicates that you are not using the correct edition or version of Hugo. The `o3de.org` website requires Hugo extended edition, version 0.93 or later.
+
+#### Steps to fix
+
+Install the latest release of **Hugo extended**, following the instructions for your machine in the [Hugo documentation](https://gohugo.io/getting-started/installing). If downloading a prebuilt binary, make sure the filename starts with `hugo_extended`.
+
+### Issue: Render of page failed / Can't evaluate field Store in page.Page
+
+Running `hugo server` outputs the following error:
+
+```cmd
+ERROR ... render of "page" failed: execute of template failed: template: blog/single.html:8:7: executing "main" at <partial "blog/content.html" .>: error calling partial: "C:\o3de.org\layouts\partials\blog\content.html:10:17": execute of template failed: template: partials/blog/content.html:10:17: executing "partials/blog/content.html" at <.Page.Store.Get>: can't evaluate field Store in type page.Page
+```
+
+#### Description
+
+This indicates that you are using an older version of Hugo that does not support the field page.Store.
+
+#### Steps to fix
+
+Install the latest release of **Hugo extended**, following the instructions for your machine in the [Hugo documentation](https://gohugo.io/getting-started/installing). If downloading a prebuilt binary, make sure the filename starts with `hugo_extended`.
+
+### Issue: SCSS processing failed
 
 Running `hugo server` outputs the following error:
 
@@ -97,17 +129,16 @@ Running `hugo server` outputs the following error:
 Error: Error building site: TOCSS: failed to transform "blah.sass" (text/x-sass): SCSS processing failed: file "stdin", line 26, col 1: File to import not found or unreadable: bootstrap/scss/functions.
 ```
 
-### Description
+#### Description
 
 This indicates that your local `o3de.org` repository may be missing bootstrap, or that the wrong version is installed. Similar errors may indicate that other dependent packages are missing.
 
 For a complete list of required dependencies, see `package.json`.
 
-### Steps to fix
+#### Steps to fix
 
 1. Open a shell or terminal and navigate to `o3de.org` repository: `cd <path-to-repo>/o3de.org`
 
 2. Verify that the required dependencies have been installed by running the command, `npm list`. This outputs the list of dependencies and indicates whether or not they've been installed.
 
 3. Install missing dependencies. You can install all of the dependencies by running the command, `npm install`. Or, you can install a specific dependency. For example: `npm install bootstrap@4.6.1`
-

--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,11 @@ title = "Open 3D Engine"
 disableKinds = ["taxonomy", "taxonomyTerm"]
 copyright = "O3DE Open 3D Engine Contributors | Documentation Distributed under CC-BY 4.0"
 
+[module]
+  [module.hugoVersion]
+    extended = true
+    min = '0.93.0'
+
 enableGitInfo = true
 enableRobotsTXT = true 
 

--- a/content/docs/contributing/to-docs/hugo.md
+++ b/content/docs/contributing/to-docs/hugo.md
@@ -8,7 +8,7 @@ weight: 600
 
 The **Open 3D Engine (O3DE)** documentation website uses the [Hugo](https://gohugo.io/) static site generator and deploys using [Netlify](https://netlify.com).
 
-See the [GitHub repository](https://github.com/o3de/o3de.org) for build instructions and prerequisites, and [the Git workflow](git-workflow.md) for more information on how the project works.
+Refer to the o3de.org [README.md](https://github.com/o3de/o3de.org#readme) for build instructions and prerequisites, and [the Git workflow](git-workflow.md) for more information on how the project works.
 
 ## Adding new pages 
 


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

In the process of troubleshooting a contributor's Hugo build error, I discovered that there is a minimum version of Hugo that's required to build the o3de.org website with the `hugo server` command. **Hugo version 0.93 or later** is now required.

Justification: This requirement was inadvertently introduced with the recent addition of support for the Mermaid diagram tool. Given the usefulness of Mermaid in the Engine Developer Guide, and that Hugo version 0.93 is almost a year old, this seems like a reasonable requirement to add.

Changes:

- Update Hugo setup instructions in this repo's README.md.
- Add new build troubleshooting instructions.
- Specify the min version and the (already known) extended edition requirements in the Hugo config file. This will cause a helpful warning to be issued if a user builds the website with a version of Hugo that does not meet the version and edition requirements.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

