### PR TITLE
Created a GitHub Action workflow that creates a PR to sync main-to-dev

### DIFF
--- a/.github/workflows/auto-pr-main-to-dev.yml
+++ b/.github/workflows/auto-pr-main-to-dev.yml
@@ -26,4 +26,4 @@ jobs:
           PULL_REQUEST_BODY: |
             This is an automatically generated PR to sync `main` to `development`.
           CONTENT_COMPARISON: true
-          TEAM_REVIEWERS: @o3de/sig-docs-community-maintainers
+          TEAM_REVIEWERS: '["@o3de/sig-docs-community-maintainers"]'

--- a/.github/workflows/auto-pr-main-to-dev.yml
+++ b/.github/workflows/auto-pr-main-to-dev.yml
@@ -1,0 +1,28 @@
+name: Auto Sync PR main-to-dev
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches main to dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "main"
+          TO_BRANCH: "development"
+          PULL_REQUEST_TITLE: (Auto) Sync main-to-development
+          PULL_REQUEST_BODY: |
+            This is an automatically generated PR to sync `main` to `development`.
+          CONTENT_COMPARISON: true

--- a/.github/workflows/auto-pr-main-to-dev.yml
+++ b/.github/workflows/auto-pr-main-to-dev.yml
@@ -26,3 +26,4 @@ jobs:
           PULL_REQUEST_BODY: |
             This is an automatically generated PR to sync `main` to `development`.
           CONTENT_COMPARISON: true
+          TEAM_REVIEWERS: @o3de/sig-docs-community-maintainers


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

This introduces a new workflow that creates a PR to sync main-to-dev. It is triggered whenever there is a merge to `main`. If there are multiple merges to `main`, only one sync PR is automatically created. 

This workflow the [**Sync Branches**](https://github.com/marketplace/actions/sync-branches) GitHub Action.

### Testing
I've tested the workflow in my own fork. Here are the test cases: 

#### Test 1
Test with few changes in `docs/` (commit [1a4d75a](https://github.com/chanmosq/o3de.org/commit/1a4d75a4166ee0a0feb0049fdb2f94c3ebbd2a7b)). The commit came from `upstream/main`, and was committed *after* the commit, WK 5 main-to-dev-sync ([d6456ee](https://github.com/o3de/o3de.org/pull/2224/commits/d6456eeb5380ecb18368cfff77b507b299d4a627)). Therefore, this commit will be branc new to `origin/development`
1. Run the following commands to cherry-pick a new commit into `main`
```shell
git switch -c main
git cherry-pick 1a4d75a
git push origin main
```
2. Create a PR: https://github.com/chanmosq/o3de.org/pull/6
3. Merge the PR.
4. A few minutes later, observe how this sync PR was automatically created: https://github.com/chanmosq/o3de.org/pull/7
	**Note: The generated sync PR in "Test 1" shows numerous commits to merge into `development`. This is not expected, given that synced `development` to this point when completing the steps in "Setting up a Test Environment". The only commit expected was 1a4d75a. However, in "Test 2", the generated sync PR has only one commit, as expected.

#### Test 2
Test with more changes in `docs/` (commit [397fca0](https://github.com/o3de/o3de.org/commit/397fca0229be1b224dad8827bd2f04c7e824270e)). We follow the same steps as **Test 1**, but with another commit. Again, merging the PR to `main` , led to the automatic creation of a sync PR: https://github.com/chanmosq/o3de.org/pull/8

##### Test 3
Test with multiple pushes to `main` (commits [29ce2f5](https://github.com/o3de/o3de.org/commit/29ce2f5c00e0528a43e1d8f4e9a71ae096236787), [29916f8](https://github.com/o3de/o3de.org/commit/29916f8e262c7c6bd6cf073518acdcdbbcbb9cbb), and [25f0bae](https://github.com/o3de/o3de.org/commit/25f0baebee402c45ca7c0808d55ddecdd5334a77)).  This did not trigger the workflow to create multiple sync PRs - it only created one sync PR, which updated whenever a new commit was pushed to `main`: https://github.com/chanmosq/o3de.org/pull/9
```shell
git switch -c main

# A push to main
git cherry-pick 29ce2f5
git push origin main

# Another push to main
git cherry-pick 29916f8
git push origin main

# One more, pushed after the auto PR was created
git cherry-pick 25f0bae
git push origin main
```

As **Test 3** shows, there is no need to worry about multiple auto sync PRs being created. 

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

