### PR TITLE
Enhance and simplify build instructions

### DIFF
--- a/content/docs/user-guide/build/distributable-engine.md
+++ b/content/docs/user-guide/build/distributable-engine.md
@@ -3,20 +3,19 @@ title: Create Distributable Open 3D Engine Builds
 linktitle: Engine and Project Distribution
 description: Learn the process for building a full bundle of libraries and executables that you can distribute to internal teams to use your customized version of Open 3D Engine (O3DE).
 weight: 200
-toc: true
 ---
 
-Often, project developers are working on teams where engineers and others will be modifying the core **Open 3D Engine (O3DE)** code for internal needs. In these cases you need a _distributable build_ of the customized O3DE and project, so that your team can collaborate all using the same technical stack that's provided in-house. 
+Often, project developers are working on teams where engineers and others will be modifying the core **Open 3D Engine (O3DE)** code for internal needs. In these cases you need a _distributable build_ of the customized O3DE and project (also known as a "pre-built SDK engine"), so that your team can all collaborate using the same technical stack that's provided in-house.
 
 This topic guides you through the creation of an engine build to distribute internally as part of project development, which can be used by a project-dedicated team while keeping the engine-dedicated team's work separated and independent.
 
-The steps outlined in this section are appropriate for build engineers to set up continuous integration (CI) systems which create and distribute new builds on a regular basis - or for developers who need to make regular one-off builds for smaller teams.
+The steps outlined in this section are appropriate for build engineers to set up continuous integration (CI) systems which create and distribute new builds on a regular basis, or for developers who need to make regular one-off builds for smaller teams.
 
 ## Prerequisites
 
 The prerequisites required for creating a distributable build are:
 
-* A local clone of O3DE source code.
+* O3DE source code.
 * A location to host the distributable build, such as source control.
 
 ## Example values
@@ -58,11 +57,16 @@ The first step in creating a distributable build is generating local binaries fr
 
 Perform the following steps from the O3DE source directory (`C:\o3de-source` in this example):
 
-1.  Generate the toolchain project files using a unique `LY_VERSION_ENGINE_NAME` CMake cache setting. This value is the name of the engine used by the O3DE project manager and registration system.
-    
+1.  Generate the toolchain project files using a unique `LY_VERSION_ENGINE_NAME` CMake cache setting. This value is the name of the engine used by **Project Manager** and the O3DE registration system. Giving the install layout a different engine name than the source engine enables the engines to be registered side-by-side.
+
     ```cmd
     cmake -B build/windows -G "Visual Studio 16" --config profile -DLY_VERSION_ENGINE_NAME="MyO3DE"
     ```
+
+    Other cache variables to consider setting on this line (using the `-D` option) include:
+
+    * `LY_3RDPARTY_PATH` : The path to a custom downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
+    * `CMAKE_INSTALL_PREFIX`: The parent directory of the `bin` directory containing the distributable binaries. You will find the Project Manager, Editor, and other binaries in the subdirectory `bin\Windows\profile\Default`. If you don't specify this option, the engine SDK binaries will be built to `<ENGINE_SOURCE>\install\bin\Windows\profile\Default`.
 
     {{< note >}}
 Use `Visual Studio 16` as the generator for Visual Studio 2019, and `Visual Studio 17` for Visual Studio 2022. For a complete list of common generators for each supported platform, refer to [Configuring projects](./configure-and-build/#configuring-projects).
@@ -71,11 +75,11 @@ Use `Visual Studio 16` as the generator for Visual Studio 2019, and `Visual Stud
     The **profile** configuration is recommended for distributed builds, as it provides additional logging and engine introspection capabilities useful during project development at minimal performance cost. **debug** builds are primarily useful during engine development.
 
 1.  Build the `INSTALL` target.
-    
+
     ```cmd
     cmake --build build/windows --target INSTALL --config profile
     ```
-    
+
     The binaries will be placed into a distributable install directory specified by the `CMAKE_INSTALL_PREFIX` CMake cache variable, or in an `install` subdirectory of the source code by default.
 
 Run the following step from the distributable install directory:

--- a/content/docs/user-guide/packaging/windows-release-builds.md
+++ b/content/docs/user-guide/packaging/windows-release-builds.md
@@ -42,7 +42,7 @@ The following instructions assume that you have:
   
   - Your project -- If you're using a source engine, you must generate a Visual Studio project for your project. For help, refer to [Create a Visual Studio project](/docs/welcome-guide/create/creating-projects-using-cli/creating-windows#create-a-visual-studio-project).
 
-  - Your engine -- If you're using a pre-built SDK engine, you must generate a Visual Studio project for your engine. For help, refer to the **Pre-built SDK engine** steps in [Building for Windows](/docs/welcome-guide/setup/setup-from-github/building-windows/).
+  - Your engine -- If you're using a pre-built SDK engine, you must generate a Visual Studio project for your engine. For help, refer to the first step in [building the INSTALL target](/docs/user-guide/build/distributable-engine/#build-the-install-target) under the topic of **Engine and Project Distribution**.
 
 - Registered your project to your engine.
 
@@ -134,7 +134,7 @@ For help with troubleshooting failures, refer to [Troubleshooting Packaging in O
 
 Now that you've prepared your project, you can create a project game release layout. You can do this in different ways, depending on how you set up your engine and whether you want to create a non-monolithic or monolithic release build.
 
-When you set up O3DE, you built your engine as either a *source engine* or a *pre-built SDK engine*. You can use either build type to create a project game release layout. For more information on build types, refer to [Build the engine](/docs/welcome-guide/setup/setup-from-github/#build-the-engine).
+When you set up O3DE, you built your engine as either a *source engine* or a *pre-built SDK engine*. You can use either build type to create a project game release layout. For more information on build types, refer to [Build the engine](/docs/welcome-guide/setup/setup-from-github/building-windows/#build-the-engine).
 
 Additionally, you can create a project game release layout that's either *non-monolithic* or *monolithic*. A non-monolithic build uses Gems as dynamically linked libraries (`.dll`), whereas a monolithic build uses Gems as statically linked libraries (`.lib`). Using Gems as `.lib` files in a monolithic build strips out unused pieces of code and removes redundant symbols across them. As a result, the total space on disk for a monolithic build is smaller than for a non-monolithic build.
 

--- a/content/docs/welcome-guide/create/creating-projects-using-cli/creating-linux.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli/creating-linux.md
@@ -21,13 +21,13 @@ To start a project based on the standard template, complete the following steps.
 
 1. Open a terminal window and change to your O3DE engine directory by doing one of the following:
 
-    * If you set up your engine as a [source engine](/docs/welcome-guide/setup/setup-from-github/building-linux/#build-the-engine), use the engine source directory. Example:
+    * If you set up your engine as a [source engine](/docs/user-guide/appendix/glossary/#source-engine), use the engine source directory. Example:
 
         ```shell
         cd $HOME/o3de
         ```
 
-    * If you installed O3DE or built your engine as an [SDK engine](/docs/welcome-guide/setup/setup-from-github/building-linux/#build-the-engine) using the `INSTALL` target, use the installed engine directory. Example:
+    * If you installed O3DE or built your engine as an [SDK engine](/docs/user-guide/appendix/glossary/#sdk-engine) using the `INSTALL` target, use the installed engine directory. Example:
 
         ```shell
         cd $HOME/o3de-install

--- a/content/docs/welcome-guide/create/creating-projects-using-cli/creating-windows.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli/creating-windows.md
@@ -21,13 +21,13 @@ To start a project based on the standard template, complete the following steps.
 
 1. Open a command line window and change to your O3DE engine directory by doing one of the following:
 
-    * If you set up your engine as a [source engine](/docs/welcome-guide/setup/setup-from-github/building-windows/#build-the-engine), use the engine source directory. Example:
+    * If you set up your engine as a [source engine](/docs/user-guide/appendix/glossary/#source-engine), use the engine source directory. Example:
 
         ```cmd
         cd C:\o3de
         ```
 
-    * If you installed O3DE or built your engine as an [SDK engine](/docs/welcome-guide/setup/setup-from-github/building-windows/#build-the-engine) using the `INSTALL` target, use the installed engine directory. Example:
+    * If you installed O3DE or built your engine as an [SDK engine](/docs/user-guide/appendix/glossary/#sdk-engine) using the `INSTALL` target, use the installed engine directory. Example:
 
         ```cmd
         cd C:\o3de-install

--- a/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-linux.md
@@ -16,16 +16,34 @@ The following instructions assume that you have:
 
 ## Build the engine
 
-To prepare to build the engine and projects, choose one of the following build types based on the primary focus of your development work, then follow the instructions in the corresponding tab:
+When building the engine from source, you have a few configuration options, based on the focus and needs of your development work:
 
-1. **Source engine** - Choose this build type if you plan to make frequent changes to the engine source code.
+* Build type
+* Build configuration
 
-1. **Pre-built SDK engine** - Choose this build type if you're primarily interested in project development and you plan to make only infrequent changes (or no changes) to the engine source.
+### Build type
 
-{{< tabs name="Engine build instructions" >}}
-{{% tab name="Source engine" %}}
+1. **Source engine** - Choose this build type if you plan to make frequent changes to the engine source code. The engine can be built by itself, if your primary interest is engine development, or it can also be built with a project that uses your custom build.
 
-1. Create a package directory in a writeable location. The following examples use the directory `$HOME/o3de-packages`.
+1. **Pre-built SDK engine** - Choose this build type if you're primarily interested in creating a distributable engine for project development, and you plan to make only infrequent changes to the engine source.
+
+{{< tip >}}
+If you don't intend to make any changes to the engine source, consider downloading and installing O3DE using the [installer for Linux](/docs/welcome-guide/setup/installing-linux/) instead.
+{{< /tip >}}
+
+### Build configuration
+
+1. **Debug** - Provides the maximum level of debugging support. Optimizations including function inlining will be avoided, making it easier to trace code. Some compilers may disable stack overflow or other memory protection runtime checks, making this the best build configuration for inspecting certain types of bugs affecting the stack. In supported IDEs, this also enables "Edit and continue" support.
+
+1. **Profile** - Offers debugging symbol support, but optimizations are enabled (equivalent to clang `-O2`, non-aggressive optimizations). This is the recommended profile for daily workflows, as it's the most representative of a release build but with symbols enabled.
+
+1. **Release** - Use this for a final release build. Includes non-aggressive optimizations and no debugging information.
+
+### Build instructions
+
+The following instructions show how to build a *source engine* in *profile* configuration. Building a pre-built SDK engine is a little more complicated. For details, refer to the topic on [creating distributable engine builds](/docs/user-guide/build/distributable-engine) in the User Guide.
+
+1. (Optional) If you don't already have a package directory, create one in a writeable location. The following examples use the directory `$HOME/o3de-packages`. Alternatively, you can let the build process use the default package directory that's also used by the O3DE installer, located in `<user>\.o3de\3rdParty`. This can save disk space if you have multiple version of O3DE, such as an engine built from source and one or more installed versions of the engine.
 
     ```shell
     mkdir $HOME/o3de-packages
@@ -38,6 +56,7 @@ To prepare to build the engine and projects, choose one of the following build t
     Open a terminal window and change to the directory where you set up O3DE, then run the `get_python` script.
 
     ```shell
+    # Run from the o3de engine root.
     python/get_python.sh
     ```
 
@@ -47,20 +66,19 @@ To prepare to build the engine and projects, choose one of the following build t
     cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=$HOME/o3de-packages
     ```
 
-    The preceding command specifies several noteworthy custom definitions (`-D`). All are optional but recommended in this example.
+    * `LY_3RDPARTY_PATH` is an optional custom definition. (Custom definitions are prefixed with `-D`.) Use it to specify the path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory. You can also leave this option off to use the default package directory.
 
-    * `LY_3RDPARTY_PATH` : The path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
+1. (Optional) Use CMake to build the source engine. This step is optional because in the "source engine" build model, the engine is built inside of every project. If you plan on working with projects, to avoid building the engine twice, consider waiting until you learn how to create and build a project,  which is covered in the [Project Creation](/docs/welcome-guide/create/) section.
 
-1. (Optional) Use CMake to build the source engine. This step is optional because in the "source engine" build model, the engine is built inside of every project. If you plan on working with projects, to avoid building the engine twice, consider waiting until you learn how to create and build a project,  which is covered in the [Project Creation](/docs/welcome-guide/create/) section. The following command builds the engine without a project.
-
-    The following example shows the `profile` build configuration.
+    The following command builds the engine, without a project, using the `profile` build configuration.
 
     ```shell
     cmake --build build/linux --target Editor --config profile -j <number of parallel build tasks>
     ```
 
     The `-j` is a recommended build tool optimization. It tells the Ninja build tool the number of parallel build tasks that will be executed simultaneously. The 'number of parallel build tasks' is recommended to match the number of cores available on the Linux host machine.
-    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
+
+    The `--config` sets the [build configuration type](/docs/user-guide/build/configure-and-build.md#generated-build-configurations): `debug`, `profile`, or `release`.
 
     Example:
 
@@ -70,108 +88,23 @@ To prepare to build the engine and projects, choose one of the following build t
 
     The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `$HOME/o3de/build/linux/bin/profile`.
 
-{{% /tab %}}
-{{% tab name="Pre-built SDK engine" %}}
-
-1. Create a package directory in a writeable location. The following examples use the directory `$HOME/o3de-packages`.
-
-    ```shell
-    mkdir $HOME/o3de-packages
-    ```
-
-    The O3DE package downloader uses this directory to retrieve external libraries needed for the engine.
-
-1. Get the Python runtime, which isn't included in the GitHub repo. The `o3de` script (part of the **O3DE CLI**) requires this runtime. You'll use this script to run common command line functions. This script also requires **CMake** to be installed and accessible on your device's path. If you haven't installed CMake, or you get an error that CMake cannot be found when running the script, refer to the [O3DE System Requirements](/docs/welcome-guide/requirements) page for installation instructions.
-
-    Open a command prompt and change to the directory where you set up O3DE, then run the `get_python` script.
-
-    ```shell
-    python/get_python.sh
-    ```
-
-1. Use CMake to create the Linux build project for the engine. Supply the build directory, the Ninja Multi-Config generator, the path to the packages directory that you created, and any other project options. Paths can be absolute or relative. Alternatively, you can use the CMake GUI to complete this step.
-
-    ```shell
-    cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=$HOME/o3de-packages -DLY_VERSION_ENGINE_NAME=o3de-install -DCMAKE_INSTALL_PREFIX=$HOME/o3de-install
-    ```
-
-    The preceding command specifies several noteworthy custom definitions (`-D`). All are optional but recommended in this example.
-
-    * `LY_3RDPARTY_PATH` : The path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
-    * `LY_VERSION_ENGINE_NAME` : The name you want to give the engine. Giving the install layout a different engine name ("o3de-install") than the source engine ("o3de") enables useful side-by-side options.
-    * `CMAKE_INSTALL_PREFIX`: The path to the installed build of the engine source. The directory you specify here is your engine install directory. You will find the Project Manager, Editor, and other tools in the subdirectory `bin/Linux/profile/Default`. If you don't specify this option, the engine SDK binaries will be built to `<ENGINE_SOURCE>/install/bin/Linux/profile/Default`.
-
-1. Use CMake to build the engine as an SDK, the same as if you installed the engine from an installer tool. The following example shows the `profile` build configuration.
-
-    ```shell
-    cmake --build build/linux --target install --config profile -j <number of parallel build tasks>
-    ```
-
-    The `-j` is a recommended build tool optimization. It tells the Ninja build tool the number of parallel build tasks that will be executed simultaneously. We recommend that the 'number of parallel build tasks' matches the number of cores available on the Linux host machine.
-    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
-
-    Example:
-
-    ```shell
-    cmake --build build/linux --target install --config profile -j 8
-    ```
-
-    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `$HOME/o3de-install/bin/Linux/profile/Default`.
-
-{{% /tab %}}
-{{< /tabs >}}
-
-{{< note >}}
+    {{< note >}}
 CMake [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) are on by default. This is a CMake feature that can greatly improve build times by merging source files into single compilation units. If you encounter a build error, disabling unity builds might help debug the problem. To disable unity builds, run the `cmake` project generation command with the `-DLY_UNITY_BUILD=OFF` argument to regenerate your project files.
-{{< /note >}}
+    {{< /note >}}
+
+1. After your first build of the engine, be sure to register it in the O3DE manifest using the steps in the next section.
 
 ## Register the engine
 
 Registering the O3DE engine enables O3DE projects to find the engine, even when they exist in different locations on your computer. The registration process creates (or updates) the **O3DE manifest** in your user directory.
 
-Choose the tab that corresponds to the engine build type you chose in the preceding set of instructions.
-
-{{< tabs name="Engine registration instructions" >}}
-{{% tab name="Source engine" %}}
-
-1. Open a command window if you don't already have one open. Change your current directory to the source engine directory.
+1. From a terminal window, use the `o3de` script to register the engine.
 
     ```shell
-    cd $HOME/o3de
-    ```
-
-1. Use the `o3de` script to register the engine.
-
-    ```shell
+    # Run from the o3de engine root.
     scripts/o3de.sh register --this-engine
     ```
 
     The O3DE manifest file is `$HOME/.o3de/o3de_manifest.json`. The paths to all the registered engines, projects, and more are recorded in this file.
-
-{{% /tab %}}
-{{% tab name="Pre-built SDK engine" %}}
-
-1. Open a command window if you don't already have one open. Change your current directory to the pre-built engine directory.
-
-    ```shell
-    cd $HOME/o3de-install
-    ```
-
-1. Get the Python runtime for the pre-built engine.
-
-    ```shell
-    python/get_python.sh
-    ```
-
-1. Use the `o3de` script to register the engine.
-
-    ```shell
-    scripts/o3de.sh register --this-engine
-    ```
-
-    The O3DE manifest file is `$HOME/.o3de/o3de_manifest.json`. The paths to all the registered engines, projects, and more are recorded in this file.
-
-{{% /tab %}}
-{{< /tabs >}}
 
 You're now ready to create a project. For an introduction to project configuration, refer to [Project Creation with Open 3D Engine](/docs/welcome-guide/create).

--- a/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
+++ b/content/docs/welcome-guide/setup/setup-from-github/building-windows.md
@@ -16,16 +16,34 @@ The following instructions assume that you have:
 
 ## Build the engine
 
-To prepare to build the engine and projects, choose one of the following build types based on the primary focus of your development work, then follow the instructions in the corresponding tab:
+When building the engine from source, you have a few configuration options, based on the focus and needs of your development work:
 
-1. **Source engine** - Choose this build type if you plan to make frequent changes to the engine source code.
+* Build type
+* Build configuration
 
-1. **Pre-built SDK engine** - Choose this build type if you're primarily interested in project development and you plan to make only infrequent changes (or no changes) to the engine source.
+### Build type
 
-{{< tabs name="Engine build instructions" >}}
-{{% tab name="Source engine" %}}
+1. **Source engine** - Choose this build type if you plan to make frequent changes to the engine source code. The engine can be built by itself, if your primary interest is engine development, or it can also be built with a project that uses your custom build.
 
-1. Create a package directory in a writeable location. The following examples use the directory `C:\o3de-packages`.
+1. **Pre-built SDK engine** - Choose this build type if you're primarily interested in creating a distributable engine for project development, and you plan to make only infrequent changes to the engine source.
+
+{{< tip >}}
+If you don't intend to make any changes to the engine source, consider downloading and installing O3DE using the [installer for Windows](/docs/welcome-guide/setup/installing-windows/) instead.
+{{< /tip >}}
+
+### Build configuration
+
+1. **Debug** - Provides the maximum level of debugging support. Optimizations including function inlining will be avoided, making it easier to trace code. Some compilers may disable stack overflow or other memory protection runtime checks, making this the best build configuration for inspecting certain types of bugs affecting the stack. In supported IDEs, this also enables "Edit and continue" support.
+
+1. **Profile** - Offers debugging symbol support, but optimizations are enabled (equivalent to clang `-O2`, non-aggressive optimizations). This is the recommended profile for daily workflows, as it's the most representative of a release build but with symbols enabled.
+
+1. **Release** - Use this for a final release build. Includes non-aggressive optimizations and no debugging information.
+
+### Build instructions
+
+The following instructions show how to build a *source engine* in *profile* configuration. Building a pre-built SDK engine is a little more complicated. For details, refer to the topic on [creating distributable engine builds](/docs/user-guide/build/distributable-engine) in the User Guide.
+
+1. (Optional) If you don't already have a package directory, create one in a writeable location. The following examples use the directory `C:\o3de-packages`. Alternatively, you can let the build process use the default package directory that's also used by the O3DE installer, located in `<user>\.o3de\3rdParty`. This can save disk space if you have multiple version of O3DE, such as an engine built from source and one or more installed versions of the engine.
 
     ```cmd
     mkdir C:\o3de-packages
@@ -38,6 +56,7 @@ To prepare to build the engine and projects, choose one of the following build t
     Open a command prompt and change to the directory where you set up O3DE, then run the `get_python` script.
 
     ```cmd
+    # Run from the o3de engine root.
     python\get_python.bat
     ```
 
@@ -49,119 +68,39 @@ To prepare to build the engine and projects, choose one of the following build t
 
     * Use `Visual Studio 16` as the generator for Visual Studio 2019, and `Visual Studio 17` for Visual Studio 2022. For a complete list of common generators for each supported platform, refer to [Configuring projects](/docs/user-guide/build/configure-and-build/#configuring-projects) in the User Guide.
 
-    * `LY_3RDPARTY_PATH` is an optional custom definition. (Custom definitions are prefixed with `-D`.) Use it to specify the path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
+    * `LY_3RDPARTY_PATH` is an optional custom definition. (Custom definitions are prefixed with `-D`.) Use it to specify the path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory. You can also leave this option off to use the default package directory.
 
-1. (Optional) Use CMake to build the source engine. This step is optional because in the "source engine" build model, the engine is built inside of every project. If you plan on working with projects, to avoid building the engine twice, consider waiting until you learn how to create and build a project, which is covered in the [Project Creation](/docs/welcome-guide/create/) section. The following command builds the engine without a project.
+1. (Optional) Use CMake to build the source engine. This step is optional because in the "source engine" build model, the engine is built inside of every project. If you plan on working with projects, to avoid building the engine twice, consider waiting until you learn how to create and build a project, which is covered in the [Project Creation](/docs/welcome-guide/create/) section.
 
-    The following example shows the `profile` build configuration.
+    The following command builds the engine, without a project, using the `profile` build configuration.
 
     ```cmd
     cmake --build build/windows --target Editor --config profile -- -m
     ```
 
     The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
-    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
 
-    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de\build\windows\bin\profile`.
+    The `--config` sets the [build configuration type](/docs/user-guide/build/configure-and-build.md#generated-build-configurations): `debug`, `profile`, or `release`.
 
-{{% /tab %}}
-{{% tab name="Pre-built SDK engine" %}}
+    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `<engine>\build\windows\bin\profile`.
 
-1. Create a package directory in a writeable location. The following examples use the directory `C:\o3de-packages`.
-
-    ```cmd
-    mkdir C:\o3de-packages
-    ```
-
-    The O3DE package downloader uses this directory to retrieve external libraries needed for the engine.
-
-1. Get the Python runtime, which isn't included in the GitHub repo. The `o3de` script (part of the **O3DE CLI**) requires this runtime. You'll use this script to run common command line functions. This script also requires **CMake** to be installed and accessible on your device's path. If you haven't installed CMake, or you get an error that CMake cannot be found when running the script, refer to the [O3DE System Requirements](/docs/welcome-guide/requirements) page for installation instructions.
-
-    Open a command prompt and change to the directory where you set up O3DE, then run the `get_python` script.
-
-    ```cmd
-    python\get_python.bat
-    ```
-
-1. Use CMake to create the Visual Studio project for the engine. Supply the build directory, the Visual Studio generator, the path to the packages directory that you created, and any other project options. Paths can be absolute or relative. Alternatively, you can use the CMake GUI to complete this step.
-
-    ```cmd
-    cmake -B build/windows -G "Visual Studio 16" -DLY_3RDPARTY_PATH=C:\o3de-packages -DLY_VERSION_ENGINE_NAME=o3de-install -DCMAKE_INSTALL_PREFIX=C:\o3de-install
-    ```
-
-    * Use `Visual Studio 16` as the generator for Visual Studio 2019, and `Visual Studio 17` for Visual Studio 2022. For a complete list of common generators for each supported platform, refer to [Configuring projects](/docs/user-guide/build/configure-and-build/#configuring-projects) in the User Guide.
-
-    The preceding command specifies several noteworthy custom definitions (`-D`). All are optional but recommended in this example.
-
-    * `LY_3RDPARTY_PATH` : The path to the downloadable package directory, also known as the "third-party path". Do not use trailing slashes when specifying the path to the packages directory.
-    * `LY_VERSION_ENGINE_NAME` : The name you want to give the engine. Giving the install layout a different engine name ("o3de-install") than the source engine ("o3de") enables useful side-by-side options.
-    * `CMAKE_INSTALL_PREFIX`: The path to the installed build of the engine source. The directory you specify here is your engine install directory. You will find the Project Manager, Editor, and other tools in the subdirectory `bin/Windows/profile/Default`. If you don't specify this option, the engine SDK binaries will be built to `<ENGINE_SOURCE>/install/bin/Windows/profile/Default`.
-
-1. Use CMake to build the engine as an SDK, the same as if you installed the engine from an installer tool. The following example shows the `profile` build configuration.
-
-    ```cmd
-    cmake --build build/windows --target INSTALL --config profile -- -m
-    ```
-
-    The `-m` is a recommended build tool optimization. It tells the Microsoft compiler (MSVC) to use multiple threads during compilation to speed up build times.
-    The `--config` sets the build configuration type: `profile`, `debug`, or `release`. For setting up O3DE, `profile` is recommended. Read more on [O3DE's build configurations](/docs/user-guide/build/configure-and-build.md#generated-build-configurations).
-
-    The engine takes a while to build. If you've used all the example commands in these steps, when the build is complete, you can find the engine tools and other binaries in `C:\o3de-install\bin\Windows\profile\Default`.
-
-{{% /tab %}}
-{{< /tabs >}}
-
-{{< note >}}
+    {{< note >}}
 CMake [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) are on by default. This is a CMake feature that can greatly improve build times by merging source files into single compilation units. If you encounter a build error, disabling unity builds might help debug the problem. To disable unity builds, run the `cmake` project generation command with the `-DLY_UNITY_BUILD=OFF` argument to regenerate your project files.
-{{< /note >}}
+    {{< /note >}}
+
+1. After your first build of the engine, be sure to register it in the O3DE manifest using the steps in the next section.
 
 ## Register the engine
 
 Registering the O3DE engine enables O3DE projects to find the engine, even when they exist in different locations on your computer. The registration process creates (or updates) the **O3DE manifest** in your user directory.
 
-Choose the tab that corresponds to the engine build type you chose in the preceding set of instructions.
-
-{{< tabs name="Engine registration instructions" >}}
-{{% tab name="Source engine" %}}
-
-1. Open a command window if you don't already have one open. Change your current directory to the source engine directory.
+1. From a command window, use the `o3de` script to register the engine.
 
     ```cmd
-    cd C:\o3de
-    ```
-
-1. Use the `o3de` script to register the engine.
-
-    ```cmd
+    # Run from the o3de engine root.
     scripts\o3de.bat register --this-engine
     ```
 
-    The O3DE manifest file is `<USER_DIRECTORY>/.o3de/o3de_manifest.json`. The paths to all the registered engines, projects, and more are recorded in this file.
-
-{{% /tab %}}
-{{% tab name="Pre-built SDK engine" %}}
-
-1. Open a command window if you don't already have one open. Change your current directory to the pre-built engine directory.
-
-    ```cmd
-    cd C:\o3de-install
-    ```
-
-1. Get the Python runtime for the pre-built engine.
-
-    ```cmd
-    python\get_python.bat
-    ```
-
-1. Use the `o3de` script to register the engine.
-
-    ```cmd
-    scripts\o3de.bat register --this-engine
-    ```
-
-    The O3DE manifest file is `<USER_DIRECTORY>/.o3de/o3de_manifest.json`. The paths to all the registered engines, projects, and more are recorded in this file.
-
-{{% /tab %}}
-{{< /tabs >}}
+    The O3DE manifest file is `<user>\.o3de\o3de_manifest.json`. The paths to all the registered engines, projects, and more are recorded in this file.
 
 You're now ready to create a project. For an introduction to project configuration, refer to [Project Creation with Open 3D Engine](/docs/welcome-guide/create).


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Make the following improvements to the build instructions in Get Started for both Windows and Linux:

- Added more info on build types and build configurations to the build instructions in Get Started.
- Made improvements for clarity.
- Simplified Get Started build instructions by removing instructions for building the engine as an SDK engine and referring readers who want to use this build type to the instructions in the User Guide.
- Made improvements to the instructions in the User Guide on building a distributable engine.
- Updated links.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

@netlify /docs/welcome-guide/setup/setup-from-github/building-windows