### PR TITLE
Overview of the Docs Contribution Process - Fixing syntax error

### DIFF
--- a/content/docs/contributing/to-docs/overview.md
+++ b/content/docs/contributing/to-docs/overview.md
@@ -63,7 +63,7 @@ Here are some important guidelines you should keep in mind about PRs in O3DE:
 
 Now that you are familiar with the O3DE docs, and have had some exposure to issues and PRs, let's have a look at the high-level process for making a contribution to documentation.
 
-1. **Agree the the O3DE Contributor License Agreement (CLA):** Refer to the project's [CONTRIBUTING.md](https://github.com/o3de/o3de.org/blob/main/CONTRIBUTING.md) for details.
+1. **Agree to the O3DE Contributor License Agreement (CLA):** Refer to the project's [CONTRIBUTING.md](https://github.com/o3de/o3de.org/blob/main/CONTRIBUTING.md) for details.
 
 1. **Create a new issue or claim an existing issue:** All contributions begin with a GitHub issue. You can file an issue and then assign it to yourself, or you can claim an existing issue. When creating a new issue, search the current issue list to ensure the issue hasn't already been submitted.
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Overview of the Docs Contribution Process](https://www.o3de.org/docs/contributing/to-docs/overview/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/2257 issue. 

* [Documentation process overview](https://www.o3de.org/docs/contributing/to-docs/overview/#documentation-process-overview) section - `Agree the the O3DE Contributor License Agreement ` - changed to `Agree to the O3DE Contributor License Agreement `


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #2257 