### PR TITLE
O3DE Documentation Contribution with Hugo - Fixing spelling errors

### DIFF
--- a/content/docs/contributing/to-docs/hugo.md
+++ b/content/docs/contributing/to-docs/hugo.md
@@ -157,13 +157,13 @@ Within a layout directory, Hugo looks for one of 4 basic types:
 * `baseof.html`: The "base" template. Do not override this unless you know what you're doing!
 * `section.html`: The template for `_index.md` files, or section homepages. 
 * `single.html`: The template for files in a directory which are _not_ `_index.md` files – i.e., regular pages.
-* `list.html`: The templae for lists of subpages. As this gets a bit confusing with `section.html`, only use this layout for blog sections.
+* `list.html`: The template for lists of subpages. As this gets a bit confusing with `section.html`, only use this layout for blog sections.
 
 Most of the top level pages in the O3DE site are `section.html` pages with no subpages.
 
-#### Understanding Hugo layout inheirtance
+#### Understanding Hugo layout inheritance
 
-As described above, Hugo looks for progressively more specific layouts and applies the most specific one it can find. However, it also does this _within_ layout files by allowing you to overide a section called `main`.
+As described above, Hugo looks for progressively more specific layouts and applies the most specific one it can find. However, it also does this _within_ layout files by allowing you to override a section called `main`.
 
 For example, let's look at `/layouts/_default/baseof.html`:
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [O3DE Documentation Contribution with Hugo](https://www.o3de.org/docs/contributing/to-docs/hugo/) page mentioned in the https://github.com/o3de/o3de.org/issues/2267 issue. 

* [Understanding Hugo layout structure section](https://www.o3de.org/docs/contributing/to-docs/hugo/#understanding-hugo-layout-structure) - `list.html: The templae for lists of subpages. ` changed to `list.html: The template for lists of subpages.`.
* [Understanding Hugo layout inheirtance section](https://www.o3de.org/docs/contributing/to-docs/hugo/#understanding-hugo-layout-inheirtance) - `Understanding Hugo layout inheirtance` -  changed to  - `Understanding Hugo layout inheritance`.
* [Understanding Hugo layout inheirtance section](https://www.o3de.org/docs/contributing/to-docs/hugo/#understanding-hugo-layout-inheirtance) - `However, it also does this within layout files by allowing you to overide a section called main.` -  changed to  - `However, it also does this within layout files by allowing you to override a section called main.`

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?