### PR TITLE
Corrects text from a merge conflict resolution

### DIFF
--- a/content/docs/user-guide/build/distributable-engine.md
+++ b/content/docs/user-guide/build/distributable-engine.md
@@ -57,8 +57,7 @@ The first step in creating a distributable build is generating local binaries fr
 
 Perform the following steps from the O3DE source directory (`C:\o3de-source` in this example):
 
-1.  Generate the toolchain project files using a unique `O3DE_INSTALL_ENGINE_NAME` CMake cache setting. This value is the name of the engine used by the O3DE project manager and registration system.
-    
+1.  Generate the toolchain project files using a unique `O3DE_INSTALL_ENGINE_NAME` CMake cache setting. This value is the name of the engine used by **Project Manager** and the O3DE registration system. Giving the install layout a different engine name than the source engine enables the engines to be registered side-by-side.
     ```cmd
     cmake -B build/windows -G "Visual Studio 16" --config profile -DO3DE_INSTALL_ENGINE_NAME="MyO3DE"
     ```


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

In a [merge conflict resolution](https://github.com/o3de/o3de.org/pull/2254/commits/a2cad04709a18f4c8af8df6e5199d5bb7412ec13), a specific version was chosen. However, there were changes from both versions that should be kept. This is a patch to fix the text.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

