### PR TITLE
Writing an O3DE Component Reference Document - Fixing syntax errors 

### DIFF
--- a/content/docs/contributing/to-docs/templates/component-reference-doc.md
+++ b/content/docs/contributing/to-docs/templates/component-reference-doc.md
@@ -24,7 +24,7 @@ The workflow:
 
 7. [Submit your document to O3DE Documentation.](#submit-your-component-reference-document)
 
-All documentation must adhere to the standards outlined in the O3DE [Style Guide](/docs/contributing/to-docs/style-guide/)and [Terminology](/docs/contributing/to-docs/terminology/). If you need any help, reach out to the Documentation and Community Special Interest Group (#sig-docs-community) on [Discord](https://discord.com/invite/o3de). 
+All documentation must adhere to the standards outlined in the O3DE [Style Guide](/docs/contributing/to-docs/style-guide/) and [Terminology](/docs/contributing/to-docs/terminology/). If you need any help, reach out to the Documentation and Community Special Interest Group (#sig-docs-community) on [Discord](https://discord.com/invite/o3de). 
 
 
 ## Does my document belong in the O3DE Component Reference?
@@ -257,7 +257,7 @@ For a component card with a complex set of properties, you may need multiple pro
 Another option is to separate the property tables into [tabs](/docs/contributing/to-docs/style-guide/format/#tabs) on your document. When content is in tabs, only the active tab displays content, while the rest is hidden. Because of this behavior, tabs are recommended if the sets of properties define configurations for different workflows that the user may or may not choose. 
 
 **Examples**:
-* [Light component](/docs/user-guide/components/reference/atom/light/): Contains several configurations that don't have a 1-1 relationship with the **Light type** property. Some propery groups are available for more than one light type, so they are documented in different property tables. Each property table specifies which light types support those properties.
+* [Light component](/docs/user-guide/components/reference/atom/light/): Contains several configurations that don't have a 1-1 relationship with the **Light type** property. Some property groups are available for more than one light type, so they are documented in different property tables. Each property table specifies which light types support those properties.
 
 * [PhysX Collider component](/docs/user-guide/components/reference/physx/collider/): Contains several configurations, which depend on the **Shape** property. Each configuration affect what properties are available, so they are documented in different property tables separated into tabs. 
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding [Writing an O3DE Component Reference Document](https://www.o3de.org/docs/contributing/to-docs/templates/component-reference-doc/) documentation page mentioned in the https://github.com/o3de/o3de.org/issues/2273 issue. 

* [Writing an O3DE Component Reference Document section](https://www.o3de.org/docs/contributing/to-docs/templates/component-reference-doc/) - `All documentation must adhere to the standards outlined in the O3DE Style Guideand Terminology.` changed to `All documentation must adhere to the standards outlined in the O3DE Style Guide and Terminology.`
* [Complex set of properties](https://www.o3de.org/docs/contributing/to-docs/templates/component-reference-doc/#tabset-docscontributingto-docstemplatescomponent-reference-doc-1-1) - `Some propery groups are available for more than one light type, so they are documented in different property tables.` - changed to - `Some property groups are available for more than one light type, so they are documented in different property tables.`


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?