### PR TITLE
Fixing syntac error in to do shortcode

### DIFF
--- a/layouts/shortcodes/todo.html
+++ b/layouts/shortcodes/todo.html
@@ -8,7 +8,7 @@
             {{ if .Get "issue" }}
                 A GitHub issue has been created for this task <a href="{{.Get "issue"}}">here</a>.
             {{else}}
-                A GitHub issue has not been been created for this task. Create an issue <a href="https://github.com/o3de/o3de.org/issues/new/choose">here</a>.
+                A GitHub issue has not been created for this task. Create an issue <a href="https://github.com/o3de/o3de.org/issues/new/choose">here</a>.
             {{end}}
       </div>
 


### PR DESCRIPTION
Signed-off-by: Jarosław Gawęda <99716227+LB-JaroslawGaweda@users.noreply.github.com>
## Change summary

Fixed issues regarding syntax error in [To Do shortcode](https://www.o3de.org/docs/engine-dev/architecture/#topics) encountered on several unfinished pages. 

* `A GitHub issue has not been been created for this task.` changed to `A GitHub issue has not been created for this task. `

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [style guide](https://o3de.org/docs/contributing/to-docs/style-guide/)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?