### PR TITLE
Remove x-robots-tag from preview-builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,10 +7,6 @@ HUGO_VERSION = "0.105.0"
 GO_VERSION = "1.18"
 
 [context.deploy-preview]
-[[headers]]
-  for = "/*"
-[headers.values]
-  X-Robots-Tag = "none"
 command = "make preview-build"
 
 [context.branch-deploy]


### PR DESCRIPTION
Reverts x-robots-tag added to preview builds' http response: o3de/o3de.org#2123.

