### PR TITLE
Clarify page banner for prerelease docs

### DIFF
--- a/layouts/partials/version-warning.html
+++ b/layouts/partials/version-warning.html
@@ -1,5 +1,12 @@
+{{ $isPreRelease := or (in site.BaseURL "development") (in site.BaseURL "stabilization") }}
 {{ $pathname := .RelPermalink }}
 
+{{ if $isPreRelease }}
+<p class="build-info-text">
+    <b>This documentation is for a prerelease version of O3DE. <a href="https://www.o3de.org{{ $pathname }}">Click here to switch to the latest release</a>, or select a version from the dropdown.</b>
+</p>
+{{ else }}
 <p class="build-info-text">
     <b>This page is not the current release of O3DE documentation. <a href="https://www.o3de.org{{ $pathname }}">Click here to switch to the latest release</a>, or select a version from the dropdown.</b>
 </p>
+{{ end }}


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Change banner for prerelease docs to start with: "This documentation is for a prerelease version of O3DE" instead of "This page is not the current release of O3DE documentation".

It could be argued that the docs in the development branch are more "current" than the last release of O3DE, so this rewording should help clear up any confusion.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

