### PR TITLE
Add sv_useGameLiftServer info to AWSGameLift local testing page

### DIFF
--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
@@ -33,7 +33,9 @@ $ java -jar GameLiftLocal.jar -p 9080
 
 ## 2. Set `sv_useGameLiftServer` to `true`
 
-To prevent the server from trying to reach out to Amazon GameLift while running locally, the AWS GameLift gem server manager will not initialize unless you opt-in to using it by setting the `sv_useGameLiftServer` CVAR to `true`. You can set this value by creating a settings registry file named **commands.MYPROJECT_serverlauncher.setreg** in the **YourProject/Registry** folder with the following contents:
+When you are ready to test with GameLift, opt-in by setting the `sv_useGameLiftServer` CVAR to `true`. This CVAR is off by default to facilitate local testing prior to the integration of the GameLift Server SDK into your game server.
+
+You can set this value by creating a settings registry file named **commands.MYPROJECT_serverlauncher.setreg** in the **YourProject/Registry** folder with the following contents:
 
 ```json
 {
@@ -53,7 +55,7 @@ To prevent the server from trying to reach out to Amazon GameLift while running 
 }
 ```
 
-This will let your game server use GameLift local when running in the Editor with `ctrl` + `g` or when running the server launcher directly (see next step).
+This will let your game server use GameLift local when running game or simulation mode in the Editor, or when running the server launcher directly (see next step).
 
 ## 3. Start Server
 

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
@@ -31,7 +31,31 @@ $ java -jar GameLiftLocal.jar -p 9080
 
 ```
 
-## 2. Start Server
+## 2. Set `sv_useGameLiftServer` to `true`
+
+To prevent the server from trying to reach out to Amazon GameLift while running locally, the AWS GameLift gem server manager will not initialize unless you opt-in to using it by setting the `sv_useGameLiftServer` CVAR to `true`. You can set this value by creating a settings registry file named **commands.MYPROJECT_serverlauncher.setreg** in the **YourProject/Registry** folder with the following contents:
+
+```json
+{
+    "Amazon":
+    {
+        "AzCore":
+        {
+            "Runtime":
+            {
+                "ConsoleCommands":
+                {
+                    "sv_useGameLiftServer": "true"
+                } 
+            } 
+        } 
+    } 
+}
+```
+
+This will let your game server use GameLift local when running in the Editor with `ctrl` + `g` or when running the server launcher directly (see next step).
+
+## 3. Start Server
 
 Make sure you have a cmake build target for your server, like YourProject.ServerLauncher. and build the application for your local testing.
 
@@ -43,7 +67,7 @@ $ bin\profile\YourProject.ServerLauncher.exe
 
 ```
 
-## 3. Start Game
+## 4. Start Game
 
 Make sure you have a cmake build target for your game, like YourProject.GameLauncher, and build the application for your local testing.
 
@@ -57,7 +81,7 @@ $ bin\profile\YourProject.GameLauncher.exe --cl_gameliftLocalEndpoint "http://lo
 
 ```
 
-## 4. Test Game and Server
+## 5. Test Game and Server
 
 Testing steps and instructions really depend on your own project, but please make sure your testing can cover CreateSession, JoinSession, LeaveSession and DestroySession use case.
 

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
@@ -35,7 +35,7 @@ $ java -jar GameLiftLocal.jar -p 9080
 
 When you are ready to test with GameLift, opt-in by setting the `sv_useGameLiftServer` CVAR to `true`. This CVAR is off by default to facilitate local testing prior to the integration of the GameLift Server SDK into your game server.
 
-You can set this value by creating a settings registry file named **commands.MYPROJECT_serverlauncher.setreg** in the **YourProject/Registry** folder with the following contents:
+You can set this value by creating a settings registry file named `commands.MyProject_serverlauncher.setreg` in the `MyProject/Registry` folder with the following contents:
 
 ```json
 {

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/local-testing.md
@@ -55,7 +55,7 @@ You can set this value by creating a settings registry file named **commands.MYP
 }
 ```
 
-This will let your game server use GameLift local when running game or simulation mode in the Editor, or when running the server launcher directly (see next step).
+This lets your game server use GameLift local when running game or simulation mode in the Editor, or when running the server launcher directly (see next step).
 
 ## 3. Start Server
 


### PR DESCRIPTION
## Change summary
Adds documentation for the CVAR added in https://github.com/o3de/o3de/pull/14964 

### Testing
Change rendered in Hugo:
![image](https://user-images.githubusercontent.com/34254888/224796430-c2f3d095-770d-45ce-9d87-79035bd456fb.png)


### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

