### PR TITLE
Fix incorrectly escaped line break in column vector.

### DIFF
--- a/content/blog/posts/vectors-matrices-matrix-order.md
+++ b/content/blog/posts/vectors-matrices-matrix-order.md
@@ -49,7 +49,7 @@ $$
 \mathbf{M} \cdot \vec{c} 
     &{}= \begin{bmatrix} m_{11} & m_{12} \\\ m_{21} & m_{22}  \end{bmatrix} \cdot \begin{bmatrix} c_{1} \\\ c_{2} \end{bmatrix} \\\ \\\
 &{}= \begin{bmatrix} 
-m_{11}c_{1} + m_{12}c_{2} \\
+m_{11}c_{1} + m_{12}c_{2} \\\
 m_{21}c_{1} + m_{22}c_{2} \end{bmatrix}
 \end{array}
 $$


### PR DESCRIPTION
## Change summary

This pull request adds the missing backslash needed to properly escape the LaTeX double backslash for the line break in a column vector.

Change is from this:

![image](https://user-images.githubusercontent.com/77458631/225881556-ebe70449-7ba5-48eb-857e-1664394e8345.png)

To this:

![image](https://user-images.githubusercontent.com/77458631/225881408-56034477-413d-4422-b378-2c9c89d97348.png)

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

