### PR TITLE
Add server targets example links to AWSGameLift gem setup

### DIFF
--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
@@ -45,7 +45,7 @@ To enable the AWS GameLift Gem in your project:
 
 You must include the AWS GameLift Gem static library in your project's CMake build target.
 
-1. **(Required)** You must include **Gem::AWSGameLift.Server.Static** as one of the **BUILD_DEPENDENCIES** for your project's server target. For an example of a networked project configured with distinct server and client targets, see the [O3DE Multiplayer project template](https://github.com/o3de/o3de-extras/tree/development/Templates/Multiplayer) or the [O3DE Multiplayer Sample project](https://github.com/o3de/o3de-multiplayersample).
+1. **(Required)** You must include **Gem::AWSGameLift.Server.Static** as one of the **BUILD_DEPENDENCIES** for your project's server target. For an example of a networked project configured with distinct server and client targets, see the [O3DE Multiplayer project template](https://github.com/o3de/o3de-extras/blob/development/Templates/Multiplayer/Template/Gem/Code/CMakeLists.txt) or the [O3DE Multiplayer Sample project](https://github.com/o3de/o3de-multiplayersample/blob/development/Gem/Code/CMakeLists.txt).
 
     ```cpp
     ly_add_target(

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
@@ -45,7 +45,7 @@ To enable the AWS GameLift Gem in your project:
 
 You must include the AWS GameLift Gem static library in your project's CMake build target.
 
-1. **(Required)** You must include **Gem::AWSGameLift.Server.Static** as **BUILD_DEPENDENCIES** for your project server target.
+1. **(Required)** You must include **Gem::AWSGameLift.Server.Static** as one of the **BUILD_DEPENDENCIES** for your project's server target. For an example of a networked project configured with distinct server and client targets, see the [O3DE Multiplayer project template](https://github.com/o3de/o3de-extras/tree/development/Templates/Multiplayer) or the [O3DE Multiplayer Sample project](https://github.com/o3de/o3de-multiplayersample).
 
     ```cpp
     ly_add_target(


### PR DESCRIPTION
## Change summary

Adds additional explanation and links to example projects where gem setup directs users to update their project's "server target", which may not exist if users haven't started with a multiplayer template.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

