### PR TITLE
Add clarifications to AWS GameLift Gem setup and use

### DIFF
--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
@@ -71,8 +71,7 @@ You must include the AWS GameLift Gem static library in your project's CMake bui
     }
    ```
 
-3. **(Optional)** If you need to make GameLift service requests in C++, then you must include **Gem::AWSGameLift.Client.Static** as **BUILD_DEPENDENCIES** for your client target.
-
+3. **(Optional)**  Clients do not need to include the following library to join a game session.  Generally, clients do not make requests directly to GameLift, instead, they connect to game platform servers that make all GameLift service requests as well as provide account sign-in, identity management, updates, and information about game modes. However, if you need to make GameLift service requests in C++ directly from the client, then you must include **Gem::AWSGameLift.Client.Static** as **BUILD_DEPENDENCIES** for your client target. Refer to [GameLift service API Reference](https://docs.aws.amazon.com/gamelift/latest/developerguide/reference-awssdk.html) for more information on the Amazon GameLift service API.
     ```cpp
     ly_add_target(
         NAME YourProject.Client.Static STATIC

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup.md
@@ -71,7 +71,9 @@ You must include the AWS GameLift Gem static library in your project's CMake bui
     }
    ```
 
-3. **(Optional)**  Clients do not need to include the following library to join a game session.  Generally, clients do not make requests directly to GameLift, instead, they connect to game platform servers that make all GameLift service requests as well as provide account sign-in, identity management, updates, and information about game modes. However, if you need to make GameLift service requests in C++ directly from the client, then you must include **Gem::AWSGameLift.Client.Static** as **BUILD_DEPENDENCIES** for your client target. Refer to [GameLift service API Reference](https://docs.aws.amazon.com/gamelift/latest/developerguide/reference-awssdk.html) for more information on the Amazon GameLift service API.
+3. **(Optional)**  Clients do not need to include the GameLift client library to join a game session.  It is [recommended that clients do not make requests directly to GameLift](https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift_quickstart_customservers_designbackend.html), instead, they connect to game platform servers that make all GameLift service requests on behalf of players, as well as provide account sign-in, identity management, updates, and information about game modes. 
+
+However, if you need to make GameLift service requests in C++ directly from the client during development or for testing, then you must include **Gem::AWSGameLift.Client.Static** as **BUILD_DEPENDENCIES** for your client target. Refer to [GameLift service API Reference](https://docs.aws.amazon.com/gamelift/latest/developerguide/reference-awssdk.html) for more information on the Amazon GameLift service API.
     ```cpp
     ly_add_target(
         NAME YourProject.Client.Static STATIC

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/session-management/cpp-api.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/session-management/cpp-api.md
@@ -175,7 +175,7 @@ After the game session has been created, notifications are broadcast through `Mu
 
 ### `OnCreateSessionBegin`
 
-When the session begins to create on the server, the `Multiplayer::SessionNotificationBus::Events::OnCreateSessionBegin()` notification is broadcast on the server side. GameLift launches servers with a default runtime configuration.  When a game session ends, GameLift resets the server to the default runtime configuration. Set game session-specific properties and load the appropriate level on the server side during this step. 
+When the session begins to create on the server, the `Multiplayer::SessionNotificationBus::Events::OnCreateSessionBegin()` notification is broadcast on the server side. When GameLift requests a game session it will supply the releveant runtime configuration, which includes key game session information, such as maximum players. It can also include game data and player data.  Set game session-specific properties and load the appropriate level on the server side during this step. 
 
 ```cpp
 bool OnCreateSessionBegin(const Multiplayer::SessionConfig& sessionConfig)

--- a/content/docs/user-guide/gems/reference/aws/aws-gamelift/session-management/cpp-api.md
+++ b/content/docs/user-guide/gems/reference/aws/aws-gamelift/session-management/cpp-api.md
@@ -29,7 +29,6 @@ AWSGameLift::AWSGameLiftRequestBus::Broadcast(
 );
 ```
 
-
 ### Session APIs
 
 ### `CreateSession`
@@ -176,7 +175,7 @@ After the game session has been created, notifications are broadcast through `Mu
 
 ### `OnCreateSessionBegin`
 
-When the session begins to create on the server, the `Multiplayer::SessionNotificationBus::Events::OnCreateSessionBegin()` notification is broadcast on the server side. During this step, it's recommended to load the level on the server side. 
+When the session begins to create on the server, the `Multiplayer::SessionNotificationBus::Events::OnCreateSessionBegin()` notification is broadcast on the server side. GameLift launches servers with a default runtime configuration.  When a game session ends, GameLift resets the server to the default runtime configuration. Set game session-specific properties and load the appropriate level on the server side during this step. 
 
 ```cpp
 bool OnCreateSessionBegin(const Multiplayer::SessionConfig& sessionConfig)


### PR DESCRIPTION
@netlify /docs/user-guide/gems/reference/aws/aws-gamelift/gem-setup/

## Change summary

- Added clarifications to GameLift docs to address #1511, #1513.

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

Fix #1511; Fix #1513;