### PR TITLE
Modify docs to include ROS 2 Iron

### DIFF
--- a/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
+++ b/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
@@ -11,16 +11,16 @@ You will learn about how ROS 2 and O3DE communicate, and how ROS 2 components in
 
 ## ROS 2 Concepts
 
-For a quick introduction to ROS 2 concepts, please refer to [ROS 2 Concepts documentation](https://docs.ros.org/en/humble/Concepts.html).
+For a quick introduction to ROS 2 concepts, please refer to [ROS 2 Concepts documentation](https://docs.ros.org/en/iron/Concepts.html).
 
 ## Structure and Communication
 
-The Gem creates a [ROS 2 node](https://docs.ros.org/en/humble/Tutorials/Understanding-ROS2-Nodes.html) which is directly a part of the ROS 2 ecosystem. As such, your simulation will not use any bridges to communicate and is subject to configuration through settings such as Environment Variables. It is truly a part of the ecosystem.
+The Gem creates a [ROS 2 node](https://docs.ros.org/en/iron/Tutorials/Understanding-ROS2-Nodes.html) which is directly a part of the ROS 2 ecosystem. As such, your simulation will not use any bridges to communicate and is subject to configuration through settings such as Environment Variables. It is truly a part of the ecosystem.
 
 Note that the simulation node is handled through `ROS2SystemComponent` - a singleton. However, you are free to create and use your own nodes if you need more than one.
 
 Typically, you will be creating publishers and subscriptions in order to communicate with the ROS 2 ecosystem using common topics.
-This is done through [rclcpp API](https://docs.ros.org/en/humble/p/rclcpp/generated/classrclcpp_1_1Node.html#classrclcpp_1_1Node). Example:
+This is done through [rclcpp API](https://docs.ros.org/en/iron/p/rclcpp/generated/classrclcpp_1_1Node.html#classrclcpp_1_1Node). Example:
 
 ```
 auto ros2Node = ROS2Interface::Get()->GetNode();
@@ -28,7 +28,7 @@ AZStd::string fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), m_MyTopic
 m_myPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(fullTopic.data(), QoS());
 ```
 
-Note that QoS class is a simple wrapper to [`rclcpp::QoS`](https://docs.ros.org/en/humble/p/rclcpp/generated/classrclcpp_1_1QoS.html).
+Note that QoS class is a simple wrapper to [`rclcpp::QoS`](https://docs.ros.org/en/iron/p/rclcpp/generated/classrclcpp_1_1QoS.html).
 
 ## Components overview
 

--- a/content/docs/user-guide/interactivity/robotics/creating-robotic-simulation.md
+++ b/content/docs/user-guide/interactivity/robotics/creating-robotic-simulation.md
@@ -32,6 +32,6 @@ Once you are set up and familiar with the [example project](/docs/user-guide/int
    2. Use `ROS2SensorComponent` as a base class if you are implementing a new sensor. 
 5. Develop necessary sensors and their prefabs.
 7. Develop your scene and simulation scenario, placing Assets and configuring components.
-8. Run the simulation with your ROS 2 robot stack. You can build quickly one with some of many [ROS 2 packages](https://index.ros.org/packages/#humble) and projects in [ROS 2 ecosystem](https://project-awesome.org/fkromer/awesome-ros2).
+8. Run the simulation with your ROS 2 robot stack. You can build quickly one with some of many [ROS 2 packages](https://index.ros.org/packages/#iron) and projects in [ROS 2 ecosystem](https://project-awesome.org/fkromer/awesome-ros2).
 
 

--- a/content/docs/user-guide/interactivity/robotics/project-configuration.md
+++ b/content/docs/user-guide/interactivity/robotics/project-configuration.md
@@ -8,13 +8,13 @@ toc: true
 
 ## Requirements
 
-* Ubuntu 22.04. Other Ubuntu versions and Linux distributions can also work as long as they support ROS 2 Humble.
+* Ubuntu 22.04. Other Ubuntu versions and Linux distributions can also work as long as they support ROS 2 Humble or ROS 2 Iron.
   {{< important >}}
   The ROS 2 Gem is not available for Windows.
   {{< /important >}}
 * [O3DE built from source on Linux](/docs/welcome-guide/setup/setup-from-github/building-linux).
 * The [latest released version](https://docs.ros.org/en/rolling/Releases.html#list-of-distributions ) of ROS 2. This instruction assumes that the `desktop` version is installed. Otherwise, some packages might be missing. 
-  * The O3DE ROS 2 has been tested with [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) with Ubuntu 22.04.
+  * The O3DE ROS 2 has been tested with [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) and [ROS 2 Iron](https://docs.ros.org/en/iron/Installation.html) with Ubuntu 22.04.
 
 ## Setting up
 
@@ -22,16 +22,16 @@ toc: true
 
 #### Source your ROS 2 workspace
 
-To build or run projects using ROS 2 Gem, you must [source your ROS 2 workspace](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html) in your console. The best way to ensure that ROS 2 is sourced at all times is by adding the following line to the `~/.profile` file:
+To build or run projects using ROS 2 Gem, you must [source your ROS 2 workspace](https://docs.ros.org/en/iron/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html) in your console. The best way to ensure that ROS 2 is sourced at all times is by adding the following line to the `~/.profile` file:
 ```
 source /opt/ros/<distro>/setup.bash
 ```
-Replace `<distro>` with the ROS 2 distribution name (such as `humble`).
+Replace `<distro>` with the ROS 2 distribution name (such as `humble` or `iron`).
 Then, you must log out and log in from Ubuntu for the change to take effect.
 
 #### Custom packages
 
-The Gem fully supports [workspace overlaying](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#source-the-overlay).
+The Gem fully supports [workspace overlaying](https://docs.ros.org/en/iron/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#source-the-overlay).
 Source your workspace on top of the ROS 2 installation to include custom packages.
 
 The Gem comes with a number of ROS 2 packages already included and linked, but you might want to include additional packages in your project.
@@ -43,7 +43,7 @@ target_depends_on_ros2_packages(<your_target> <ros_package1> <ros_package2>)
 
 #### Working with multiple ROS versions
 
-If you have multiple ROS 2 versions installed, make sure you [source](https://docs.ros.org/en/humble/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay) the one you would like to use. You can check which version is sourced in your console by checking the value of `ROS_DISTRO` environment variable (`echo $ROS_DISTRO`).
+If you have multiple ROS 2 versions installed, make sure you [source](https://docs.ros.org/en/iron/Tutorials/Workspace/Creating-A-Workspace.html#source-the-overlay) the one you would like to use. You can check which version is sourced in your console by checking the value of `ROS_DISTRO` environment variable (`echo $ROS_DISTRO`).
 
 > You currently need to rebuild your project if it was previously built with another ROS version.
 

--- a/content/docs/user-guide/interactivity/robotics/troubleshooting.md
+++ b/content/docs/user-guide/interactivity/robotics/troubleshooting.md
@@ -21,7 +21,7 @@ If you don't find your problem covered here, try searching the issues and discus
 
 #### Correct installation
 Is your ROS 2 installed? Is it sourced properly? Was it also true when your project was built? Check `ROS_DISTRO` and `AMENT_PREFIX_PATH`.
-  - `echo $ROS_DISTRO` should show non-empty value, for example `humble`.
+  - `echo $ROS_DISTRO` should show non-empty value, for example `humble` or `iron`.
   - `echo $AMENT_PREFIX_PATH` should include your ROS 2 distribution installation path as well as any additional workspaces you have sourced (if any). 
   - If you are using ROS services in your project, make sure that the `RMW_IMPLEMENTATION` environment variable is the same on the both ends (check in each).
 


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

I've modified all ROS 2 documentation links to forward the user to the ROS 2 Iron documentation instead of ROS 2 Humble, reflecting the ROS 2 Gem support for ROS 2 Iron, and added information that the ROS 2 Gem supports ROS 2 Iron.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

