### PR TITLE
Clarify usage and placement of net cfg files

### DIFF
--- a/content/docs/user-guide/networking/multiplayer/running.md
+++ b/content/docs/user-guide/networking/multiplayer/running.md
@@ -47,7 +47,8 @@ You can manually launch the executables for Client and Server and configure them
 
 You can manually launch the executables for Client and Server and pass a pre-defined configuration file to each for them to execute on launch. Commands in these cfgs files are executed in listed order.
 
-1. In your project directory create `launch_client.cfg` and `launch_server.cfg`.
+1. In the root of your project directory create `launch_client.cfg` and `launch_server.cfg`.
+
 2. Open `launch_server.cfg` and edit it to look like the following:
 
     ```txt

--- a/content/docs/user-guide/networking/settings.md
+++ b/content/docs/user-guide/networking/settings.md
@@ -21,22 +21,28 @@ Use the following [console functor (cfunc)](/docs/user-guide/programming/az-cons
 | LoadLevel              | Unloads the current level and loads a new one with the given asset name. <br> Used to setup the initial level for the game or simiulation. | *(Required)* Path to a level file.                                               | Command is not specific to network or multiplayer but used for all games and simulations. | 
 | sv_launch_local_client | Launches a local client and connects to this host server.                                                                                  |                                                                                  | Only works if currently hosting.                                                          |
 
-These console commands can be executed dynamically via the [console command line](/docs/user-guide/editor/console/) or placed within a console command configuration file, usually with the `.cfg` suffix. Commands will be executed in the order written.
+These console commands can be executed dynamically via the [console command line](/docs/user-guide/editor/console/) or placed within a console command configuration file.
 
-For a networked game or simulation, a typical server configuration file should contain:
+When using a console command configuration file, it is common practice to place the file in the project root directory. Use `.cfg`  as the filename suffix. Commands will be executed in the order written.
 
-```
+For a networked game or simulation, a typical _server_ configuration file should contain:
+
+```cmd
 host
 LoadLevel <path to Level>
 ```
 
-And the client's configuration file should contain:
+A typical _client_ configuration file should contain:
 
-```
+```cmd
 connect
 ```
 
-Console commands in configuration files can be passed to client and server launchers using the `console-command-file` option, for example `MultiplayerSample.ServerLauncher.exe --console-command-file=launch_server.cfg`.
+Console commands in configuration files can be passed to client and server launchers using the `console-command-file` option. Example:
+
+```cmd
+MultiplayerSample.ServerLauncher.exe --console-command-file=launch_server.cfg
+```
 
 ## Client settings
 The `cl` CVARs control client behavior.


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Clarifies where to place network-related .cfg files in a project.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

Fixes #1635 
Fixes #1657 (networking-specific part)

@netlify /docs/user-guide/networking/settings