### PR TITLE
Add O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE documentation

### DIFF
--- a/content/docs/user-guide/build/reference.md
+++ b/content/docs/user-guide/build/reference.md
@@ -123,6 +123,15 @@ These settings control how the package download system functions.
   *Type*: `BOOL`
   *Default*: `OFF`
 
+* **`O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE`** - Generates symbol files (`.pdb`) in release configurations and turns off optimizations making it easier to troubleshoot issues in release builds.
+
+  {{< note >}}
+  Currently only supported for Windows and "Visual Studio" generators.
+  {{< /note >}}
+
+  *Type*: `BOOL`
+  *Default*: `OFF`
+
 <!-- 
   TODO: Platform-specific settings - should they go here, on the platform pages, or somewhere else entirely (like in the reference appendix?)
 -->

--- a/content/docs/user-guide/packaging/troubleshooting.md
+++ b/content/docs/user-guide/packaging/troubleshooting.md
@@ -24,8 +24,11 @@ The following are techniques you can use to help you debug any issues that you m
 In Visual Studio, you can compile with optimizations disabled and debug symbols enabled. This lets Visual Studio's debugging tools produce more helpful information that can help you debug.
 
 Make the following modifications to the `Configurations_msvc.cmake` file in the `<engine>\cmake\Platform\Common\MSVC` directory. In `ly_append_configurations_options`, under `COMPILATION _RELEASE`:
- - Change `/Od` to `/Ox`.
+ - Change `/Ox` to `/Od`.
  - Add `/Zi`.
+
+Make the following modifications under `LINK_NON_STATIC_RELEASE`:
+ - Add `/DEBUG`.
 
 After making those modifications, `ly_append_configurations_options` should look like this:
 
@@ -42,6 +45,11 @@ ly_append_configurations_options(
         /Oy             # Omit the frame pointer
         /Zi             # Generate debugging information (no Edit/Continue)
     
+    LINK_NON_STATIC_RELEASE
+        /OPT:REF # Eliminates functions and data that are never referenced
+        /OPT:ICF # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
+        /INCREMENTAL:NO
+        /DEBUG              # Generate pdbs
     # ... 
 ```
 

--- a/content/docs/user-guide/packaging/troubleshooting.md
+++ b/content/docs/user-guide/packaging/troubleshooting.md
@@ -21,37 +21,8 @@ The following are techniques you can use to help you debug any issues that you m
 
 ### Compile with optimizations disabled and debug symbols enabled
 
-In Visual Studio, you can compile with optimizations disabled and debug symbols enabled. This lets Visual Studio's debugging tools produce more helpful information that can help you debug.
+In Visual Studio, you can compile with optimizations disabled and debug symbols enabled by configuring with the CMake variable `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` set to `ON`. This lets Visual Studio's debugging tools produce more helpful information that can help you debug.
 
-Make the following modifications to the `Configurations_msvc.cmake` file in the `<engine>\cmake\Platform\Common\MSVC` directory. In `ly_append_configurations_options`, under `COMPILATION _RELEASE`:
- - Change `/Ox` to `/Od`.
- - Add `/Zi`.
-
-Make the following modifications under `LINK_NON_STATIC_RELEASE`:
- - Add `/DEBUG`.
-
-After making those modifications, `ly_append_configurations_options` should look like this:
-
-```
-ly_append_configurations_options(
-
-    # ...
-
-    COMPILATION_RELEASE
-        /Od             # Enable debug symbols
-        /Ob2            # Inline any suitable function
-        /Ot             # Favor fast code over small code
-        /Oi             # Use Intrinsic Functions
-        /Oy             # Omit the frame pointer
-        /Zi             # Generate debugging information (no Edit/Continue)
-    
-    LINK_NON_STATIC_RELEASE
-        /OPT:REF # Eliminates functions and data that are never referenced
-        /OPT:ICF # Perform identical COMDAT folding. Redundant COMDATs can be removed from the linker output
-        /INCREMENTAL:NO
-        /DEBUG              # Generate pdbs
-    # ... 
-```
 
 ### Create a `profile` build
 


### PR DESCRIPTION
Provide docs on how to use `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` instead of modifying engine files so you can generate debug symbols in release configurations.

Depends on PR: https://github.com/o3de/o3de/pull/16147

## Change summary

- replace engine modification steps with instructions to CMake configure with `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` to `ON`
- add `O3DE_BUILD_WITH_DEBUG_SYMBOLS_RELEASE` to debug reference page

### Submission Checklist:

* [x ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x ] **Help the user** - Does the documentation show the user something *meaningful*?

