### PR TITLE
Add default gem seedlist docs

### DIFF
--- a/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
+++ b/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
@@ -256,7 +256,10 @@ Automatically include the default seed lists for the O3DE Engine, default projec
 +  **Gems** - `Gems/gem_name/Assets/gem_name_Dependencies.xml`
 +  **Project** - `project_name/project_name_Dependencies.xml`
 
-By default, the project dependencies includes pre-loaded particle libraries and game-wide audio, excluding level-specific audio.
+This flag also includes default seed list files in the the following locations:
++  **Engine** - `<engine root>/Assets/Engine/SeedAssetList.seed`
++  **Platform** - `<engine root>/Assets/Engine/Platforms/<platform>/*.seed`
++  **Gems** - `<gem name>/Assets/seedList.seed`
 
 This argument can be used along with other arguments that provide seeds.
 

--- a/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
+++ b/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
@@ -19,7 +19,7 @@ See the [Asset Bundler Concepts and Terms](/docs/user-guide/packaging/asset-bund
 AssetBundlerBatch command --parameterWithArgs arg1,arg2 --flagParameter ...
 ```
 
- The `AssetBundlerBatch` executable is contained in the `dev/Bin64HostPlatform` folder of your project.
+ The `AssetBundlerBatch` executable is contained in the same folder as the `Editor` and `AssetProcessor` executables.  If you do not find the executable, you likely need to build `AssetBundlerBatch` by running the `cmake --build <build path>` command with `--target AssetBundlerBatch`. 
 
 The elements in this example invocation break down to:
 +  `command` - The command for the asset bundler to run. Examples include `seeds` and `assetLists`.

--- a/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
+++ b/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
@@ -256,7 +256,7 @@ Automatically include the default seed lists for the O3DE Engine, default projec
 +  **Gems** - `Gems/gem_name/Assets/gem_name_Dependencies.xml`
 +  **Project** - `project_name/project_name_Dependencies.xml`
 
-This flag also includes default seed list files in the the following locations:
+This flag also includes default seed list files in the following locations:
 +  **Engine** - `<engine root>/Assets/Engine/SeedAssetList.seed`
 +  **Platform** - `<engine root>/Assets/Engine/Platforms/<platform>/*.seed`
 +  **Gems** - `<gem name>/Assets/seedList.seed`

--- a/content/docs/user-guide/programming/gems/creating.md
+++ b/content/docs/user-guide/programming/gems/creating.md
@@ -39,19 +39,19 @@ Assets used by your Gem in a launcher runtime should have their source assets li
 
 ### Default `<GemName>/Assets/seedList.seed`
 
-This file contains a list of compiled asset paths and platforms that will automatically appear in the *Asset Bundler* GUI making it easy for users to find and include in their project asset bundle.
-They will also be included in a bundle when the [*AssetBundlerBatch* `--addDefaultSeedListFiles`](/docs/user-guid/packaging/asset-bundler/command-line-reference/#options) CLI option is used.
+This file contains a list of compiled asset paths and platforms that will automatically appear in the Asset Bundler GUI making it easy for users to find and include in their project asset bundle.
+They will also be included in a bundle when the [*AssetBundlerBatch* `--addDefaultSeedListFiles`](/docs/user-guide/packaging/asset-bundler/command-line-reference/#options-2) CLI option is used.
 The `seedList.seed` approach is useful when you want to provide a ready-to-use list of default compiled assets and the platforms they're used on.
 
-Refer to the [Asset Bundler documentation](/docs/user-guide/packaging/asset-bundler/) for more information on the *Asset Bundler*, `.seed` files and bundling assets,
+Refer to the [Asset Bundler documentation](/docs/user-guide/packaging/asset-bundler/) for more information on the Asset Bundler, `.seed` files, and bundling assets.
 
 {{<important>}}
-The filename `seedList.seed` is case-sensitive and must be in your Gem `Assets` folder or the seed list will not automatically appear in the *Asset Bundler* GUI.
+The filename `seedList.seed` is case-sensitive and must be in your Gem `Assets` folder or the seed list will not automatically appear in the Asset Bundler GUI.
 {{</important>}}
 
 ### Gem dependencies
 
-The Gem dependencies `.xml` file contains a list of source assets which will be used by the *Asset Processor* to create a seed list containing all the compiled asset paths and platforms.
+The Gem dependencies `.xml` file contains a list of source assets which will be used by the Asset Processor to create a seed list containing all the compiled asset paths and platforms.
 Using the Gem dependencies file is convenient for specifying source assets with glob patterns, for example when you want to include all shader variants, but does require running the Asset Processor.   
 
 Refer to [Default dependencies for O3DE projects](/docs/user-guide/packaging/asset-bundler/default-dependencies/) for instructions on creating Gem dependencies.

--- a/content/docs/user-guide/programming/gems/creating.md
+++ b/content/docs/user-guide/programming/gems/creating.md
@@ -35,6 +35,29 @@ For more information on how to use the `o3de` tool, refer to [Project Configurat
 
 Each Gem has an `Assets` directory that can contain models, textures, scripts, animations, and more. Asset files are accessed the same way as they are in a game project. O3DE uses this root directory to find the asset file path. For example, when O3DE looks for the `textures/rain/rainfall_ddn.tif` file, it looks in the `<GemName>/Assets/textures/rain/` directory.
 
+Assets used by your Gem in a launcher runtime should have their source assets listed in a [Gem dependencies `.xml` file](#gem-dependencies) or their compiled asset path should be listed in [`<GemName>/Assets/seedList.seed`](#default-gemnameassetsseedlistseed). 
+
+### Default `<GemName>/Assets/seedList.seed`
+
+This file contains a list of compiled asset paths and platforms that will automatically appear in the *Asset Bundler* GUI making it easy for users to find and include in their project asset bundle.
+They will also be included in a bundle when the [*AssetBundlerBatch* `--addDefaultSeedListFiles`](/docs/user-guid/packaging/asset-bundler/command-line-reference/#options) CLI option is used.
+The `seedList.seed` approach is useful when you want to provide a ready-to-use list of default compiled assets and the platforms they're used on.
+
+Refer to the [Asset Bundler documentation](/docs/user-guide/packaging/asset-bundler/) for more information on the *Asset Bundler*, `.seed` files and bundling assets,
+
+{{<important>}}
+The filename `seedList.seed` is case-sensitive and must be in your Gem `Assets` folder or the seed list will not automatically appear in the *Asset Bundler* GUI.
+{{</important>}}
+
+### Gem dependencies
+
+The Gem dependencies `.xml` file contains a list of source assets which will be used by the *Asset Processor* to create a seed list containing all the compiled asset paths and platforms.
+Using the Gem dependencies file is convenient for specifying source assets with glob patterns, for example when you want to include all shader variants, but does require running the Asset Processor.   
+
+Refer to [Default dependencies for O3DE projects](/docs/user-guide/packaging/asset-bundler/default-dependencies/) for instructions on creating Gem dependencies.
+
+
+
 ## Code (optional)
 
 Gem code can be contained in any directory that is picked up by the `CMakeLists.txt` file of the Gem, although, by convention, Gems with only one source module use `Code` for the directory name.


### PR DESCRIPTION
## Change summary

Update documentation about `seedList.seed` file for gems and locations of various seed lists that the engine searches for by default.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

