### PR TITLE
Added a doc page for the Settings Registry detailing how to use the new `$import` directive

### DIFF
--- a/content/docs/user-guide/settings/_index.md
+++ b/content/docs/user-guide/settings/_index.md
@@ -36,7 +36,7 @@ You can interact with the Settings Registry in O3DE through the following method
 | [Output the Settings Registry to Stream with C++](./output-settings-registry) | Output the Settings Registry to an IO stream with C++. |
 | [Settings Registry Developer Guide](./developer-documentation) | Provides detailed developer information about the Settings Registry. Settings Registry examples are provided for multiple scenarios. The interaction between the CMake Build Generation system, the Settings Registry, and the Gem Module System are described in detail. |
 | [Gem Loading and the Settings Registry](./gem-loading) | Learn how the Settings Registry is used to load Gem Modules and configure Gem settings. |
-| [Settings Registry $import Chaining](./import-settings-registry) | Learn how the Settings Registry can trigger imports of other Settings Registry files. |
+| [Settings Registry Chaining](./import-settings-registry) | Learn how the Settings Registry can trigger imports of other Settings Registry files. |
 
 ## Related topics
 

--- a/content/docs/user-guide/settings/_index.md
+++ b/content/docs/user-guide/settings/_index.md
@@ -36,7 +36,7 @@ You can interact with the Settings Registry in O3DE through the following method
 | [Output the Settings Registry to Stream with C++](./output-settings-registry) | Output the Settings Registry to an IO stream with C++. |
 | [Settings Registry Developer Guide](./developer-documentation) | Provides detailed developer information about the Settings Registry. Settings Registry examples are provided for multiple scenarios. The interaction between the CMake Build Generation system, the Settings Registry, and the Gem Module System are described in detail. |
 | [Gem Loading and the Settings Registry](./gem-loading) | Learn how the Settings Registry is used to load Gem Modules and configure Gem settings. |
-| [Settings Registry Import Chaining](./import-settings-registry) | Lean how the Settings Registry can trigger imports of other Settings Registry files. |
+| [Settings Registry $import Chaining](./import-settings-registry) | Learn how the Settings Registry can trigger imports of other Settings Registry files. |
 
 ## Related topics
 

--- a/content/docs/user-guide/settings/_index.md
+++ b/content/docs/user-guide/settings/_index.md
@@ -36,6 +36,7 @@ You can interact with the Settings Registry in O3DE through the following method
 | [Output the Settings Registry to Stream with C++](./output-settings-registry) | Output the Settings Registry to an IO stream with C++. |
 | [Settings Registry Developer Guide](./developer-documentation) | Provides detailed developer information about the Settings Registry. Settings Registry examples are provided for multiple scenarios. The interaction between the CMake Build Generation system, the Settings Registry, and the Gem Module System are described in detail. |
 | [Gem Loading and the Settings Registry](./gem-loading) | Learn how the Settings Registry is used to load Gem Modules and configure Gem settings. |
+| [Settings Registry Import Chaining](./import-settings-registry) | Lean how the Settings Registry can trigger imports of other Settings Registry files. |
 
 ## Related topics
 

--- a/content/docs/user-guide/settings/import-settings-registry.md
+++ b/content/docs/user-guide/settings/import-settings-registry.md
@@ -1,0 +1,39 @@
+---
+title: Settings Registry $import Chaining
+linkTitle: Settings Registry $import
+description: Learn how the Settings Registry can use the $import directive to merge additional settings registry files in Open 3D Engine (O3DE).
+weight: 300
+---
+
+The Settings Registry supports the ability to merge additional Settings Registry files \[.setreg(patch)] via using the [JSON Importer Framework](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.h) within the O3DE.  
+Any fields withingthe Settings Registry file that has the field name of `$import` can be used to specify additional `.setreg`, `.setregpatch` or any other json format files to merge to the Settings Registry.  
+When a Settings Registry file is merged using the [Merge API](./developer-api#merge-api), it triggers the logic to look for `$import` directives within the settings file to gather a list of additional files to merge.
+The order in which the additional files are merged are in a post-order traversal.  
+The imported files are merged before the current Settings Registry file.  
+Therefore the current file settings _overrides_ its `$import` directive settings.
+
+## Chain import setreg file using a `$import` directive string
+
+The following shows how to use the `$import` to merge another Settings Registry file using a string value.
+
+### test.apple.setreg
+```json
+{
+    "$import": "test.ios.setreg"
+}
+```
+
+## Chain import setreg file using a `$import` directive object
+
+The following shows how to use the `$import` to merge another Settings Registry file using a JSON object with a `filename` key
+
+### test.ios.setreg
+```json
+{
+    "$import": {
+        "filename": "test.mobile.setreg"
+    }
+}
+```
+
+With the above approach, a chain of files to merge the Settings Registry can be triggered by merging a file via the `MergeSettingsFolder` or `MergeSettingsFile` API.

--- a/content/docs/user-guide/settings/import-settings-registry.md
+++ b/content/docs/user-guide/settings/import-settings-registry.md
@@ -5,29 +5,53 @@ description: Learn how the Settings Registry can use the $import directive to me
 weight: 300
 ---
 
-The Settings Registry supports the ability to merge additional Settings Registry files \[.setreg(patch)] via using the [JSON Importer Framework](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.h) within the O3DE.  
-Any fields withingthe Settings Registry file that has the field name of `$import` can be used to specify additional `.setreg`, `.setregpatch` or any other json format files to merge to the Settings Registry.  
-When a Settings Registry file is merged using the [Merge API](./developer-api#merge-api), it triggers the logic to look for `$import` directives within the settings file to gather a list of additional files to merge.
-The order in which the additional files are merged are in a post-order traversal.  
-The imported files are merged before the current Settings Registry file.  
-Therefore the current file settings _overrides_ its `$import` directive settings.
+The Settings Registry supports the ability to merge additional Settings Registry files `*.setreg(patch)` via the [JSON Importer Framework](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.h).  
+Any field named `$import` within a Settings Registry file cab be used to specify additional `*.setreg`, `*.setregpatch` or any other JSON format files to merge to the Settings Registry.  
 
-## Chain import setreg file using a `$import` directive string
+When a Settings Registry file is merged using the [Merge API](./developer-api#merge-api), it triggers the logic to look for `$import` directives within the settings file to merge additional JSON files.
+The order in which the additional files are merged occur at the point where their `$import` directives are processed.  
+Any setting that appears before the `$import` directive can be overridden by the JSON contents of the imported file.  
+Any setting that appears after the `$import` directive will override and merge over the JSON contents of the imported file.
 
-The following shows how to use the `$import` to merge another Settings Registry file using a string value.
+# Chain import setreg file using a `$import` directive string
+
+The following shows how to use the `$import` directive to merge another Settings Registry file using a string value.
 
 ### test.apple.setreg
 ```json
 {
-    "$import": "test.ios.setreg"
+    "pre_field": { "first": 1, "second": 2 },
+    "$import": "test.ios.setreg",
+    "post_field": { "1": 11, "2": 12 }
 }
 ```
 
-## Chain import setreg file using a `$import` directive object
-
-The following shows how to use the `$import` to merge another Settings Registry file using a JSON object with a `filename` key
-
 ### test.ios.setreg
+```json
+{
+    "pre_field": { "second": 202 },
+    "post_field": { "2": 120 }
+}
+```
+
+The merging the `test.apple.setreg` file results in the final JSON output that follows.
+
+### Import Result
+```json
+{
+    "pre_field": { "first": 1, "second": 202 },
+    "post_field": { "1": 11, "2": 12 }
+}
+```
+
+Notice that the `"pre_field"` that appear before the `$import` directive has its `"second"` field value (`202`) overridden by the imported `test.ios.setreg` file.  
+Contrast the difference with the `"post_field"` that appears after the `$import` directive. The `"2"` field value (`12`) is from the original `test.apple.setreg` file.
+
+# Chain import setreg file using a `$import` directive object
+
+The following shows how to use the `$import` directive to merge another Settings Registry file using a JSON object with a `filename` key.
+
+### test.android.setreg
 ```json
 {
     "$import": {
@@ -36,4 +60,70 @@ The following shows how to use the `$import` to merge another Settings Registry 
 }
 ```
 
-With the above approach, a chain of files to merge the Settings Registry can be triggered by merging a file via the `MergeSettingsFolder` or `MergeSettingsFile` API.
+# Importing multiple setreg file using a `$import` directive.
+
+The following shows how multiple uses of the same `$import` key can be used to merge multiple Settings Registry files.
+
+Given the following two Settings Registry files `number.setreg` and `string.setreg`, how the JSON contents are merged depends on the order they are specifed in the import file
+
+## Example Data
+
+### number.setreg
+```json
+{
+    "1": 7,
+    "2": 14
+}
+```
+
+### string.setreg
+```json
+{
+    "1": "Hello",
+    "3": "World"
+}
+```
+
+## Example 1
+Merging the aggregate setreg file with the following contents will merge the `string.setreg` over of the `number.setreg`.
+
+### aggregate.setreg
+```json
+{
+    "$import": "number.setreg",
+    "$import": "string.setreg"
+}
+```
+
+The value of for key `"1"` is from the `string.setreg` file.
+### aggregate.setreg (Post Import)
+```json
+{
+    "1": "Hello",
+    "2": 14,
+    "3": "World"
+}
+```
+
+## Example 2
+Swapping the order of the `$import` directives changes the result of the values within the Settings Registry.
+
+### aggregate2.setreg
+```json
+{
+    "$import": "string.setreg",
+    "$import": "number.setreg"
+}
+```
+
+The value of key `"1"` is from the `number.setreg` file.
+### aggregate2.setreg (Post Import)
+```json
+{
+    "1": 7,
+    "2": 14,
+    "3": "World"
+}
+```
+
+With the above approach you can merge a chain of files into the Settings Registry via the `MergeSettingsFolder` or `MergeSettingsFile` API.

--- a/content/docs/user-guide/settings/import-settings-registry.md
+++ b/content/docs/user-guide/settings/import-settings-registry.md
@@ -1,23 +1,23 @@
 ---
-title: Settings Registry $import Chaining
-linkTitle: Settings Registry $import
+title: Settings Registry Chaining
+linkTitle: Settings Registry Chaining
 description: Learn how the Settings Registry can use the $import directive to merge additional settings registry files in Open 3D Engine (O3DE).
-weight: 300
+weight: 1000
 ---
 
 The Settings Registry supports the ability to merge additional Settings Registry files `*.setreg(patch)` via the [JSON Importer Framework](https://github.com/o3de/o3de/blob/development/Code/Framework/AzCore/AzCore/Serialization/Json/JsonImporter.h).  
-Any field named `$import` within a Settings Registry file cab be used to specify additional `*.setreg`, `*.setregpatch` or any other JSON format files to merge to the Settings Registry.  
+Any field named `$import` within a Settings Registry file can be used to specify additional `*.setreg`, `*.setregpatch`, or any other JSON format files to merge to the Settings Registry.  
 
-When a Settings Registry file is merged using the [Merge API](./developer-api#merge-api), it triggers the logic to look for `$import` directives within the settings file to merge additional JSON files.
-The order in which the additional files are merged occur at the point where their `$import` directives are processed.  
-Any setting that appears before the `$import` directive can be overridden by the JSON contents of the imported file.  
-Any setting that appears after the `$import` directive will override and merge over the JSON contents of the imported file.
+When a Settings Registry file is merged using the [Merge API](./developer-api#merge-api), it triggers the logic to look for `$import` directives within the settings file to merge additional JSON files.  
+The order in which the additional files are merged is determined by the location of the `$import` directive.  
+* Any setting that appears _before_ the `$import` directive can be overridden by the JSON contents of the imported file.  
+* Any setting that appears _after_ the `$import` directive can override the JSON contents of the imported file.
 
-# Chain import setreg file using a `$import` directive string
+## Chain import setreg file using a `$import` directive string
 
-The following shows how to use the `$import` directive to merge another Settings Registry file using a string value.
+The following example shows how to use the `$import` directive to merge another Settings Registry file using a string value.
 
-### test.apple.setreg
+#### `test.apple.setreg`
 ```json
 {
     "pre_field": { "first": 1, "second": 2 },
@@ -26,7 +26,7 @@ The following shows how to use the `$import` directive to merge another Settings
 }
 ```
 
-### test.ios.setreg
+#### `test.ios.setreg`
 ```json
 {
     "pre_field": { "second": 202 },
@@ -34,7 +34,7 @@ The following shows how to use the `$import` directive to merge another Settings
 }
 ```
 
-The merging the `test.apple.setreg` file results in the final JSON output that follows.
+After `test.ios.setreg` is merged, the `test.apple.setreg` file results in the following final JSON output:
 
 ### Import Result
 ```json
@@ -47,28 +47,47 @@ The merging the `test.apple.setreg` file results in the final JSON output that f
 Notice that the `"pre_field"` that appear before the `$import` directive has its `"second"` field value (`202`) overridden by the imported `test.ios.setreg` file.  
 Contrast the difference with the `"post_field"` that appears after the `$import` directive. The `"2"` field value (`12`) is from the original `test.apple.setreg` file.
 
-# Chain import setreg file using a `$import` directive object
+## Chain import setreg file using a `$import` directive object
 
-The following shows how to use the `$import` directive to merge another Settings Registry file using a JSON object with a `filename` key.
+The following shows how to use the `$import` directive to merge another Settings Registry file using a JSON object with a `filename` key.  
+The reason to use the `$import` directive object over the `$import` directive string, is that the object syntax supports an additional `"patch"` field.  
+The `"patch"` field is a JSON object, whose content will be merged directly over the imported content data before being merged over the initial Settings Registry file data.
 
-### test.android.setreg
+#### `test.mobile.setreg`
+```json
+{
+    "device_abis": [
+        "arm64-v8a"
+    ]
+}
+```
+
+The `test.android.setreg` patches the `"device_abis"` array of the `test.mobile.setreg` after reading the imported contents into memory, but before applying the contents to the rest of the `test.android.setreg` data.
+
+#### `test.android.setreg`
 ```json
 {
     "$import": {
-        "filename": "test.mobile.setreg"
+        "filename": "test.mobile.setreg",
+        "patch": {
+            "device_abis": [
+                "arm64-v8a",
+                "x86_64"
+            ]
+        }
     }
 }
 ```
 
-# Importing multiple setreg file using a `$import` directive.
+## Importing multiple setreg files using a `$import` directive
 
 The following shows how multiple uses of the same `$import` key can be used to merge multiple Settings Registry files.
 
-Given the following two Settings Registry files `number.setreg` and `string.setreg`, how the JSON contents are merged depends on the order they are specifed in the import file
+Given the two Settings Registry files that follow, `number.setreg` and `string.setreg`, the result of the merge depends on the order in which the files appear in the import file.
 
-## Example Data
+### Example Data
 
-### number.setreg
+#### `number.setreg`
 ```json
 {
     "1": 7,
@@ -76,7 +95,7 @@ Given the following two Settings Registry files `number.setreg` and `string.setr
 }
 ```
 
-### string.setreg
+#### `string.setreg`
 ```json
 {
     "1": "Hello",
@@ -84,10 +103,10 @@ Given the following two Settings Registry files `number.setreg` and `string.setr
 }
 ```
 
-## Example 1
-Merging the aggregate setreg file with the following contents will merge the `string.setreg` over of the `number.setreg`.
+### Example 1
+Merging the aggregate setreg file with the following contents will merge `string.setreg` over `number.setreg`.
 
-### aggregate.setreg
+#### `aggregate.setreg`
 ```json
 {
     "$import": "number.setreg",
@@ -95,8 +114,8 @@ Merging the aggregate setreg file with the following contents will merge the `st
 }
 ```
 
-The value of for key `"1"` is from the `string.setreg` file.
-### aggregate.setreg (Post Import)
+The value of key `"1"` is from the `string.setreg` file.
+#### `aggregate.setreg` (Post Import)
 ```json
 {
     "1": "Hello",
@@ -105,10 +124,10 @@ The value of for key `"1"` is from the `string.setreg` file.
 }
 ```
 
-## Example 2
+### Example 2
 Swapping the order of the `$import` directives changes the result of the values within the Settings Registry.
 
-### aggregate2.setreg
+#### `aggregate2.setreg`
 ```json
 {
     "$import": "string.setreg",
@@ -117,7 +136,7 @@ Swapping the order of the `$import` directives changes the result of the values 
 ```
 
 The value of key `"1"` is from the `number.setreg` file.
-### aggregate2.setreg (Post Import)
+#### `aggregate2.setreg` (Post Import)
 ```json
 {
     "1": 7,
@@ -126,4 +145,4 @@ The value of key `"1"` is from the `number.setreg` file.
 }
 ```
 
-With the above approach you can merge a chain of files into the Settings Registry via the `MergeSettingsFolder` or `MergeSettingsFile` API.
+Using the approach shown in the preceding examples, you can merge a chain of files into the Settings Registry with the `MergeSettingsFolder` or `MergeSettingsFile` [Merge APIs](./developer-api#merge-api).


### PR DESCRIPTION
## Change summary

The `$import` directive can be used by Settings Registry files to trigger merge chaining of additional Settings Registry files.

Related o3de PR to add `$import` directive support to the Settings Registry is at o3de/o3de#16175

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

