### PR TITLE
Fix version dropdown and warnings

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -5,7 +5,7 @@
 {{ $menu   := site.Menus.main }}
 {{ $isDocs := in .RelPermalink "/docs/" }}
 {{ $isPreview := in site.BaseURL "deploy-preview" }}
-{{ $isRelease := in site.BaseURL "www.o3de.org" }}
+{{ $isRelease := in site.BaseURL "docs.o3de.org" }}
 
 <div class="sticky-top" id="docs-banners">
   <div class="main-navbar navbar navbar-light navbar-docs" role="navigation" aria-label="main navigation">


### PR DESCRIPTION
Fixes issue with version handling where the documentation in docs.o3de.org/docs would not be recognized as being for version 23.05, and the warning header would always be displayed regardless. The url at the top always redirects to the current page.

(note that this fix cannot be verified locally or in the deployment version since it does a check on the base url)

Before:
![image](https://github.com/o3de/o3de.org/assets/82231674/fbcd7f56-c006-4318-afa0-ed11bc010441)

After:
The yellow header should not be displayed in docs.o3de.org, and the version dropdown should display 23.05.