### PR TITLE
Fix base url for 23.05 version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ sourceRepo = "https://github.com/o3de/o3de"
 # Docs version data format: ["display name", "baseURL"]
 # Note: A version that has "www.o3de.org" in its baseURL will get " (latest)" appended to its display name in the version selector.
 versions = [
-  ["23.05", "https://docs.o3de.org/docs"],
+  ["23.05", "https://docs.o3de.org"],
   ["development", "https://development--o3deorg.netlify.app"],
   ["22.10", "https://version-2210--o3deorg.netlify.app"],
   ["22.05", "https://version-2205--o3deorg.netlify.app"]


### PR DESCRIPTION
This should fix the docs version switcher in the documentation pages.