### PR TITLE
Update required packages for O3DE on Ubuntu Linux 20.04 and 22.04

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -45,7 +45,7 @@ Creating new projects or using the advanced development features of O3DE require
 ## Microsoft Windows
 
 At this time, Microsoft Windows is the primary platform for using the O3DE
-editor and for building source. Specifically, **Windows 10 version 1809 (10.0.17763)**
+editor and for building source. Specifically, **Windows 10 version 20H2 (10.0.19042.2251)**
 or later is required.
 
 ### Microsoft Visual Studio

--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -45,7 +45,7 @@ Creating new projects or using the advanced development features of O3DE require
 ## Microsoft Windows
 
 At this time, Microsoft Windows is the primary platform for using the O3DE
-editor and for building source. Specifically, **Windows 10 version 20H2 (10.0.19042.2251)**
+editor and for building source. Specifically, **Windows 10 version 1809 (10.0.17763)**
 or later is required.
 
 ### Microsoft Visual Studio
@@ -219,18 +219,16 @@ O3DE also requires some additional library packages to be installed:
 * libxkbcommon-dev
 * libxkbcommon-x11-dev
 * libfontconfig1-dev
-* libcurl4-openssl-dev
-* libsdl2-dev
+* libpcre2-16-0
 * zlib1g-dev
 * mesa-common-dev
-* libssl-dev
 * libunwind-dev
 * libzstd-dev
 
 You can download and install these packages through `apt`.
 
 ```shell
-sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libcurl4-openssl-dev libsdl2-dev zlib1g-dev mesa-common-dev libssl-dev libunwind-dev libzstd-dev
+sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev
 ```
 
 ### Ninja Build System (Optional)


### PR DESCRIPTION
Remove : libcurl4-openssl-dev libsdl2-dev libssl-dev
Add    : libpcre2-16-0

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

This is a update to the required ubuntu packages based on testing the latest debian package installer on clean
versions of both Ubuntu 20.04 and Ubuntu 22.04. This also includes package updates [removal of openssl debian package dependency](https://github.com/o3de/o3de/pull/16226) of openssl on ubuntu () 

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X ] **Help the user** - Does the documentation show the user something *meaningful*?

There are no grammatical updates, just updates to the package inventory list in the code samples.

Do not merge until https://github.com/o3de/o3de/pull/16226 is merged into o3de/development