### PR TITLE
fix ed_enableOutlinerOverrideManagement documentation

### DIFF
--- a/content/docs/learning-guide/tutorials/entities-and-prefabs/override-a-prefab.md
+++ b/content/docs/learning-guide/tutorials/entities-and-prefabs/override-a-prefab.md
@@ -39,14 +39,8 @@ Overrides are not limited to the level. In fact, any prefab that is open for edi
 
 ## Enable prefab overrides
 
-To enable prefab overrides in Entity Outliner, you must set the `ed_enableOutlinerOverrideManagement` console variable (CVar) to "true":
-
-1. In **O3DE Editor**, from the **Tools** menu, choose **Console Variables**.
-2. In Console Variables editor, set the `ed_enableOutlinerOverrideManagement` flag to true. It can be easily found by typing `outliner` into the filter box:
-
-{{< image-width src="/images/learning-guide/tutorials/entities-and-prefabs/outliner-prefab-prefs.png" width="700" alt="CVar settings to enable Outliner override support" >}}
-
-Alternatively, if you want the flag to be automatically enabled when O3DE Editor starts, you can create a settings registry file with the following contents:
+To enable prefab overrides in Entity Outliner, you must set the `ed_enableOutlinerOverrideManagement` console variable (CVar) to "true". Although you *can* set this in the **Console Variables Editor**, this feature is not currently changeable
+while the Editor is running, so it must be set before the Editor starts, via a settings registry file. You should create a settings registry file with the following contents:
 
 ```JSON
 {

--- a/content/docs/learning-guide/tutorials/entities-and-prefabs/override-a-prefab.md
+++ b/content/docs/learning-guide/tutorials/entities-and-prefabs/override-a-prefab.md
@@ -10,7 +10,7 @@ When a prefab is open in [Prefab Edit Mode](/docs/learning-guide/tutorials/entit
 
 | O3DE Experience | Time to Complete | Feature Focus | Last Updated |
 | --- | --- | --- | --- |
-| Beginner | 15 Minutes | Using prefab overrides to make prefab instances unique. | April 27, 2023 |
+| Beginner | 15 Minutes | Using prefab overrides to make prefab instances unique. | October 11, 2023 |
 
 ## Prerequisites
 


### PR DESCRIPTION
fix for prefab override docs to reflect that ed_enableOutlinerOverrideManagement is not checked again after the Editor has fully booted

## Change summary

fix for prefab override docs to reflect that ed_enableOutlinerOverrideManagement is not checked again after the Editor has fully booted

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

