### PR TITLE
Update using-in-lua.md Script Events using Lua

### DIFF
--- a/content/docs/user-guide/scripting/script-events/using-in-lua.md
+++ b/content/docs/user-guide/scripting/script-events/using-in-lua.md
@@ -6,11 +6,23 @@ weight: 300
 
 Lua scripts can use script events to communicate with each other. There are two example scripts that show this communication, both available in the `Gems\ScriptEvents\Assets\Scripts\Example` directory. They are called `ScriptEvents_Addressable.lua` and `ScriptEvents_Broadcast.lua`. If an EBus is addressed, events are sent to a specific address ID. Events that are broadcast globally are received at all addresses. For more information, see [The Open 3D Engine Event Bus (EBus) System](/docs/user-guide/programming/messaging/ebus/).
 
+The following table shows only some of the available return and input values. It is not complete.
+
+| type | syntax | input | return |
+| --- | --- | --- | --- |
+| string | typeid("") | yes | yes |
+| number | typeid(0) | yes | yes |
+| entity id | typeid(EntityId()) | yes | yes |
+
+TIP: If you are struggling with the input and return limitations, consider using a JSON/string serializer/deserializer.
+
+---
+
 ### ScriptEvents_Addressable.lua
 
-The `ScriptEvents_Addressable.lua` example script implements a handler for a script event that requires an address for a handler to be invoked. It broadcasts a method, but only handlers connected to the address that match the one specified in the event can invoke it.
+The `ScriptEvents_Addressable.lua` example script implements a handler for a Script Event that requires an address for a handler to be invoked. It broadcasts a method, but only handlers connected to the address that matches the one specified in the event can invoke it.
 
-**Example**
+**Example 1: one single Lua file with verifications of the results**
 
 ```lua
 -- ScriptEvents_Addressable.lua
@@ -83,11 +95,72 @@ ScriptExpectTrue(returnValue, "Method0's return value must be true")
 Script_Event.Event.MethodWithId1("ScriptEventAddress")
 ```
 
+The next example highlights the separation of logic between the definition of the Script Event method/function in one Lua Script; and how to call it in another Lua Script. The Addressable Script Events are a good choice when you need to communicate between two, and only two different Lua Scripts. In other words, one-to-one (1:1) relationship.
+
+**Example 2: Define script event in one Lua script; call it in another Lua script(1:1)**
+
+```lua
+-- -- This is the first Lua file. This is where you define the Addressable Script Event and respective method(s)
+
+-- -- just a function/method
+function ScriptTrace(txt)
+    Debug.Log(txt);
+end
+
+-- -- table with the method/function
+luaScriptEventWithId =
+{
+    MethodWithId0 = function(self, param1, param2)
+        ScriptTrace("MethodWithId0 handled");
+        return true;
+    end
+}
+
+-- -- When this Lua script is first activated, it will define the Script Event
+function OnActivate()
+
+    -- -- Script Event name = "Script_Event"! Address type = string, typeid("")
+    local scriptEventDefinition = ScriptEvent("Script_Event", typeid(""));
+    
+    -- -- Custom method name = "MethodWithId0"! Return value = Boolean, typeid(false)
+    local method0 = scriptEventDefinition:AddMethod("MethodWithId0", typeid(false));
+    -- -- Input pameter name "Param0" of type number, typeid(0)
+    method0:AddParameter("Param0", typeid(0));
+    -- -- Input pameter name "Param1" of type Id, typeid(EntityId())
+    method0:AddParameter("Param1", typeid(EntityId()));
+    
+    -- -- Register to enable the Script Event
+    scriptEventDefinition:Register();
+    
+    -- -- Connect using a string address: "ScriptEventAddress"
+    scriptEventHandler = Script_Event.Connect(luaScriptEventWithId, "ScriptEventAddress");
+end
+
+-- -- Optional. Disconnect when this Lua Script Deactivates
+function OnDeactivate()
+    -- scriptEventHandler:Disconnect();
+end
+
+```
+
+```lua
+-- -- This is the second Lua file. This is where you invoke/call/consume/get-return-value
+-- -- NOTE: In some UI cases (uicanvas), you should avoid calling the Script Event inside the OnActivate function.
+
+-- -- "ScriptEventAddress" is the address you defined earlier
+function FunctionInAnotherLuaFile()
+    local returnValue = Script_Event.Event.MethodWithId0("ScriptEventAddress", 1, EntityId(12345));
+end
+
+```
+
+---
+
 ### ScriptEvents_Broadcast.lua
 
 The `ScriptEvents_Broadcast.lua` example script implements a handler for a broadcast script event. Because broadcast script events do not specify an address type, any handler can connect to them.
 
-**Example**
+**Example 3: one single file with verifications of the results**
 
 ```lua
 -- ScriptEvents_Broadcast.lua
@@ -155,3 +228,76 @@ ScriptExpectTrue(returnValue, "BroadcastMethod0's return value must be true")
 -- To broadcast an event without a return or parameters, invoke BroadcastMethod1.
 Script_Broadcast.Broadcast.BroadcastMethod1()
 ```
+
+The next example highlights the separation of logic between the definition of the Script Event method/function in one Lua Script; and how to call it in multiple/different Lua Scripts. The Broadcast Script Events are a good choice when you need to communicate between more than two Lua Scripts. In other words, one-to-many (1:M) relationship.
+
+**Example 4: Define script event in one Lua script; call it in other Lua scripts (1:M)**
+
+```lua
+-- -- This is the first Lua file. This is where you define the Broadcast Script Event and respective method(s)
+
+-- -- just a function/method
+function ScriptTrace(txt)
+    Debug.Log(txt);
+end
+
+-- -- table with the method/function
+luaScriptEventBroadcast =
+{
+    BroadcastMethod0 = function(self, param1, param2)
+        ScriptTrace("BroadcastMethod0 Called"):
+        return true;
+    end
+}
+
+-- -- When this Lua script is first activated, it will define the Script Event
+function OnActivate()
+
+    -- -- Script Event name = "Script_Broadcast"! Note that there is NO ADDRESS
+    local scriptEventDefinition = ScriptEvent("Script_Broadcast");
+    
+    -- -- Custom method name = "BroadcastMethod0"! return value = Boolean, typeid(false)
+    local method0 = scriptEventDefinition:AddMethod("BroadcastMethod0", typeid(false));
+    -- -- Input parameter name "Param0" of type number, typeid(0)
+    method0:AddParameter("Param0", typeid(0));
+    -- -- Input parameter name "Param1" of type id, typeid(EntityId())
+    method0:AddParameter("Param1", typeid(EntityId()));
+    
+    -- -- Register to enable the Script Event
+    scriptEventDefinition:Register();
+    
+    -- -- Connect
+    scriptEventHandler = Script_Broadcast.Connect(luaScriptEventBroadcast, self.entityId);
+    -- scriptEventHandler = Script_Broadcast.Connect(luaScriptEventBroadcast);
+end
+
+-- -- Optional. Disconnect when this Lua Script Deactivates
+function Spells004:OnDeactivate()
+	  -- scriptEventHandler:Disconnect();
+end
+
+```
+
+
+```lua
+-- -- This is a second Lua file. This is one of the files that can invoke/call/consume/get-return-value
+-- -- NOTE: In some UI cases (uicanvas), you should avoid calling the Script Event inside the OnActivate function.
+
+-- -- NO ADDRESS needed
+function FunctionInAnotherLuaFile2()
+    local returnValue = Script_Broadcast.Broadcast.BroadcastMethod0(2, EntityId(23456))
+end
+
+```
+
+```lua
+-- -- This is the third Lua file. This is another one of the files that can invoke/call/consume/get-return-value
+-- -- NOTE: In some UI cases (uicanvas), you should avoid calling the Script Event inside the OnActivate function.
+
+-- -- NO ADDRESS needed
+function FunctionInAnotherLuaFile3()
+    local returnValue = Script_Broadcast.Broadcast.BroadcastMethod0(3, EntityId(234567))
+end
+
+```
+


### PR DESCRIPTION

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Script Events in Lua are showcased with two more code examples.
Clear separation of communication between different scripts.
Clear "where to call what" functions using Lua.
Incomplete table of available input and return types with Script Events (these are the ones I tested so far).
Added some other tips along the text like "JSON" and "avoid calling Script Events OnActivate". O3DE does not have a JSON library, so I did not include a link (e.g., https://github.com/rxi/json.lua).

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

