### PR TITLE
Adding note that you must export the O3DE_SNAP environment variable or command line builds will fail for Snap O3DE SDK

### DIFF
--- a/content/docs/user-guide/build/_index.md
+++ b/content/docs/user-guide/build/_index.md
@@ -24,6 +24,10 @@ Use `Visual Studio 16` as the generator for Visual Studio 2019, and `Visual Stud
 {{% /tab %}}
 {{% tab name="Linux" %}}
 
+{{< important >}}
+When building using the O3DE pre-build **Snap** SDK, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
+
 ```shell
 cd <project-directory>
 cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=<absolute-path-to-packages>

--- a/content/docs/user-guide/build/configure-and-build.md
+++ b/content/docs/user-guide/build/configure-and-build.md
@@ -77,6 +77,10 @@ cmake -B build/windows -S . -G "Visual Studio 16" -DLY_3RDPARTY_PATH=<downloadab
 {{% /tab %}}
 {{% tab name="Linux" %}}
 
+{{< important >}}
+When building using the O3DE pre-build **Snap** SDK, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
+
 ```shell
 cmake -B build/linux -S . -G "Ninja Multi-Config" -DLY_3RDPARTY_PATH=<downloadable-packages-directory>
 ```

--- a/content/docs/user-guide/platforms/linux/_index.md
+++ b/content/docs/user-guide/platforms/linux/_index.md
@@ -33,9 +33,13 @@ Refer to [Creating Projects Using the Command Line Interface](/docs/welcome-guid
 
 Although CMake supports Unix Make Files on Linux, we recommend that you use Ninja as a build system to support multiple configurations in your generated builds. These instructions use "Ninja Multi-Config" as the CMake generator.
 
+{{< important >}}
+When building using the O3DE pre-build **Snap** SDK, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
 
 ### Multiple Config Builds
 The following command generates a build folder, `build/linux`, under the root of the project folder, `$O3DE_PROJECT_PATH`, by using Ninja as the build generator and clang-12 as the compiler.
+
 
 ```shell
 
@@ -60,6 +64,10 @@ cmake -B build/linux -S . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_CONFIG
 ## Building from command line
 
 Once the build folder is generated, building from command line is the same process as for other platforms.
+
+{{< important >}}
+When building using the O3DE pre-build **Snap** SDK, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
 
 ### Multiple Config Builds
 

--- a/content/docs/welcome-guide/create/creating-projects-using-cli/creating-linux.md
+++ b/content/docs/welcome-guide/create/creating-projects-using-cli/creating-linux.md
@@ -67,6 +67,10 @@ If you move the project, you will need to update this manifest entry.
 
 Use **CMake** to create the Linux build project for your O3DE project.
 
+{{< important >}}
+When building using the O3DE pre-build **Snap** SDK, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
+
 1. Create the Linux build project in your new project directory. Supply the build directory, the project source directory, the Ninja Multi-Config generator, and any other project options. Paths can be absolute or relative. Example:
 
     ```shell

--- a/content/docs/welcome-guide/setup/installing-linux.md
+++ b/content/docs/welcome-guide/setup/installing-linux.md
@@ -143,6 +143,10 @@ Example of launching Project Manager from the shell:
 o3de
 ```
 
+{{< important >}}
+When configuring or building using the O3DE pre-build **Snap** SDK from the command line, first export the `O3DE_SNAP` environment variable so CMake does not attempt to install Python pip requirements and fail. To export the `O3DE_SNAP` environment variable, run the command `export O3DE_SNAP` from the command line before running the CMake commands below.
+{{< /important >}}
+
 ## Removing O3DE installed from a Snap package
 
 1. Run `snap` to remove O3DE:


### PR DESCRIPTION
## Change summary

Builds will fail when using the Snap O3DE SDK from the command line if you don't first export the O3DE_SNAP environment variable.  This should be fixed in the engine, but for now, documenting the workaround.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

