### PR TITLE
Update requirements.md

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -227,11 +227,12 @@ O3DE also requires some additional library packages to be installed:
 * libstdc++-12-dev
 * libunwind-dev
 * libzstd-dev
+* libcurl4-openssl-dev
 
 You can download and install these packages through `apt`.
 
 ```shell
-sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev
+sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev libcurl4-openssl-dev
 ```
 
 ### Ninja Build System (Optional)


### PR DESCRIPTION
CMake does not check for presence of libcurl for AWSCore so this fails later during the build, in any case seems to be a hard dependency. https://github.com/o3de/o3de/issues/11783
