### PR TITLE
Update ragdoll.md to point to the correct EmotionFX tutorial

### DIFF
--- a/content/docs/user-guide/components/reference/physx/ragdoll.md
+++ b/content/docs/user-guide/components/reference/physx/ragdoll.md
@@ -22,7 +22,7 @@ You use the PhysX system and the **Animation Editor** to create a ragdoll.
 
 1. Choose **Tools**, **Animation Editor**.
 
-1. Use the **Animation Editor** to create and control the physical representation of the ragdoll. For more information, see [Creating and Simulating a PhysX Ragdoll](/docs/user-guide/visualization/animation/animation-editor/creating-and-simulating-physx-ragdoll/).
+1. Use the **Animation Editor** to create and control the physical representation of the ragdoll. For more information, see [Creating and Simulating a PhysX Ragdoll](/docs/user-guide/visualization/animation/animation-editor/ragdoll/).
 
 ## PhysX Ragdoll Component Properties 
 


### PR DESCRIPTION
## Change summary

Ragdoll documentation was pointing to an incorrect nonexistent [url ](https://www.docs.o3de.org/docs/user-guide/visualization/animation/animation-editor/creating-and-simulating-physx-ragdoll/) for EmotionFX - updated the [url ](https://www.docs.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/)to point to the correct doc.
