### PR TITLE
Update headless deployment of simulation

### DIFF
--- a/content/docs/user-guide/interactivity/robotics/deploying-simulation.md
+++ b/content/docs/user-guide/interactivity/robotics/deploying-simulation.md
@@ -97,7 +97,7 @@ To run headless, start with `-NullRenderer -rhi=null`.
 ```
 The above command should work for environments that have no GPU. 
 If your simulation relies on the ROS 2 Camera component, you will need RHI. 
-In such cases, it can be simulated with third-party tools like `xvfb-run`, which creates a virtual X server environment.
+In such cases, it can be simulated with `console-mode` switch:
 ```bash
-xvfb-run ./Ros2Project.GameLauncher
+./Ros2Project.GameLauncher -console-mode
 ```


### PR DESCRIPTION
## Change summary

We have headless console mode in development and planned 2409:
https://github.com/o3de/o3de/pull/18137
https://github.com/o3de/o3de/pull/18093
so I decided to retire solution utilizing `xvfb`.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

