### PR TITLE
Cherry-pick change from #2541

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -222,11 +222,12 @@ O3DE also requires some additional library packages to be installed:
 * libunwind-dev
 * libzstd-dev
 * tix
+* libcurl4-openssl-dev
 
 You can download and install these packages through `apt`.
 
 ```shell
-sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix
+sudo apt install libglu1-mesa-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix libcurl4-openssl-dev
 ```
 
 ### Ninja Build System (Optional)


### PR DESCRIPTION
CMake does not check for presence of libcurl for AWSCore so this fails later during the build, in any case seems to be a hard dependency. https://github.com/o3de/o3de/issues/11783

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

#2541 was approved, but required a retarget. The original contributor has been unresponsive lately, so I went ahead to try to retarget it. However, due to changes since his submission, it doesn't rebase cleanly, so I've cherry-picked the change into a fresh copy of development.

From the original PR:

> CMake does not check for presence of libcurl for AWSCore so this fails later during the build, in any case seems to be a hard dependency. https://github.com/o3de/o3de/issues/11783

@spham-amzn can you do a quick check on this, since you were involved with the original PR, please? ❤️ 

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

