### PR TITLE
Add note about Ninja requirement for script-only mode.

### DIFF
--- a/content/docs/user-guide/build/script-only-projects.md
+++ b/content/docs/user-guide/build/script-only-projects.md
@@ -17,6 +17,11 @@ Third party gems and plugins can only be used if they are also pre-built.
 Despite these limitations it is a way to quickly get into the editor and start creating immediately, without downloading a compiler and without downloading any additional c++ development libraries such as the Qt SDK.
 
 ## Creating a Script-only Project
+
+{{< note >}}
+While Script-only mode does not require a C++ compiler, a compatible build system such as [Ninja](https://ninja-build.org/) or [GNU Make](https://www.gnu.org/software/make/) *is* required, because it's responsible for copying all the bits and pieces into the build folder.
+{{< /note >}}
+
 You can create a new Script-only project by using the ScriptOnlyProject [template](/docs/user-guide/build/templates.md), see the [Creating Projects](/docs/welcome-guide/create) document for more information.
 
 You can also convert an existing project into a Script-only project by modifying the `project.json` file in the root.  The flag that determines whether a project is script-only is the following tag at the root of a `project.json`:


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

Script-only mode requires Ninja or GNU Make to work properly, and right now, O3DE does not ship with it, so we need to inform the user of that requirement. I added it as a note, because it's the only external requirement for this mode, so this calls attention to it.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

