### PR TITLE
Document difference between dynamic and static ros2 frames

### DIFF
--- a/content/docs/user-guide/components/reference/ros2/core/ros2-frame.md
+++ b/content/docs/user-guide/components/reference/ros2/core/ros2-frame.md
@@ -35,3 +35,4 @@ The **ROS 2 Frame** component depends on Transform Service, which is provided by
 **ROS 2 Frame** component handles namespace, frame id, and joint name associated with an entity, which is a part of a robot.
 Many other components such as sensors and controllers depend on it. **ROS 2 Frame** works internally with these components to
 ensure namespacing of topics, sending of proper `frame_id` in each message, and broadcasting of transforms to `/tf` and `/tf_static` topics.
+The transformation is continously updated and published to `/tf` if the entity contains a JointComponent (which is not a fixed joint) or an ArticulatedComponent. Otherwise, it will be published once on the `/tf_static` topic and not updated even if the entity moves.


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Just a small addition which makes the difference between static and dynamic ROS 2 frames more clear.
Took us a bit of work to figure out why a frame was not correctly for an object that we moved around with a Lua script.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

