### PR TITLE
Fix: Broken link in Welcome Guide

### DIFF
--- a/content/docs/welcome-guide/_index.md
+++ b/content/docs/welcome-guide/_index.md
@@ -32,6 +32,6 @@ O3DE is an open-source, cross-platform, real time 3D engine that you can use to 
 
 | Tutorial | Description |
 |---|---|
-| [Create your first game: Pong!](/docs/learning-guide/tutorials/first-project/) | Start from a new O3DE project and build your first game: Pong! What's "Pong"? Two paddles square off, in a ball-based battle to land the highest score. This tutorial series will introduce you to basic game UI development, scripting, and controls in O3DE. |
+| [Create your first game: Pong!](/docs/learning-guide/samples/follow-along/pong/) | Start from a new O3DE project and build your first game: Pong! What's "Pong"? Two paddles square off, in a ball-based battle to land the highest score. This tutorial series will introduce you to basic game UI development, scripting, and controls in O3DE. |
 
 For more detailed docs, check out the [Open 3D Engine User Guide](/docs/user-guide/).


### PR DESCRIPTION
## Change summary
This PR adjusts the broken link in [Welcome Guide](https://docs.o3de.org/docs/welcome-guide/), in section`Get Started Tutorials`.

Adjusted URL in [content/docs/welcome-guide/_index.md](https://github.com/o3de/o3de.org/blob/development/content/docs/welcome-guide/_index.md):

From:
`[Create your first game: Pong!](/docs/learning-guide/tutorials/first-project/)
`

To:
`[Create your first game: Pong!](/docs/learning-guide/samples/follow-along/pong/)
`

- [X] I checked if the URL existed elsewhere in the code, but I couldn't find it.
- [X] I checked another open PR, but the link is with `".md"`, which is not necessary.

**If it is not useful, you can close it.**

### Submission Checklist:

* [X] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [X] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [X] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [X] **Help the user** - Does the documentation show the user something *meaningful*?

