### PR TITLE
Platform Location Fix

### DIFF
--- a/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
+++ b/content/docs/user-guide/packaging/asset-bundler/command-line-reference.md
@@ -124,7 +124,7 @@ Prints the contents of the seed list after performing operations.
 
 The platforms used for this command. Defaults to all supported platforms for the current project. Supported platforms can be changed by modifying `AssetProcessorPlatformConfig.ini`.
 
-Platform names can be found in the `AssetProcessorPlatformConfig.ini` file, or as folder names found under `dev/Cache/ProjectName`.
+Platform names can be found in the `Registry/AssetProcessorPlatformConfig.setreg` file, or as folder names found under `dev/Cache/ProjectName`.
 
 * *Type:* Multi-value argument
 * *Required:* No


### PR DESCRIPTION
## Change summary

Small change pointing users to the correct file path for finding available platforms.

### Submission Checklist:

* [ x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x ] **Help the user** - Does the documentation show the user something *meaningful*?

