### PR TITLE
Add information about Terrain and low-pipeline

### DIFF
--- a/content/docs/atom-guide/dev-guide/render-pipelines.md
+++ b/content/docs/atom-guide/dev-guide/render-pipelines.md
@@ -19,31 +19,31 @@ The render pipeline consists of a root pass that drives a collection of passes t
 
 This table lists the features that are supported by the Main Rendering Pipeline and the Low-end Rendering Pipeline by default.
 
-| Feature | Description | Main Pipeline | Low-end Pipeline |
-| - | - | - | - |
-| Skinning | Compute-shader-based mesh skinning for bone weighted animations and morph targets. | Yes | Yes |
-| Directional shadows | Cascaded shadowmap to simulate sun light. | Yes | Yes |
-| Punctual shadows | Shadows for punctual light types: point and spot lights. | Yes | Yes |
-| Area lights | Spherical, disk, capsule, quad, and polygonal lights. | Yes | Yes |
-| Light culling | Tile-based or cluster-based light culling for efficient light iteration in the Forward+ pass. | Yes | Yes |
-| RTX global illumination | Real-time global illumination that uses NVIDIA RTXGI (RTX Global Illumination). | Yes | No |
-| Reflection probe | Generates and uses reflection probes for specular image-based lighting (IBL). | Yes | Yes |
-| Physically based sky | Basic sky rendering that uses physically-based atmospheric modeling. | Yes | No |
-| HDR skybox | Uses an HDR image as a skybox. | Yes | Yes |
-| Screen space ambient occlusion (SSAO) | Applies SSAO to the scene to create contact shadows where objects meet.  | Yes | No |
-| Subsurface scattering | Calculates subsurface scattering for materials, such as skin, by using a screen space technique. | Yes | No |
-| Deferred fog | Applies a height-based fog to the scene. | Yes | No |
-| Screen space reflections (SSR) | Implements SSR by using renderered lighting buffer to approximate real-time reflections. | Yes | No |
-| Depth of field | Applies a bokeh-shaped depth of field effect to the scene that's based on the scene's depth and camera focus paramters. | Yes | No |
-| Bloom | Applies a bloom effect to the rendered image, making bright pixels bleed out into neighboring pixels. | Yes | No |
-| Subpixel morphological anti-aliasing (SMAA) | Applies SMAA as an anti-aliasing technique. | Yes | No |
-| Temporal anti-aliasing (TAA) | TAA uses motion vectors and temporal super-sampling to reduce aliasing in the final image. | Yes | No |
-| Light adaptation | Adjusts brightness of the final image based on the scene's average luminance, so the image appears neither too dark nor too bright. | Yes | Yes |
-| Look modification and color grading | Allows artists to adjust the final look of the image by using look up tables (LUTs). | Yes | Yes |
-| Display mapping | Adjusts the color values of the final image based on the color range that the screen expects. | Yes | Yes |
-| User interface (UI) | Renders 2D UI components. | Yes | Yes |
-| Auxilary geometry (AuxGeom) | Renders various geometry and text for in-editor tools and debugging, such as gizmos, grids, debug lines, and shapes. | Yes | Yes |
-
+| Feature                                     | Description                                                                                                                         | Main Pipeline | Low-end Pipeline |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- |
+| Skinning                                    | Compute-shader-based mesh skinning for bone weighted animations and morph targets.                                                  | Yes           | Yes              |
+| Directional shadows                         | Cascaded shadowmap to simulate sun light.                                                                                           | Yes           | Yes              |
+| Punctual shadows                            | Shadows for punctual light types: point and spot lights.                                                                            | Yes           | Yes              |
+| Area lights                                 | Spherical, disk, capsule, quad, and polygonal lights.                                                                               | Yes           | Yes              |
+| Light culling                               | Tile-based or cluster-based light culling for efficient light iteration in the Forward+ pass.                                       | Yes           | Yes              |
+| RTX global illumination                     | Real-time global illumination that uses NVIDIA RTXGI (RTX Global Illumination).                                                     | Yes           | No               |
+| Reflection probe                            | Generates and uses reflection probes for specular image-based lighting (IBL).                                                       | Yes           | Yes              |
+| Physically based sky                        | Basic sky rendering that uses physically-based atmospheric modeling.                                                                | Yes           | No               |
+| HDR skybox                                  | Uses an HDR image as a skybox.                                                                                                      | Yes           | Yes              |
+| Screen space ambient occlusion (SSAO)       | Applies SSAO to the scene to create contact shadows where objects meet.                                                             | Yes           | No               |
+| Subsurface scattering                       | Calculates subsurface scattering for materials, such as skin, by using a screen space technique.                                    | Yes           | No               |
+| Deferred fog                                | Applies a height-based fog to the scene.                                                                                            | Yes           | No               |
+| Screen space reflections (SSR)              | Implements SSR by using rendered lighting buffer to approximate real-time reflections.                                              | Yes           | No               |
+| Depth of field                              | Applies a bokeh-shaped depth of field effect to the scene that's based on the scene's depth and camera focus parameters.            | Yes           | No               |
+| Bloom                                       | Applies a bloom effect to the rendered image, making bright pixels bleed out into neighboring pixels.                               | Yes           | No               |
+| Subpixel morphological anti-aliasing (SMAA) | Applies SMAA as an anti-aliasing technique.                                                                                         | Yes           | No               |
+| Temporal anti-aliasing (TAA)                | TAA uses motion vectors and temporal super-sampling to reduce aliasing in the final image.                                          | Yes           | No               |
+| Light adaptation                            | Adjusts brightness of the final image based on the scene's average luminance, so the image appears neither too dark nor too bright. | Yes           | Yes              |
+| Look modification and color grading         | Allows artists to adjust the final look of the image by using look up tables (LUTs).                                                | Yes           | Yes              |
+| Display mapping                             | Adjusts the color values of the final image based on the color range that the screen expects.                                       | Yes           | Yes              |
+| User interface (UI)                         | Renders 2D UI components.                                                                                                           | Yes           | Yes              |
+| Auxilary geometry (AuxGeom)                 | Renders various geometry and text for in-editor tools and debugging, such as gizmos, grids, debug lines, and shapes.                | Yes           | Yes              |
+| Terrain system                              | Enables terrain authoring, simulation, and visualization for levels of arbitrary size                                               | Yes           | No               |
 
 
 ## File structure

--- a/content/docs/user-guide/visualization/environments/terrain/_index.md
+++ b/content/docs/user-guide/visualization/environments/terrain/_index.md
@@ -6,15 +6,17 @@ weight: 100
 toc: true
 ---
 
-The terrain system uses a series of components to enable terrain authoring, simulation, and visualization for levels of aribtrary size. To use the terrain system, you must enable the Terrain Gem for your project.
+The terrain system uses a series of components to enable terrain authoring, simulation, and visualization for levels of arbitrary size. To use the terrain system, you must enable the Terrain Gem for your project.
 
 ## System Requirements
 
 To use the full capabilities of the terrain system, enable the following Gems:
 
-| | | |
-| - | - | - |
-| **Terrain Gem** | Required | Provides the terrain system and the core terrain components. These are the foundation for enabling the terrain system and creating terrain areas. |
+|                         |            |                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Terrain Gem**         | Required   | Provides the terrain system and the core terrain components. These are the foundation for enabling the terrain system and creating terrain areas.                                                                                                                                                                                                                                |
 | **Gradient Signal Gem** | Dependency | Provides gradient and gradient modifier components, which are used to express height and surface type data to the terrain system. The gradient components generate various gradient signals, such as random noise and Perlin noise, or enable the use of authored data such as height maps or weight maps. The gradient modifier components modify and mix the gradient signals. |
-| **Surface Data Gem** | Dependency | Enables the terrain system to emit signals, or tags, that communicate its surface characteristics. This system enables the Dynamic Vegetation system to place objects on the terrain surface without having any direct knowledge or dependency on the terrain system itself. |
-| **FastNoise Gem** | Optional | Provides an expressive **FastNoise Gradient** component that generates many procedural noise variations. In **Entity Inspector**, the **FastNoise Gradient** component appears in the **Gradient** category. You use it like any other gradient component. |
+| **Surface Data Gem**    | Dependency | Enables the terrain system to emit signals, or tags, that communicate its surface characteristics. This system enables the Dynamic Vegetation system to place objects on the terrain surface without having any direct knowledge or dependency on the terrain system itself.                                                                                                     |
+| **FastNoise Gem**       | Optional   | Provides an expressive **FastNoise Gradient** component that generates many procedural noise variations. In **Entity Inspector**, the **FastNoise Gradient** component appears in the **Gradient** category. You use it like any other gradient component.                                                                                                                       |
+
+> **Note:** Terrain functionality is only available in the *Main* rendering pipeline. Visit [rendering pipelines description](../../../../atom-guide/dev-guide/render-pipelines.md) for more details.


### PR DESCRIPTION
## Change summary

The main rendering profile requirement information is added to the Terrain description and the rendering pipelines description. 
Two small typos and the tables' formatting is changed additionally.

The change was triggered by the discussion in the issue: https://github.com/o3de/o3de/issues/18468

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

