### PR TITLE
Remove references to control_toolbox

### DIFF
--- a/content/docs/user-guide/interactivity/robotics/project-configuration.md
+++ b/content/docs/user-guide/interactivity/robotics/project-configuration.md
@@ -52,7 +52,7 @@ If you have multiple ROS 2 versions installed, make sure you [source](https://do
 * gazebo_msgs: `ros-${ROS_DISTRO}-gazebo-msgs`
     * gazebo_msgs are used for robot spawning (no dependency on Gazebo).
 * Ackermann messages: `ros-${ROS_DISTRO}-ackermann-msgs`
-* Control toolbox `ros-${ROS_DISTRO}-control-toolbox`
+* Control messages `ros-${ROS_DISTRO}-control-msgs`
 * XACRO `ros-${ROS_DISTRO}-xacro`
 * Vision msgs `ros-${ROS_DISTRO}-vision-msgs`
 
@@ -61,7 +61,7 @@ If a `desktop` installation of ROS 2 distro was selected, everything else should
 Use this helpful command to install:
 
 ```
-sudo apt install ros-${ROS_DISTRO}-ackermann-msgs ros-${ROS_DISTRO}-control-toolbox ros-${ROS_DISTRO}-nav-msgs ros-${ROS_DISTRO}-gazebo-msgs ros-${ROS_DISTRO}-xacro ros-${ROS_DISTRO}-vision-msgs
+sudo apt install ros-${ROS_DISTRO}-ackermann-msgs ros-${ROS_DISTRO}-control-msgs ros-${ROS_DISTRO}-nav-msgs ros-${ROS_DISTRO}-gazebo-msgs ros-${ROS_DISTRO}-xacro ros-${ROS_DISTRO}-vision-msgs
 ```
 
 ### Clone the Gem repository

--- a/content/docs/user-guide/interactivity/robotics/vehicle-dynamics.md
+++ b/content/docs/user-guide/interactivity/robotics/vehicle-dynamics.md
@@ -29,7 +29,7 @@ The wheel controller has the following parameters shown below.
 
 ### Ackermann Drive Model
 
-The implementation of **AckermannDriveModel** uses [PID controllers](https://en.wikipedia.org/wiki/PID_controller) from [control_toolbox](https://github.com/ros-controls/control_toolbox) package. The model computes velocities or forces in the joints of the vehicle and applies it accordingly to commanded velocity.
+The implementation of **AckermannDriveModel** uses [PID controllers](https://en.wikipedia.org/wiki/PID_controller). The model computes velocities or forces in the joints of the vehicle and applies it accordingly to commanded velocity.
 
 ![AckermannModel](/images/user-guide/gems/ros2/ackermanModel.png)
 


### PR DESCRIPTION
<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

Requires https://github.com/o3de/o3de-extras/pull/825 first.

`control_toolbox` dependency is removed from ROS 2 gem. This PR removes all references to it.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

