### PR TITLE
Changing "GPU bubbles" for Async Compute description

### DIFF
--- a/content/docs/atom-guide/dev-guide/rhi/rhi.md
+++ b/content/docs/atom-guide/dev-guide/rhi/rhi.md
@@ -18,7 +18,7 @@ The RHI provides customers with a platform-independent, general purpose renderin
 The RHI is designed to allow platform developers to take advantage of specialized hardware features, to the extent possible, without the need for custom code paths at both the lower and higher levels of the renderer. The Frame Scheduler, a component of the RHI, enables whole-frame optimization by representing render passes as nodes in a graph. The graph execution strategy is determined at the platform-specific level to best optimize the frame for the needs of the hardware. RHI is an ever-growing layer with plans to support more backends and the latest API across current backends. Some of the RHI's optimization techniques include the following:
 - Generate multi-threaded command buffer on platforms that facilitate it, such as PC and mobile.
 - Save significant amounts of GPU memory by reclaiming unused regions within the current frame.
-- Ability to use Async Compute to help fill up GPU bubbles within a frame.
+- Ability to use Async Compute to help fill up compute resources not used by graphics tasks within a frame.
 - Explicitly track all the resources through FrameGraph. 
 - Ability to keep render targets in on-chip memory on mobile.
 - Long term, we will take advantage of Heterogeneous and linked multi-GPU setups, which will become more tractable by having full-frame knowledge.


### PR DESCRIPTION
GPU bubbles mean macroscopical idle time spans in a GPU timeline, most likely due to inefficient uses of graphics APIs on the CPU side, if you fill up such bubbles you are doing synchronized compute. While Async Compute executes simultaneously/concurrently when there is a graphics task, i.e., not a bubble, what Async Compute really fill up is SIMD slots that are not occupied by graphics wavefronts due to some bottleneck preventing a higher occupancy, so that compute wavefronts may execute when graphics wavefronts are blocked.

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

