### PR TITLE
Do not describe Windows as a primary platform

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -44,9 +44,9 @@ Creating new projects or using the advanced development features of O3DE require
 
 ## Microsoft Windows
 
-At this time, Microsoft Windows is the primary platform for using the O3DE
-editor and for building source. Specifically, **Windows 10 version 20H2 (10.0.19042)**
-or later is required.
+To use the O3DE Editor on Windows, **Windows 10 version 20H2 (10.0.19042)** or later is required.
+
+The following instructions describe how to install the required additional software.
 
 ### Microsoft Visual Studio
 


### PR DESCRIPTION
## Change summary

This PR removes the description of Windows being the primary platform. I decided to use almost the same text of the Linux section since it's pretty straightforward.

Closes #2669

### Submission Checklist:

Since it's a simple fix, it's N/A I suppose?

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

