### PR TITLE
Update requirements after O3DE#18893

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -213,21 +213,25 @@ O3DE also requires some additional library packages to be installed:
 * libxcb-xinput-dev
 * libxcb-xfixes0-dev
 * libxcb-xkb-dev
+* libxcb-image0-dev
+* libxcb-randr0-dev
+* libxcb-keysyms1-dev
 * libxkbcommon-dev
 * libxkbcommon-x11-dev
 * libfontconfig1-dev
+* libcurl4-openssl-dev
 * libpcre2-16-0
 * zlib1g-dev
 * mesa-common-dev
-* libstdc++-12-dev
+* libssl-dev
 * libunwind-dev
 * libzstd-dev
-* tix
+* xxd
 
 You can download and install these packages through `apt`.
 
 ```shell
-sudo apt install libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libunwind-dev libzstd-dev tix
+sudo apt install libglu1-mesa-dev libxcb-randr0-dev libxcb-xinerama0 libxcb-xinput0 libxcb-xinput-dev libxcb-xfixes0-dev libxcb-xkb-dev libxcb-image0-dev libxcb-randr0-dev libxcb-keysyms1-devlibxkbcommon-dev libxkbcommon-x11-dev libfontconfig1-dev libcurl4-openssl-dev libpcre2-16-0 zlib1g-dev mesa-common-dev libssl-dev libunwind-dev libzstd-dev xxd
 ```
 
 ### Ninja Build System (Optional)


### PR DESCRIPTION
## Change summary

`libxcb-keysyms1-dev` is required after changes in https://github.com/o3de/o3de/pull/18893

The requirements were updated based on https://github.com/yaakuro/o3de/blob/44326574ffb1396cb77a2d78e359e84ddf8ee745/scripts/build/build_node/Platform/Linux/package-list.ubuntu-jammy.txt
ROS packages are skipped - they are only needed for `ROS2` Gem and are listed in the other pages of this documentation.

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?

