### PR TITLE
Miniaudio - updated playback component link duplicate to the right name

### DIFF
--- a/content/docs/user-guide/gems/reference/audio/miniaudio/miniaudio.md
+++ b/content/docs/user-guide/gems/reference/audio/miniaudio/miniaudio.md
@@ -7,7 +7,7 @@ toc: true
 
 The MiniAudio Gem provides support for audio playback and positioning using [MiniAudio](https://miniaud.io) in **Open 3D Engine (O3DE)** projects.  Multiple audio formats are supported and sounds can be previewed in the Editor without entering game mode.
 
-For more information on using the components provided by this Gem, refer to the [MiniAudio Playback Component](/docs/user-guide/components/reference/audio/mini-audio-playback.md) and [MiniAudio Playback Component](/docs/user-guide/components/reference/audio/mini-audio-listener.md) documentation.
+For more information on using the components provided by this Gem, refer to the [MiniAudio Playback Component](/docs/user-guide/components/reference/audio/mini-audio-playback.md) and [MiniAudio Listener Component](/docs/user-guide/components/reference/audio/mini-audio-listener.md) documentation.
 
 ## Supported Audio Formats
 * FLAC

--- a/content/docs/user-guide/gems/reference/audio/miniaudio/miniaudio.md
+++ b/content/docs/user-guide/gems/reference/audio/miniaudio/miniaudio.md
@@ -7,7 +7,7 @@ toc: true
 
 The MiniAudio Gem provides support for audio playback and positioning using [MiniAudio](https://miniaud.io) in **Open 3D Engine (O3DE)** projects.  Multiple audio formats are supported and sounds can be previewed in the Editor without entering game mode.
 
-For more information on using the components provided by this Gem, refer to the [MiniAudio Playback Component](/docs/user-guide/components/reference/audio/mini-audio-playback.md) and [MiniAudio Listener Component](/docs/user-guide/components/reference/audio/mini-audio-listener.md) documentation.
+For more information on using the components provided by this Gem, refer to the [MiniAudio Playback Component](/docs/user-guide/components/reference/audio/mini-audio-playback.md) and [MiniAudio Listener Component](/docs/user-guide/components/reference/audio/mini-audio-listener.md) documentation. 
 
 ## Supported Audio Formats
 * FLAC


### PR DESCRIPTION
The Miniaudio overview page: https://www.docs.o3de.org/docs/user-guide/gems/reference/audio/miniaudio/miniaudio/

Says:

For more information on using the components provided by this Gem, refer to the MiniAudio Playback Component and MiniAudio Playback Component documentation.

I edited it to say Listener Component on the appropriate link.