### PR TITLE
Add math flag to toml, update theme for current one with the rest of the math support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.24
 
 require (
 	github.com/o3de/api.o3de.org v0.0.0-20250619195622-67020d64f7b5 // indirect
-	github.com/o3de/hugo-odie v0.0.0-20250607164835-e8c6464265ee // indirect
+	github.com/o3de/hugo-odie v0.0.0-20250926192417-45f3dcf3acd2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,9 @@ github.com/o3de/hugo-odie v0.0.0-20241126002926-cac27abcb022 h1:cnPDk4/430IcnnbP
 github.com/o3de/hugo-odie v0.0.0-20241126002926-cac27abcb022/go.mod h1:nsaJnNh0bcthbzUyIh5ZAkSmxr5VMy9DvF6ohz6+M04=
 github.com/o3de/hugo-odie v0.0.0-20250607164835-e8c6464265ee h1:wLdC9W1ObTx1mGM9ypAmAZ4Wi2RK7nJ4eeElP0kNgvo=
 github.com/o3de/hugo-odie v0.0.0-20250607164835-e8c6464265ee/go.mod h1:nsaJnNh0bcthbzUyIh5ZAkSmxr5VMy9DvF6ohz6+M04=
+github.com/o3de/hugo-odie v0.0.0-20250925181214-be7e5cba112a h1:SD38w8wKxZ8vGbRpET65y1VqTm8xNkHZbeqKPiYtxdk=
+github.com/o3de/hugo-odie v0.0.0-20250925181214-be7e5cba112a/go.mod h1:nsaJnNh0bcthbzUyIh5ZAkSmxr5VMy9DvF6ohz6+M04=
+github.com/o3de/hugo-odie v0.0.0-20250925183307-3bcc173cefc0 h1:Uaw6x7H/82HRQ+6wYO6lkYcv9z2li+VM2Qlpw/zzMts=
+github.com/o3de/hugo-odie v0.0.0-20250925183307-3bcc173cefc0/go.mod h1:nsaJnNh0bcthbzUyIh5ZAkSmxr5VMy9DvF6ohz6+M04=
+github.com/o3de/hugo-odie v0.0.0-20250926192417-45f3dcf3acd2 h1:jpr3CHOMCb2lae1GPcz3GDHpGQ79EUEP1ZIsDAPeFCI=
+github.com/o3de/hugo-odie v0.0.0-20250926192417-45f3dcf3acd2/go.mod h1:nsaJnNh0bcthbzUyIh5ZAkSmxr5VMy9DvF6ohz6+M04=

--- a/hugo.toml
+++ b/hugo.toml
@@ -29,11 +29,19 @@ enableRobotsTXT = true
       source = "content"
       target = "content/docs/api"
 
-[markup.highlight]
-  style = "paraiso-dark"
-
-[markup.goldmark.renderer]
-  unsafe = true
+[markup]
+  [markup.highlight]
+    style = "paraiso-dark"
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
+    [markup.goldmark.renderer]
+      unsafe = true
+  
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
@@ -48,6 +56,7 @@ enableRobotsTXT = true
   contentDir = "/content/"
   docsDir = "/docs/"
   sourceRepo = "https://github.com/o3de/o3de"
+  math = true
 
 [params.docs]
 # Docs version data format: ["display name", "baseURL"]


### PR DESCRIPTION

<!--
    Thanks for your contribution to the Open 3D Engine documentation! Before creating your pull
    request, we ask you to sign off on our submission checklist to ensure that your PR comes through
    quickly. Our reviewers' role is to make sure that all non-trivial submissions follow these best practices.

    By submitting your pull request with DCO signoff, you agree to the Code of Conduct and
    Open 3D Engine documentation and website licensing terms.
-->

## Change summary

<!-- Provide a short description of your changes. -->

To activate math syntax rendering, we needed to add `params.math` to the toml file, and update the theme to load MathJax (the default recommendation for Hugo). This does those things (the theme's already been updated).

## To Test

1. Pick a page or make a new one
2. Write some math as [illustrated here](https://gohugo.io/content-management/mathematics/#step-5)
3. Run `hugo server` and view your page
4. The page should display the math in an evidently different way, and right-clicking on it should bring up a custom MathJax context menu