### PR TITLE
Update the cmake requirement for Ubuntu 22.04LTS from 3.22 to 3.24

### DIFF
--- a/content/docs/welcome-guide/requirements.md
+++ b/content/docs/welcome-guide/requirements.md
@@ -147,7 +147,7 @@ Install CMake using the instructions for the version of Ubuntu that you have ins
 {{< tabs name="CMake install" >}}
 {{% tab name="22.04 LTS" %}}
 
-You can install the default version of CMake for Ubuntu 22.04 LTS, which is version 3.22. To install more recent versions, refer to the CMake [download page](https://cmake.org/download/#latest).
+The default version of CMake for Ubuntu 22.04 LTS is version 3.22, however version 3.24 is the minimum requirement for O3DE. To install more recent versions, refer to the CMake [download page](https://cmake.org/download/#latest).
 
 ```shell
 sudo apt install cmake


### PR DESCRIPTION
Update the documentation to say that the ubuntu 22.04lts default cmake is 3.22 and that as of 25.10.0 the new cmake minimum requirement is 3.24