### PR TITLE
Fix double title in audio

### DIFF
--- a/content/docs/user-guide/interactivity/audio/audio-controls-editor/middleware-pane.md
+++ b/content/docs/user-guide/interactivity/audio/audio-controls-editor/middleware-pane.md
@@ -1,5 +1,4 @@
 ---
-title: Middleware Controls Pane
 title: Audio Engine Middleware Controls Pane
 description: Use the Audio Controls Editor's audio engine middleware controls pane to filter and select a middleware-specific control to assign to an ATL control in Open 3D Engine.
 weight: 300


### PR DESCRIPTION
## Change summary

There was a double title in the audio middleware description page; I removed one to ensure the page works correctly:

Before the change:
```
hugo server
Watching for changes in /home/jhanca/devroot/o3de.org/{content,layouts,package.json,static}
Watching for config changes in /home/jhanca/devroot/o3de.org/hugo.toml, /home/jhanca/devroot/o3de.org/go.mod
Start building sites … 
hugo v0.152.2-6abdacad3f3fe944ea42177844469139e81feda6+extended linux/amd64 BuildDate=2025-10-24T15:31:49Z VendorInfo=snap:0.152.2

Built in 2121 ms
Error: error building site: process: readAndProcessContent: "/home/jhanca/devroot/o3de.org/content/docs/user-guide/interactivity/audio/audio-controls-editor/middleware-pane.md:3:1": [2:1] mapping key "title" already defined at [1:1]
   1 | title: Middleware Controls Pane
>  2 | title: Audio Engine Middleware Controls Pane
       ^
   3 | description: Use the Audio Controls Editor's audio engine middleware controls pane to filter and select a middleware-specific control to assign to an ATL control in Open 3D Engine.
   4 | weight: 300
   5 | toc: true

```

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?

