### PR TITLE
Unify names importing-robot(s)

### DIFF
--- a/content/docs/user-guide/interactivity/robotics/_index.md
+++ b/content/docs/user-guide/interactivity/robotics/_index.md
@@ -19,7 +19,7 @@ These Gems provide various O3DE components such as sensors, robot control and st
 | [Joints Manipulation](joints-manipulation.md)                       | Control robotic manipulators and joints.                                                                                          |
 | [Grippers](grippers.md)                                             | Documentation of robotic grippers feature.                                                                                        |
 | [Georeference](georeference.md)                                     | Link your scene with the existing location.                                                                                       |
-| [Importing robots](importing-robot.md)                              | Learn how to import robots using Robot Importer.                                                                                  |
+| [Importing robots](importing-robots.md)                             | Learn how to import robots using Robot Importer.                                                                                  |
 | [Troubleshooting the simulation](troubleshooting.md)                | Helpful solutions to some of the most common issues with ROS 2.                                                                   |
 | [Simulation Time for Robotics Gems](simulation-time.md)             | Configure simulation time settings for robotics Gems in O3DE.                                                                     |
 | [Registry settings](registry-settings.md)                           | List of registry settings for robotics Gems.                                                                                      |

--- a/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
+++ b/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
@@ -33,12 +33,12 @@ Note that QoS class is a simple wrapper to [`rclcpp::QoS`](https://docs.ros.org/
 
 Four ROS 2 related Gems are provided. Each of them has a specific purpose:
 
-| Gem name            | Description                                                                                     |
-| ------------------- | ----------------------------------------------------------------------------------------------- |
-| [ROS2](/docs/user-guide/gems/reference/robotics/ros2.md) | Base Gem for any _ROS 2_ based Gem/project, including:  <ul><li> _ROS 2 Node_ (singleton) allowing the communication with the _ROS 2_ ecosystem <li> automated handling of simulation time <li> handling of transformation frames  <li> handling ROS 2 _namespaces_ and ROS 2 _topics_   <li> dynamic objects spawning via ROS 2 _services_ <li> base components (e.g. for sensors that can be implemented in any Gem)                         |
-| [ROS2Sensors](/docs/user-guide/gems/reference/robotics/ros2sensors.md) | Gem interfacing with _ROS 2_ ecosystem implementing the following simulation sensors: camera, contact, GNSS, imu, lidar, odometry                                                     |
-| [ROS2Controllers](/docs/user-guide/gems/reference/robotics/ros2controllers.md) | Gem interfacing with _ROS 2_ ecosystem implementing robot control, manipulation, grippers, and vehicle dynamics; it will also include sensors related to controllers (e.g. wheel odometry) |
-| [ROS2RobotImporter](/docs/user-guide/gems/reference/robotics/ros2robotimporter.md) | Gem implementing robot importer tool using _ROS 2_ components                                   |
+| Gem name                                                                           | Description                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [ROS2](/docs/user-guide/gems/reference/robotics/ros2.md)                           | Base Gem for any _ROS 2_ based Gem/project, including:  <ul><li> _ROS 2 Node_ (singleton) allowing the communication with the _ROS 2_ ecosystem <li> automated handling of simulation time <li> handling of transformation frames  <li> handling ROS 2 _namespaces_ and ROS 2 _topics_   <li> dynamic objects spawning via ROS 2 _services_ <li> base components (e.g. for sensors that can be implemented in any Gem) |
+| [ROS2Sensors](/docs/user-guide/gems/reference/robotics/ros2sensors.md)             | Gem interfacing with _ROS 2_ ecosystem implementing the following simulation sensors: camera, contact, GNSS, imu, lidar, odometry                                                                                                                                                                                                                                                                                      |
+| [ROS2Controllers](/docs/user-guide/gems/reference/robotics/ros2controllers.md)     | Gem interfacing with _ROS 2_ ecosystem implementing robot control, manipulation, grippers, and vehicle dynamics; it will also include sensors related to controllers (e.g. wheel odometry)                                                                                                                                                                                                                             |
+| [ROS2RobotImporter](/docs/user-guide/gems/reference/robotics/ros2robotimporter.md) | Gem implementing robot importer tool using _ROS 2_ components                                                                                                                                                                                                                                                                                                                                                          |
 
 ## Components overview
 
@@ -131,7 +131,7 @@ To control robotic joints systems such as manipulator arms, some integration wit
 Two kinds of simulated joint systems are supported:
 - Articulation links, which benefit from stability of reduced coordinate articulations in the physics engine.
 - Hinge and prismatic joint components.
-When [importing a robot](importing-robot.md) with joints, you decide which of these systems to use.
+When [importing a robot](importing-robots.md) with joints, you decide which of these systems to use.
 
 There are three interfaces to control joint systems: `JointsPositionControllerRequests`, `JointsManipulationRequests` and `JointsTrajectoryRequest`.
 Each of these has one or more implementations within ROS 2 Gem, and it is possible to develop custom behaviors in a modular way using these interfaces.

--- a/content/docs/user-guide/interactivity/robotics/creating-robotic-simulation.md
+++ b/content/docs/user-guide/interactivity/robotics/creating-robotic-simulation.md
@@ -22,7 +22,7 @@ Once you are set up and familiar with the [example project](/docs/user-guide/int
 2. [Register ROS2 Gem for your Project](/docs/user-guide/project-config/register-gems/)
 3. Create or import Assets for your robots and environment.
    1. You can use formats supported by O3DE.
-   2. You can [import your robot from URDF/XACRO](/docs/user-guide/interactivity/robotics/importing-robot).
+   2. You can [import your robot from URDF/XACRO](/docs/user-guide/interactivity/robotics/importing-robots).
    3. Imported models might require some adjustments to be simulation-ready.
    4. Mobilize robot with Vehicle Dynamics controllers.
 4. Determine which sensors you need to simulate.

--- a/content/docs/user-guide/interactivity/robotics/importing-robot/sdformat-plugins.md
+++ b/content/docs/user-guide/interactivity/robotics/importing-robot/sdformat-plugins.md
@@ -7,7 +7,7 @@ weight: 470
 
 ## Introduction
 
-Robots described in either [SDFormat](http://sdformat.org/), [URDF](http://wiki.ros.org/urdf), or [XACRO](http://wiki.ros.org/xacro) format, can be imported into your O3DE simulation project using the Robot Importer. The tool creates O3DE entities and components that model a robot. You can find more details about Robot Importer in the [documentation](/docs/user-guide/interactivity/robotics/importing-robot/). 
+Robots described in either [SDFormat](http://sdformat.org/), [URDF](http://wiki.ros.org/urdf), or [XACRO](http://wiki.ros.org/xacro) format, can be imported into your O3DE simulation project using the Robot Importer. The tool creates O3DE entities and components that model a robot. You can find more details about Robot Importer in the [documentation](/docs/user-guide/interactivity/robotics/importing-robots/). 
 
 SDFormat standard allows the extension of the functionality of the imported robot by adding _plugins_ to the description. The same description can be incorporated into URDF and XACRO files using `<gazebo>` tag. Technically, such a plugin is a dynamically loaded chunk of code that can extend _world_, _model_, or _sensor_ description. Currently, only _models_, _sensors_ and _plugins_ are supported. Please refer to [SDformat sensors page](./sdformat-sensors.md) to learn more about _sensors_ and _plugins_. 
 

--- a/content/docs/user-guide/interactivity/robotics/importing-robot/sdformat-sensors.md
+++ b/content/docs/user-guide/interactivity/robotics/importing-robot/sdformat-sensors.md
@@ -7,7 +7,7 @@ weight: 480
 
 ## Introduction
 
-Robots described in either [SDFormat](http://sdformat.org/), [URDF](http://wiki.ros.org/urdf), or [XACRO](http://wiki.ros.org/xacro) format, can be imported into your O3DE simulation project using the Robot Importer. The tool creates O3DE entities and components that model a robot. You can find more details about Robot Importer in the [documentation](/docs/user-guide/interactivity/robotics/importing-robot/). 
+Robots described in either [SDFormat](http://sdformat.org/), [URDF](http://wiki.ros.org/urdf), or [XACRO](http://wiki.ros.org/xacro) format, can be imported into your O3DE simulation project using the Robot Importer. The tool creates O3DE entities and components that model a robot. You can find more details about Robot Importer in the [documentation](/docs/user-guide/interactivity/robotics/importing-robots/). 
 
 Similarly, the robots' [sensors](http://sdformat.org/spec?ver=1.10&elem=sensor) are imported from the description files into O3DE using ROS 2 sensor components available in [ROS 2 Gem](/docs/user-guide/gems/reference/robotics/ros2/). Note, that the sensor's description can be stored directly in SDFormat files or using `<gazebo>` tag in URDF and XACRO files.
 

--- a/content/docs/user-guide/interactivity/robotics/importing-robots.md
+++ b/content/docs/user-guide/interactivity/robotics/importing-robots.md
@@ -1,5 +1,5 @@
 ---
-linkTitle: Importing robot
+linkTitle: Importing robots
 title: Importing robots
 description: Importing robots from description file with ROS 2 Gem in Open 3D Engine (O3DE).
 weight: 400
@@ -18,7 +18,7 @@ SDFormat, URDF, and XACRO are widely used robot description standards within the
 
 [XML Macros (XACRO)](http://wiki.ros.org/xacro) is a macro language that simplifies the creation and maintenance of URDF files. XACRO allows you to generate URDF files using XML macros. In XACRO, you can define parameters and include files, which is useful to change and iterate on robot models. You can also expand and reuse XACRO across multiple robot models. 
 
-URDF/XACRO files contain complete robot descriptions, including references to external geometry files. While you can define primitive geometries directly within the URDF/XACRO file, it's common practice to use external mesh files, in formats such as DAE (Collada) or STL, to represent the visual and collision shapes of the robot.
+URDF/XACRO files contain complete robot descriptions, including references to external geometry files. While you can define primitive geometries directly within the URDF/XACRO file, it is a common practice to use external mesh files, in formats such as DAE (Collada) or STL, to represent the visual and collision shapes of the robot.
 Robot models are typically available in packages that include the URDF/XACRO file and additional geometry files that contain visualizations and collision shapes, either as primitive geometries or external mesh files. These packages may be distributed as ROS workspaces, which are more straightforward to use in ROS applications. 
 
 ## Introduction to Robot Importer
@@ -26,7 +26,7 @@ Robot models are typically available in packages that include the URDF/XACRO fil
 Import robots into your O3DE simulation project using the Robot Importer that's included in the ROS 2 Gem. Robot Importer has the following features:
 
 - Guides you through the import process step by step.
-- Allows to change parameters of the import.
+- Allows changing parameters of the import.
 - Reads SDF, URDF and XACRO files.
 - Copies all required assets files to the `Assets` folder of your O3DE project.
 - Creates a prefab with a multi-body structure using articulations or classic rigid bodies and joints components.

--- a/content/docs/user-guide/interactivity/robotics/joints-manipulation.md
+++ b/content/docs/user-guide/interactivity/robotics/joints-manipulation.md
@@ -57,7 +57,7 @@ The template comes with a couple of examples which you can run following its [RE
 ### Configure your robot
 
 #### Import the robot
-Once your project is up, use the [robot import](importing-robot.md) feature to load your robot of choice into O3DE.
+Once your project is up, use the [robot import](importing-robots.md) feature to load your robot of choice into O3DE.
 Make sure that the checkbox ```Use articulation for joints and rigid bodies``` is checked on the last page of the importer.
 Using articulations is strongly recommended for stable simulation of robotic arms and other joint systems.
 


### PR DESCRIPTION
Closes #2772

## Change summary

Two names `importing-robot` and `importing-robots` were used in the documentation, leading to some dead links and inconsistency. This is fixed in this PR.

### Submission Checklist:

* [ ] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [ ] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [ ] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [ ] **Help the user** - Does the documentation show the user something *meaningful*?
* [ ] **All commits are signed off** - Do all commits have a `Signed-off-by` line at the end, with an email verified by GitHub?
