### PR TITLE
Fix broken link to Animation Editor's Ragdoll page, closes #2486

### DIFF
--- a/content/docs/user-guide/components/reference/physx/ragdoll.md
+++ b/content/docs/user-guide/components/reference/physx/ragdoll.md
@@ -22,7 +22,7 @@ You use the PhysX system and the **Animation Editor** to create a ragdoll.
 
 1. Choose **Tools**, **Animation Editor**.
 
-1. Use the **Animation Editor** to create and control the physical representation of the ragdoll. For more information, see [Creating and Simulating a PhysX Ragdoll](/docs/user-guide/visualization/animation/animation-editor/creating-and-simulating-physx-ragdoll/).
+1. Use the **Animation Editor** to create and control the physical representation of the ragdoll. For more information, see [Ragdoll](/docs/user-guide/visualization/animation/animation-editor/ragdoll/).
 
 ## PhysX Ragdoll Component Properties 
 


### PR DESCRIPTION
## Change summary

Animation Editor now has multiple pages about Ragdoll, starting by "Ragdoll" page:

https://docs.o3de.org/docs/user-guide/visualization/animation/animation-editor/ragdoll/

This PR change the link to that page.

Closes #2486

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
* [x] **All commits are signed off** - Do all commits have a `Signed-off-by` line at the end, with an email verified by GitHub?
