### PR TITLE
Fix broken link to ROS 2 Frames, closes #2771

### DIFF
--- a/content/docs/user-guide/components/reference/ros2/sensors/ros2-gnss-sensor.md
+++ b/content/docs/user-guide/components/reference/ros2/sensors/ros2-gnss-sensor.md
@@ -12,7 +12,7 @@ The **ROS 2 GNSS Sensor** component encapsulates the simulation of a Global Navi
 
 ## Dependencies
 
-[ROS 2 Frame Component](/user-guide/components/reference/ros2/core/ros2-frame)
+[ROS 2 Frame Component](/docs/user-guide/components/reference/ros2/core/ros2-frame)
 
 ## Properties
 

--- a/content/docs/user-guide/components/reference/ros2/sensors/ros2-lidar-sensor.md
+++ b/content/docs/user-guide/components/reference/ros2/sensors/ros2-lidar-sensor.md
@@ -15,7 +15,7 @@ Lidars are useful for tasks such as obstacle detection, localization, and naviga
 
 ## Dependencies
 
-[ROS 2 Frame component](/user-guide/components/reference/ros2/core/ros2-frame)
+[ROS 2 Frame Component](/docs/user-guide/components/reference/ros2/core/ros2-frame)
 
 ## Properties
 

--- a/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
+++ b/content/docs/user-guide/interactivity/robotics/concepts-and-components-overview.md
@@ -90,7 +90,7 @@ The ROS 2 frame component handles two main responsibilities:
 1. **Transformations**: It publishes the transformation of its entity in the TF2 tree. It also allows querying transformations to other frames.
 2. **Namespacing**: It provides a namespace for topics and services related to the entity.
 
-More details about frames can be found in the [Frames documentation](user-guide/components/reference/ros2/core/ros2-frame/).
+More details about frames can be found in the [Frames documentation](/docs/user-guide/components/reference/ros2/core/ros2-frame/).
 
 ### Sensors
 


### PR DESCRIPTION
## Change summary

The Frames documentation link missed the `/docs` prefix, by adding it, the link now works again.

Closes #2771 

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
* [x] **All commits are signed off** - Do all commits have a `Signed-off-by` line at the end, with an email verified by GitHub?
