### PR TITLE
Project export fixes (broken links and typo)

### DIFF
--- a/content/docs/user-guide/packaging/project-export/manual-export-atom-sampleviewer-ios.md
+++ b/content/docs/user-guide/packaging/project-export/manual-export-atom-sampleviewer-ios.md
@@ -10,7 +10,7 @@ This guide covers how to manually build and deploy games on iOS. First, we will 
 For this demonstration, we will use the O3DE Atom Sample Viewer project as our reference point for ensuring proper behavior. Results may vary for other projects.
 
 {{< note >}}
-To learn more about the project export tooling, please consult the page [Project Export CLI Tool.](/docs/user-guide/packaging/project-export/project-export-cli)
+To learn more about the project export tooling, please consult the [Project Export for Windows and Linux page](/docs/user-guide/packaging/project-export/project-export-pc)
 {{< /note >}}
 {{< important >}}
 The iOS export functionality is only available on macOS, which is currently experimental for O3DE.

--- a/content/docs/user-guide/packaging/project-export/project-export-android.md
+++ b/content/docs/user-guide/packaging/project-export/project-export-android.md
@@ -17,7 +17,7 @@ To learn more about how to manually export an Android project, please consult th
 ## Prerequisites
 1. Make sure that the [Project Export for Windows and Linux page](/docs/user-guide/packaging/project-export/project-export-pc) prerequisites are satisfied.
 2. Make sure you have your project created and registered with your engine. Check that you can successfully build and open your project with the Editor.
-3. Ensure all prerequisites for working with Android in O3DE are satsified. You can learn about software dependencies [here](/docs/user-guide/platforms/android/#prerequisite-software-and-packages) and project setup prerequisites [here](/docs/user-guide/platforms/android/generating_android_project_windows/#prerequisites). For the Android SDK, make sure to record where the root folder path is located on your hard drive, as that will be needed for setting up configuration.
+3. Ensure all prerequisites for working with Android in O3DE are satisfied. You can learn about software dependencies [here](/docs/user-guide/platforms/android/#prerequisite-software-and-packages) and project setup prerequisites [here](/docs/user-guide/platforms/android/generating_android_project_windows/#prerequisites). For the Android SDK, make sure to record where the root folder path is located on your hard drive, as that will be needed for setting up configuration.
 4. Ensure that you have a proper keystore file configured for signing. You can learn more [here](/docs/user-guide/platforms/android/#apk-signing). Here is an example keystore file you can create to start with (you will need the JDK with `keytool`):
 ```
 set KEYSTORE_FILE_PATH=C:\path\to\android-key.keystore

--- a/content/docs/user-guide/packaging/project-export/project-export-ios.md
+++ b/content/docs/user-guide/packaging/project-export/project-export-ios.md
@@ -15,7 +15,7 @@ The iOS export functionality is only available on macOS, which is currently expe
 {{< /important >}}
 
 ## Prerequisites
-1. Make sure that the [Project Export CLI Tool page](/docs/user-guide/packaging/project-export/project-export-cli) prerequisites are satisfied.
+1. Make sure that the [Project Export for Windows and Linux page](/docs/user-guide/packaging/project-export/project-export-pc) prerequisites are satisfied.
 2. Make sure you have your project created and registered with your engine.
 3. Have a valid copy of Xcode installed on your machine, and a valid Apple Developer ID associated with that IDE. To set up such an ID, go to [developer.apple.com](https://developer.apple.com). To use your desired Apple ID, in Xcode go to `Xcode -> Settings`. In the Settings window, go to the Accounts tab and click the '+' icon at the bottom of the left panel to add your account. Select Apple ID to proceed, and follow on-screen instructions.
 4. You will also need to ensure that Xcode has the standard SDKs installed for macOS and iOS, and that your preferred iOS test device is compatible with Xcode. If you are not sure, you can consult [this page on installing Simulator Runtimes](https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes).

--- a/content/docs/user-guide/packaging/project-export/project-export-ios.md
+++ b/content/docs/user-guide/packaging/project-export/project-export-ios.md
@@ -8,7 +8,7 @@ weight: 420
 This guide covers how to use project export tooling to build and deploy games on iOS. We will use the iOS export script to generate an Xcode project and prepare assets and then build the project. The end result of export should be an IPA file that can be installed on your iOS device.
 
 {{< note >}}
-To learn more about the project export tooling, please consult the page [Project Export CLI Tool.](/docs/user-guide/packaging/project-export/project-export-cli)
+To learn more about the project export tooling, please consult the [Project Export for Windows and Linux page](/docs/user-guide/packaging/project-export/project-export-pc)
 {{< /note >}}
 {{< important >}}
 The iOS export functionality is only available on macOS, which is currently experimental for O3DE.

--- a/content/docs/user-guide/packaging/project-export/project-export-pc.md
+++ b/content/docs/user-guide/packaging/project-export/project-export-pc.md
@@ -9,7 +9,7 @@ weight: 400
 ## Prerequisites
 To make best use of the export button in the Project Manager, or the `export-project` CLI command, it is recommended to have a project with at least one starting level, and all necessary seedlist files prepared. AssetProcessor Registry file settings may need to be tweaked. To learn how to set this up, please consult the following page: [Creating a Project Game Release Layout for Windows, section: Set the Starting Level](../windows-release-builds/#set-the-starting-level).
 
-To learn more about the AssetBundler and Seed Files, please visit the [overview page on the AssetBundler tool](https://docs.o3de.org/docs/user-guide/packaging/asset-bundler/overview/).
+To learn more about the AssetBundler and Seed Files, please visit the [overview page on the AssetBundler tool](/docs/user-guide/packaging/asset-bundler/overview/).
 
 
 {{< note >}}


### PR DESCRIPTION
## Change summary

This PR copies first prerequisite from Android to iOS, the reason is that Android had the same change:

https://github.com/o3de/o3de.org/commit/09c0931c8c21701f3693f83c13d2f24733dffead#diff-5cfe2e4e5501bb331be42be726fe2498b0bd520ee32b56a3d39206a941e8412bR18

And in my understanding, it also applies for iOS.

While working on the issue, I noticed some other little problems, so I fixed them too:

- Fix a typo on "Project Export for Android" I spotted while reading the page.
- On "Project Export for Windows and Linux", there's a link to O3DE website, I changed that to the local URL of the same page.

Closes #2616

### Submission Checklist:

* [x] **Descriptive active voice** - Do descriptive sentences have a clear *subject* and *action verb*?
* [x] **Answer the question at hand** - Does the documentation answer a *what*, *why*, *how*, or *where* type of question?
* [x] **Consistency** - Does the content consistently follow the [Style Guide](https://o3de.org/docs/contributing/to-docs/style-guide/quick-reference)?
* [x] **Help the user** - Does the documentation show the user something *meaningful*?
* [x] **All commits are signed off** - Do all commits have a `Signed-off-by` line at the end, with an email verified by GitHub?
